### PR TITLE
fix fast json

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -180,6 +180,12 @@
 					</exclusion>
 				</exclusions>
 			</dependency>
+			<!-- used by ctrip dal -->
+			<dependency>
+				<groupId>com.alibaba</groupId>
+				<artifactId>fastjson</artifactId>
+				<version>1.2.7</version>
+			</dependency>
 			<dependency>
 				<groupId>com.ctrip.framework.clogging</groupId>
 				<artifactId>clogging-agent</artifactId>

--- a/scripts/sql/apolloconfigdb.sql
+++ b/scripts/sql/apolloconfigdb.sql
@@ -363,7 +363,7 @@ CREATE TABLE `ServerConfig` (
 # ------------------------------------------------------------
 INSERT INTO `ServerConfig` (`Key`, `Cluster`, `Value`, `Comment`)
 VALUES
-    ('eureka.service.url', 'default', 'http://localhost:8080/eureka/', 'Eureka服务Url'),
+    ('eureka.service.url', 'default', 'http://localhost:8080/eureka/', 'Eureka服务Url，多个service以英文逗号分隔'),
     ('namespace.lock.switch', 'default', 'false', '一次发布只能有一个人修改开关'),
     ('item.value.length.limit', 'default', '20000', 'item value最大长度限制'),
     ('appnamespace.private.enable', 'default', 'false', '是否开启private namespace'),


### PR DESCRIPTION
some versions of fast json if used with Eureka will cause errors like 'Missing dependency for field: javax.ws.rs.core.UriInfo com.alibaba.fastjson.support.jaxrs.FastJsonProvider.uriInfo'