### PR TITLE
use custom connection validator instead of sending SELECT 1 query

### DIFF
--- a/apollo-common/src/main/java/com/ctrip/framework/apollo/common/utils/DataSourceValidator.java
+++ b/apollo-common/src/main/java/com/ctrip/framework/apollo/common/utils/DataSourceValidator.java
@@ -1,0 +1,27 @@
+package com.ctrip.framework.apollo.common.utils;
+
+import org.apache.tomcat.jdbc.pool.Validator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+
+/**
+ * @author Jason Song(song_s@ctrip.com)
+ */
+public class DataSourceValidator implements Validator {
+  private static final Logger LOGGER = LoggerFactory.getLogger(DataSourceValidator.class);
+  private static final int DEFAULT_VALIDATE_TIMEOUT_IN_SECONDS = 5;
+
+  @Override
+  public boolean validate(Connection connection, int validateAction) {
+    boolean isValid = false;
+    try {
+      isValid = connection.isValid(DEFAULT_VALIDATE_TIMEOUT_IN_SECONDS);
+    } catch (Throwable ex) {
+      LOGGER.warn("Data source validation error", ex);
+    }
+
+    return isValid;
+  }
+}

--- a/apollo-common/src/main/resources/application.properties
+++ b/apollo-common/src/main/resources/application.properties
@@ -3,7 +3,8 @@ spring.http.converters.preferred-json-mapper=gson
 # DataSource
 spring.datasource.testWhileIdle=true
 spring.datasource.testOnBorrow=true
-spring.datasource.validationQuery=SELECT 1
+spring.datasource.validatorClassName=com.ctrip.framework.apollo.common.utils.DataSourceValidator
+spring.datasource.validationInterval=5000
 spring.datasource.initSQL=set names utf8mb4
 
 # Naming strategy

--- a/apollo-common/src/test/java/com/ctrip/framework/apollo/common/AllTests.java
+++ b/apollo-common/src/test/java/com/ctrip/framework/apollo/common/AllTests.java
@@ -1,5 +1,6 @@
 package com.ctrip.framework.apollo.common;
 
+import com.ctrip.framework.apollo.common.utils.DataSourceValidatorTest;
 import com.ctrip.framework.apollo.common.utils.InputValidatorTest;
 
 import org.junit.runner.RunWith;
@@ -8,7 +9,7 @@ import org.junit.runners.Suite.SuiteClasses;
 
 @RunWith(Suite.class)
 @SuiteClasses({
-    InputValidatorTest.class
+    InputValidatorTest.class, DataSourceValidatorTest.class
 })
 public class AllTests {
 

--- a/apollo-common/src/test/java/com/ctrip/framework/apollo/common/utils/DataSourceValidatorTest.java
+++ b/apollo-common/src/test/java/com/ctrip/framework/apollo/common/utils/DataSourceValidatorTest.java
@@ -1,0 +1,54 @@
+package com.ctrip.framework.apollo.common.utils;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.sql.Connection;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Jason Song(song_s@ctrip.com)
+ */
+public class DataSourceValidatorTest {
+  private DataSourceValidator datasourceValidator;
+
+  @Before
+  public void setUp() throws Exception {
+    datasourceValidator = new DataSourceValidator();
+  }
+
+  @Test
+  public void testValidateSuccessfully() throws Exception {
+    Connection someConnection = mock(Connection.class);
+    int someValidationAction = 1;
+
+    when(someConnection.isValid(anyInt())).thenReturn(true);
+
+    assertTrue(datasourceValidator.validate(someConnection, someValidationAction));
+  }
+
+  @Test
+  public void testValidateFailed() throws Exception {
+    Connection someConnection = mock(Connection.class);
+    int someValidationAction = 1;
+
+    when(someConnection.isValid(anyInt())).thenReturn(false);
+
+    assertFalse(datasourceValidator.validate(someConnection, someValidationAction));
+  }
+
+  @Test
+  public void testValidateWithException() throws Exception {
+    Connection someConnection = mock(Connection.class);
+    int someValidationAction = 1;
+
+    when(someConnection.isValid(anyInt())).thenThrow(new RuntimeException("error"));
+
+    assertFalse(datasourceValidator.validate(someConnection, someValidationAction));
+  }
+
+}


### PR DESCRIPTION
By using connection.isValid, we could take advantage of mysql PING mechanism to do the validation instead of sending an actual query like SELECT 1.