### PR TITLE
support better rollback.

### DIFF
--- a/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/entity/Item.java
+++ b/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/entity/Item.java
@@ -13,7 +13,6 @@ import javax.persistence.Table;
 @Entity
 @Table(name = "Item")
 @SQLDelete(sql = "Update Item set isDeleted = 1 where id = ?")
-@Where(clause = "isDeleted = 0")
 public class Item extends BaseEntity {
 
   @Column(name = "NamespaceId", nullable = false)

--- a/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/repository/ItemRepository.java
+++ b/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/repository/ItemRepository.java
@@ -2,6 +2,7 @@ package com.ctrip.framework.apollo.biz.repository;
 
 import com.ctrip.framework.apollo.biz.entity.Item;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.PagingAndSortingRepository;
@@ -11,18 +12,26 @@ import java.util.List;
 
 public interface ItemRepository extends PagingAndSortingRepository<Item, Long> {
 
+  @Query("SELECT i FROM Item i WHERE i.namespaceId = ?1 AND i.key=?2 AND i.isDeleted = 0")
   Item findByNamespaceIdAndKey(Long namespaceId, String key);
 
+  @Query("SELECT i FROM Item i WHERE i.namespaceId = ?1 AND i.isDeleted = 0 ORDER BY i.lineNum ASC")
   List<Item> findByNamespaceIdOrderByLineNumAsc(Long namespaceId);
 
+  @Query("SELECT i FROM Item i WHERE i.namespaceId = ?1 AND i.isDeleted = 0")
   List<Item> findByNamespaceId(Long namespaceId);
 
+  @Query("SELECT i FROM Item i WHERE i.namespaceId = ?1 AND i.isDeleted = 0 AND i.dataChangeLastModifiedTime > ?2")
   List<Item> findByNamespaceIdAndDataChangeLastModifiedTimeGreaterThan(Long namespaceId, Date date);
 
-  Item findFirst1ByNamespaceIdOrderByLineNumDesc(Long namespaceId);
+  @Query("SELECT i FROM Item i WHERE i.namespaceId = ?1 AND i.isDeleted = 0 ORDER BY i.lineNum DESC")
+  List<Item> findFirst1ByNamespaceIdOrderByLineNumDesc(Long namespaceId, Pageable page);
 
   @Modifying
   @Query("update Item set isdeleted=1,DataChange_LastModifiedBy = ?2 where namespaceId = ?1")
   int deleteByNamespaceId(long namespaceId, String operator);
+
+  @Query("SELECT i FROM Item i WHERE i.namespaceId = ?1 AND i.key = ?2 ORDER BY i.dataChangeLastModifiedTime DESC")
+  List<Item> findFirst1ByKeyOrderByDataChangeLastModifiedTime(Long namespaceId, String key, Pageable page);
 
 }

--- a/apollo-biz/src/test/java/com/ctrip/framework/apollo/biz/service/ReleaseServiceTest.java
+++ b/apollo-biz/src/test/java/com/ctrip/framework/apollo/biz/service/ReleaseServiceTest.java
@@ -1,5 +1,6 @@
 package com.ctrip.framework.apollo.biz.service;
 
+import com.ctrip.framework.apollo.biz.entity.Namespace;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
@@ -16,12 +17,14 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.data.domain.PageRequest;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -39,6 +42,8 @@ public class ReleaseServiceTest extends AbstractUnitTest {
   private ItemSetService itemSetService;
   @InjectMocks
   private ReleaseService releaseService;
+  @Mock
+  private ItemService itemService;
 
   private String appId = "appId-test";
   private String clusterName = "cluster-test";
@@ -72,6 +77,7 @@ public class ReleaseServiceTest extends AbstractUnitTest {
   public void testNamespaceNotExist() {
 
     when(releaseRepository.findOne(releaseId)).thenReturn(firstRelease);
+    when(namespaceService.findOne(anyString(), anyString(), anyString())).thenReturn(new Namespace());
 
     releaseService.rollback(releaseId, user);
   }
@@ -79,6 +85,7 @@ public class ReleaseServiceTest extends AbstractUnitTest {
   @Test(expected = BadRequestException.class)
   public void testHasNoRelease() {
 
+    when(namespaceService.findOne(anyString(), anyString(), anyString())).thenReturn(new Namespace());
     when(releaseRepository.findOne(releaseId)).thenReturn(firstRelease);
     when(releaseRepository.findByAppIdAndClusterNameAndNamespaceNameAndIsAbandonedFalseOrderByIdDesc(appId,
                                                                                                      clusterName,
@@ -92,6 +99,8 @@ public class ReleaseServiceTest extends AbstractUnitTest {
   @Test
   public void testRollback() {
 
+    when(namespaceService.findOne(anyString(), anyString(), anyString())).thenReturn(new Namespace());
+    when(itemService.findItemsWithOrdered(anyString(), anyString(), anyString())).thenReturn(new ArrayList<>());
     when(releaseRepository.findOne(releaseId)).thenReturn(firstRelease);
     when(releaseRepository.findByAppIdAndClusterNameAndNamespaceNameAndIsAbandonedFalseOrderByIdDesc(appId,
                                                                                                      clusterName,

--- a/apollo-biz/src/test/resources/sql/release-creation-test.sql
+++ b/apollo-biz/src/test/resources/sql/release-creation-test.sql
@@ -94,6 +94,10 @@ INSERT INTO `cluster` (ID, `Name`, `AppId`, `ParentClusterId`, `IsDeleted`, `Dat
 INSERT INTO `namespace` (ID, `AppId`, `ClusterName`, `NamespaceName`, `IsDeleted`, `DataChange_CreatedBy`, `DataChange_LastModifiedBy`)VALUES(1011, 'test', 'default6', 'application', 0, 'apollo', 'apollo');
 INSERT INTO `namespace` (ID, `AppId`, `ClusterName`, `NamespaceName`, `IsDeleted`, `DataChange_CreatedBy`, `DataChange_LastModifiedBy`)VALUES(1012, 'test', 'child-cluster6', 'application', 0, 'apollo', 'apollo');
 
+INSERT INTO `item` (`NamespaceId`, `Key`, `Value`, `IsDeleted`, `Comment`, `DataChange_CreatedBy`, `DataChange_LastModifiedBy`) VALUES (1011, 'k1', 'v1', true,'', 'apollo', 'apollo');
+INSERT INTO `item` (`NamespaceId`, `Key`, `Value`, `IsDeleted`, `Comment`, `DataChange_CreatedBy`, `DataChange_LastModifiedBy`)VALUES(1011, 'k2', 'v2-2', true,'', 'apollo', 'apollo');
+INSERT INTO `item` (`NamespaceId`, `Key`, `Value`, `IsDeleted`, `Comment`, `DataChange_CreatedBy`, `DataChange_LastModifiedBy`)VALUES(1011, 'k3', 'v1-2', true,'', 'apollo', 'apollo');
+
 INSERT INTO `release` (`Id`, `ReleaseKey`, `Name`, `Comment`, `AppId`, `ClusterName`, `NamespaceName`, `Configurations`, `IsAbandoned`)VALUES(6, '20160823102253-fc0071ddf9fd3260', '20160823101703-release', '', 'test', 'default6', 'application', '{"k1":"v1-1","k2":"v2-1","k3":"v3"}', 0);
 INSERT INTO `release` (`Id`, `ReleaseKey`, `Name`, `Comment`, `AppId`, `ClusterName`, `NamespaceName`, `Configurations`, `IsAbandoned`)VALUES(7, '20160823102253-fc0071ddf9fd3260', '20160823101703-release', '', 'test', 'default6', 'application', '{"k1":"v1","k2":"v2"}', 0);
 INSERT INTO `release` (`Id`, `ReleaseKey`, `Name`, `Comment`, `AppId`, `ClusterName`, `NamespaceName`, `Configurations`, `IsAbandoned`)VALUES(8, '20160823102253-fc0071ddf9fd3260', '20160823101703-release', '', 'test', 'child-cluster6', 'application', '{"k1":"v1-2","k2":"v2-1","k3":"v3"}', 0);

--- a/apollo-portal/src/main/resources/static/views/component/rollback-modal.html
+++ b/apollo-portal/src/main/resources/static/views/component/rollback-modal.html
@@ -13,7 +13,7 @@
             </div>
             <div class="modal-body">
                 <div class="alert alert-warning" role="alert">
-                    此操作将会回滚到上一个发布版本，且当前版本作废，但不影响正在修改的配置。可在发布历史页面查看当前生效的版本
+                    此操作将会回滚到上一个发布版本，且当前版本作废。可在发布历史页面查看当前生效的版本
                     <a target="_blank"
                        href="/config/history.html?#/appid={{appId}}&env={{env}}&clusterName={{toRollbackNamespace.baseInfo.clusterName}}&namespaceName={{toRollbackNamespace.baseInfo.namespaceName}}">点击查看</a>
                 </div>


### PR DESCRIPTION
The current rollback does not work well, because the changes after the release  were kept in the database. I think we should delete these changes and rollback the configurations to a clean version.