### PR TITLE
clear http response inputstream and errorstream to reuse connection.

### DIFF
--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/util/http/HttpUtil.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/util/http/HttpUtil.java
@@ -70,6 +70,7 @@ public class HttpUtil {
   private <T> HttpResponse<T> doGetWithSerializeFunction(HttpRequest httpRequest,
                                                          Function<String, T> serializeFunction) {
     InputStreamReader isr = null;
+    InputStreamReader esr = null;
     int statusCode;
     try {
       HttpURLConnection conn = (HttpURLConnection) new URL(httpRequest.getUrl()).openConnection();
@@ -92,9 +93,14 @@ public class HttpUtil {
       conn.connect();
 
       statusCode = conn.getResponseCode();
+      try {
+        isr = new InputStreamReader(conn.getInputStream(), StandardCharsets.UTF_8);
+        esr = new InputStreamReader(conn.getErrorStream(), StandardCharsets.UTF_8);
+      } catch (Exception e) {
+        // ignore
+      }
 
       if (statusCode == 200) {
-        isr = new InputStreamReader(conn.getInputStream(), StandardCharsets.UTF_8);
         String content = CharStreams.toString(isr);
         return new HttpResponse<>(statusCode, serializeFunction.apply(content));
       }
@@ -102,16 +108,25 @@ public class HttpUtil {
       if (statusCode == 304) {
         return new HttpResponse<>(statusCode, null);
       }
-
     } catch (Throwable ex) {
       throw new ApolloConfigException("Could not complete get operation", ex);
     } finally {
       if (isr != null) {
         try {
+          CharStreams.toString(isr);
           isr.close();
         } catch (IOException e) {
           // ignore
         }
+      }
+
+      if (esr != null) {
+          try {
+              CharStreams.toString(esr);
+              esr.close();
+          } catch (Exception e) {
+              // ignore
+          }
       }
     }
 


### PR DESCRIPTION
I missed some cases in the previous pull request. It is when server status code is more than 400, you will get an excepion if you try to open input stream. I have fixed it in this pull request.
1. you should test scenarios when server response code is more than 400.
2. In normal cases, you will get null if you try to get error inputstream and it is ok.