### PR TITLE
增加了json格式的配置值的自动注入特性，以及@Value注解的自动刷新特性

### DIFF
--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/annotation/ApolloConfigRegistrar.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/annotation/ApolloConfigRegistrar.java
@@ -30,5 +30,11 @@ public class ApolloConfigRegistrar implements ImportBeanDefinitionRegistrar {
 
     BeanRegistrationUtil.registerBeanDefinitionIfNotExists(registry, ApolloAnnotationProcessor.class.getName(),
         ApolloAnnotationProcessor.class);
+
+    BeanRegistrationUtil.registerBeanDefinitionIfNotExists(registry, ApolloValueProcessor.class.getName(),
+            ApolloValueProcessor.class);
+
+    BeanRegistrationUtil.registerBeanDefinitionIfNotExists(registry, SpringValueProcessor.class.getName(),
+            SpringValueProcessor.class);
   }
 }

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/annotation/ApolloProcessor.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/annotation/ApolloProcessor.java
@@ -1,0 +1,66 @@
+package com.ctrip.framework.apollo.spring.annotation;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.core.Ordered;
+import org.springframework.core.PriorityOrdered;
+import org.springframework.util.ReflectionUtils;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Create by zhangzheng on 2018/2/6
+ */
+public class ApolloProcessor implements BeanPostProcessor, PriorityOrdered {
+    @Override
+    public Object postProcessBeforeInitialization(Object bean, String beanName) throws BeansException {
+        Class clazz = bean.getClass();
+        for(Field field:findAllField(clazz)){
+            processField(bean, field);
+        }
+        for(Method method:findAllMethod(clazz)){
+            processMethod(bean, method);
+        }
+        return bean;
+    }
+
+    @Override
+    public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+        return bean;
+    }
+
+    protected void processField(Object bean, Field field){}
+
+    protected void processMethod(Object bean, Method method){}
+
+
+    @Override
+    public int getOrder() {
+        return Ordered.LOWEST_PRECEDENCE;
+    }
+
+    private List<Field> findAllField(Class clazz) {
+        final List<Field> res = new LinkedList<>();
+        ReflectionUtils.doWithFields(clazz, new ReflectionUtils.FieldCallback() {
+            @Override
+            public void doWith(Field field) throws IllegalArgumentException, IllegalAccessException {
+                res.add(field);
+            }
+        });
+        return res;
+    }
+
+    private List<Method> findAllMethod(Class clazz) {
+        final List<Method> res = new LinkedList<>();
+        ReflectionUtils.doWithMethods(clazz, new ReflectionUtils.MethodCallback() {
+            @Override
+            public void doWith(Method method) throws IllegalArgumentException, IllegalAccessException {
+                res.add(method);
+            }
+        });
+        return res;
+    }
+}

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/annotation/ApolloValue.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/annotation/ApolloValue.java
@@ -1,0 +1,19 @@
+package com.ctrip.framework.apollo.spring.annotation;
+
+import com.ctrip.framework.apollo.core.ConfigConsts;
+import org.springframework.core.ParameterizedTypeReference;
+
+import java.lang.annotation.*;
+import java.lang.reflect.Type;
+
+/**
+ * Create by zhangzheng on 2018/2/6
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.METHOD})
+@Documented
+public @interface ApolloValue {
+
+    String value();
+
+}

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/annotation/ApolloValueProcessor.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/annotation/ApolloValueProcessor.java
@@ -1,0 +1,102 @@
+package com.ctrip.framework.apollo.spring.annotation;
+
+import com.ctrip.framework.apollo.spring.auto.SpringValue;
+import com.ctrip.framework.foundation.internals.Utils;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.LinkedListMultimap;
+import com.google.common.collect.Multimap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.context.EnvironmentAware;
+import org.springframework.core.Ordered;
+import org.springframework.core.PriorityOrdered;
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.core.env.Environment;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Create by zhangzheng on 2018/2/6
+ */
+public class ApolloValueProcessor extends ApolloProcessor implements EnvironmentAware{
+
+    private Pattern pattern = Pattern.compile("\\$\\{(.*?)(:(.*?))?}");
+    private static Multimap<String, SpringValue> monitor = LinkedListMultimap.create();
+    private Logger logger = LoggerFactory.getLogger(ApolloValueProcessor.class);
+
+    private static Boolean isAutoUpdate  = true;
+
+    private Environment environment;
+
+    public static Multimap<String, SpringValue> monitor() {
+        return monitor;
+    }
+
+    @Override
+    protected void processField(Object bean, Field field) {
+        ApolloValue apolloValue = AnnotationUtils.getAnnotation(field, ApolloValue.class);
+        if(apolloValue==null){
+            return;
+        }
+        Matcher matcher = pattern.matcher(apolloValue.value());
+        Preconditions.checkArgument(matcher.matches(),String.format("the apollo value annotation for field:%s is not correct," +
+                "please use ${somekey} pattern",field.getType()));
+        String key = matcher.group(1);
+        String propertyValue = environment.getProperty(key);
+        SpringValue springValue = SpringValue.create(bean,field);
+        if(!Utils.isBlank(propertyValue)){
+            springValue.updateVal(propertyValue);
+        }
+
+        if(isAutoUpdate){
+            monitor.put(key, SpringValue.create(bean, field));
+            logger.info("Listening apollo key = {}", key);
+        }
+        super.processField(bean, field);
+
+    }
+
+    @Override
+    protected void processMethod(Object bean, Method method) {
+
+        ApolloValue apolloValue = AnnotationUtils.getAnnotation(method, ApolloValue.class);
+        if(apolloValue==null){
+            return;
+        }
+        Matcher matcher = pattern.matcher(apolloValue.value());
+        Preconditions.checkArgument(matcher.matches(),String.format("the apollo value annotation for field:%s is not correct," +
+                "please use ${somekey} pattern",method.getName()));
+        String key = matcher.group(1);
+        String propertyValue = environment.getProperty(key);
+        SpringValue springValue = SpringValue.create(bean,method);
+        if(!Utils.isBlank(propertyValue)){
+            springValue.updateVal(propertyValue);
+        }
+        if(isAutoUpdate){
+            monitor.put(key, SpringValue.create(bean, method));
+            logger.info("Listening apollo key = {}", key);
+        }
+        super.processMethod(bean,method);
+    }
+
+
+    @Override
+    public void setEnvironment(Environment environment) {
+        this.environment = environment;
+    }
+
+    public Boolean getAutoUpdate() {
+        return isAutoUpdate;
+    }
+
+    public static void setAutoUpdate(Boolean autoUpdate) {
+        isAutoUpdate = autoUpdate;
+    }
+}

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/annotation/ApolloValueProcessor.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/annotation/ApolloValueProcessor.java
@@ -31,7 +31,6 @@ public class ApolloValueProcessor extends ApolloProcessor implements Environment
     private static Multimap<String, SpringValue> monitor = LinkedListMultimap.create();
     private Logger logger = LoggerFactory.getLogger(ApolloValueProcessor.class);
 
-    private static Boolean isAutoUpdate  = true;
 
     private Environment environment;
 
@@ -54,8 +53,8 @@ public class ApolloValueProcessor extends ApolloProcessor implements Environment
         if(!Utils.isBlank(propertyValue)){
             springValue.updateVal(propertyValue);
         }
-
-        if(isAutoUpdate){
+        DisableAutoUpdate disableAutoUpdate = AnnotationUtils.getAnnotation(field, DisableAutoUpdate.class);
+        if(disableAutoUpdate==null){
             monitor.put(key, SpringValue.create(bean, field));
             logger.info("Listening apollo key = {}", key);
         }
@@ -79,7 +78,8 @@ public class ApolloValueProcessor extends ApolloProcessor implements Environment
         if(!Utils.isBlank(propertyValue)){
             springValue.updateVal(propertyValue);
         }
-        if(isAutoUpdate){
+        DisableAutoUpdate disableAutoUpdate = AnnotationUtils.getAnnotation(method, DisableAutoUpdate.class);
+        if(disableAutoUpdate==null){
             monitor.put(key, SpringValue.create(bean, method));
             logger.info("Listening apollo key = {}", key);
         }
@@ -92,11 +92,4 @@ public class ApolloValueProcessor extends ApolloProcessor implements Environment
         this.environment = environment;
     }
 
-    public Boolean getAutoUpdate() {
-        return isAutoUpdate;
-    }
-
-    public static void setAutoUpdate(Boolean autoUpdate) {
-        isAutoUpdate = autoUpdate;
-    }
 }

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/annotation/DisableAutoUpdate.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/annotation/DisableAutoUpdate.java
@@ -1,0 +1,12 @@
+package com.ctrip.framework.apollo.spring.annotation;
+
+import java.lang.annotation.*;
+
+/**
+ * Create by zhangzheng on 2018/2/8
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.METHOD})
+@Documented
+public @interface DisableAutoUpdate {
+}

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/annotation/SpringValueProcessor.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/annotation/SpringValueProcessor.java
@@ -1,0 +1,74 @@
+package com.ctrip.framework.apollo.spring.annotation;
+
+import com.ctrip.framework.apollo.spring.auto.SpringValue;
+import com.google.common.base.Preconditions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.AnnotationUtils;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Create by zhangzheng on 2018/2/7
+ * 该类用来实现@Value注入的apollo配置信息的自动注入
+ */
+public class SpringValueProcessor extends ApolloProcessor{
+
+    private Pattern pattern = Pattern.compile("\\$\\{(.*?)(:(.*?))?}");
+    private Logger logger = LoggerFactory.getLogger(SpringValueProcessor.class);
+
+    private static Boolean isAutoUpdate = true;//自动更新开关
+
+    @Override
+    protected void processField(Object bean, Field field) {
+        if(!isAutoUpdate){
+            return;
+        }
+        Value value = AnnotationUtils.getAnnotation(field, Value.class);
+        if(value==null){
+            return;
+        }
+        Matcher matcher = pattern.matcher(value.value());
+        Preconditions.checkArgument(matcher.matches(),String.format("the apollo value annotation for field:%s is not correct," +
+                "please use ${somekey} or ${someKey:someDefaultValue} pattern",field.getType()));
+        String key = matcher.group(1);
+
+        ApolloValueProcessor.monitor().put(key, SpringValue.create(bean, field));
+        logger.info("Listening apollo key = {}", key);
+
+        super.processField(bean, field);
+    }
+
+    @Override
+    protected void processMethod(Object bean, Method method) {
+        if(!isAutoUpdate){
+            return;
+        }
+        Value value = AnnotationUtils.getAnnotation(method, Value.class);
+        if(value==null){
+            return;
+        }
+        Matcher matcher = pattern.matcher(value.value());
+        Preconditions.checkArgument(matcher.matches(),String.format("the apollo value annotation for field:%s is not correct," +
+                "please use ${somekey} or ${someKey:someDefaultValue} pattern",method.getName()));
+        String key = matcher.group(1);
+
+        ApolloValueProcessor.monitor().put(key, SpringValue.create(bean, method));
+        logger.info("Listening apollo key = {}", key);
+
+
+        super.processMethod(bean, method);
+    }
+
+
+
+    public static void setAutoUpdate(Boolean autoUpdate) {
+        isAutoUpdate = autoUpdate;
+    }
+}

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/annotation/SpringValueProcessor.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/annotation/SpringValueProcessor.java
@@ -23,11 +23,11 @@ public class SpringValueProcessor extends ApolloProcessor{
     private Pattern pattern = Pattern.compile("\\$\\{(.*?)(:(.*?))?}");
     private Logger logger = LoggerFactory.getLogger(SpringValueProcessor.class);
 
-    private static Boolean isAutoUpdate = true;//自动更新开关
 
     @Override
     protected void processField(Object bean, Field field) {
-        if(!isAutoUpdate){
+        DisableAutoUpdate disableAutoUpdate = AnnotationUtils.getAnnotation(field, DisableAutoUpdate.class);
+        if(disableAutoUpdate!=null){
             return;
         }
         Value value = AnnotationUtils.getAnnotation(field, Value.class);
@@ -47,7 +47,8 @@ public class SpringValueProcessor extends ApolloProcessor{
 
     @Override
     protected void processMethod(Object bean, Method method) {
-        if(!isAutoUpdate){
+        DisableAutoUpdate disableAutoUpdate = AnnotationUtils.getAnnotation(method, DisableAutoUpdate.class);
+        if(disableAutoUpdate!=null){
             return;
         }
         Value value = AnnotationUtils.getAnnotation(method, Value.class);
@@ -67,8 +68,4 @@ public class SpringValueProcessor extends ApolloProcessor{
     }
 
 
-
-    public static void setAutoUpdate(Boolean autoUpdate) {
-        isAutoUpdate = autoUpdate;
-    }
 }

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/auto/SpringValue.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/auto/SpringValue.java
@@ -1,0 +1,119 @@
+package com.ctrip.framework.apollo.spring.auto;
+
+import com.ctrip.framework.apollo.util.function.Functions;
+import com.google.common.base.Function;
+import com.google.gson.Gson;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.util.Date;
+
+/**
+ * Spring @Value or @ApolloValue field or method info
+ * @author github.com/zhegexiaohuozi [wanghaomiao@huli.com]
+ * @since 2017/12/20.
+ */
+public class SpringValue {
+    private static Gson gson = new Gson();
+
+    private Object bean;
+    private Field field;
+    private Method method;
+    private boolean isField = false;
+    private String className;
+    private String fieldName;
+    private Function<String, ?> parser;
+    private Type genericType;
+    private Class type;
+
+    private Logger logger = LoggerFactory.getLogger(SpringValue.class);
+
+    private SpringValue(Object ins, Field field) {
+        this.bean = ins;
+        this.className = ins.getClass().getName();
+        this.fieldName = field.getName();
+        this.field = field;
+        this.isField = true;
+        this.genericType = field.getGenericType();
+        this.type = field.getType();
+        this.parser = findParser(field.getType());
+    }
+
+    private SpringValue(Object ins, Method method) {
+        this.bean = ins;
+        this.method = method;
+        this.className = ins.getClass().getName();
+        this.fieldName = method.getName() + "(*)";
+        Class<?>[] paramTps = method.getParameterTypes();
+        if (paramTps.length != 1){
+            logger.error("invalid setter,can not update in {}.{}",className,fieldName);
+            return;
+        }
+        this.type = paramTps[0];
+        this.genericType = method.getGenericParameterTypes()[0];
+        this.parser = findParser(paramTps[0]);
+    }
+
+    public static SpringValue create(Object ins, Field field){
+        return new SpringValue(ins,field);
+    }
+
+    public static SpringValue create(Object ins, Method method){
+        return new SpringValue(ins,method);
+    }
+
+    public void updateVal(String newVal){
+        try {
+            if (isField){
+                boolean accessible = field.isAccessible();
+                field.setAccessible(true);
+                field.set(bean,parseVal(newVal));
+                field.setAccessible(accessible);
+            }else {
+                Class<?>[] paramTps = method.getParameterTypes();
+                if (paramTps.length != 1){
+                    logger.error("invalid setter ,can not update val={} in {}.{}",newVal,className,fieldName);
+                    return;
+                }
+                method.invoke(bean,parseVal(newVal));
+            }
+            logger.info("auto update apollo changed value, newVal={} in {}.{}",newVal,className,fieldName);
+        }catch (Exception e){
+            logger.error("update field {}.{} filed with new val={},msg ={}",className,fieldName,newVal,e.getMessage());
+        }
+    }
+
+    private Object parseVal(String newVal){
+        if (parser == null){
+            if(type.equals(String.class)){
+                return newVal;
+            }
+            return gson.fromJson(newVal,genericType);
+        }
+        return parser.apply(newVal);
+    }
+
+    private Function<String, ?> findParser(Class<?> targetType) {
+        Function<String, ?> res = null;
+        if (targetType.equals(int.class) || targetType.equals(Integer.class)) {
+            res = Functions.TO_INT_FUNCTION;
+        } else if (targetType.equals(long.class) || targetType.equals(Long.class)) {
+            res = Functions.TO_LONG_FUNCTION;
+        }  else if (targetType.equals(boolean.class) || targetType.equals(Boolean.class)) {
+            res = Functions.TO_BOOLEAN_FUNCTION;
+        } else if (targetType.equals(Date.class)) {
+            res = Functions.TO_DATE_FUNCTION;
+        }else if (targetType.equals(short.class) || targetType.equals(Short.class)){
+            res = Functions.TO_SHORT_FUNCTION;
+        }else if (targetType.equals(double.class) || targetType.equals(Double.class)){
+            res = Functions.TO_DOUBLE_FUNCTION;
+        }else if (targetType.equals(float.class) || targetType.equals(Float.class)){
+            res = Functions.TO_FLOAT_FUNCTION;
+        }
+        return res;
+    }
+
+}

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/config/ConfigPropertySourcesProcessor.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/config/ConfigPropertySourcesProcessor.java
@@ -1,5 +1,7 @@
 package com.ctrip.framework.apollo.spring.config;
 
+import com.ctrip.framework.apollo.spring.annotation.ApolloValueProcessor;
+import com.ctrip.framework.apollo.spring.annotation.SpringValueProcessor;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProcessor;
@@ -22,5 +24,12 @@ public class ConfigPropertySourcesProcessor extends PropertySourcesProcessor
         PropertySourcesPlaceholderConfigurer.class);
     BeanRegistrationUtil.registerBeanDefinitionIfNotExists(registry, ApolloAnnotationProcessor.class.getName(),
         ApolloAnnotationProcessor.class);
+
+    BeanRegistrationUtil.registerBeanDefinitionIfNotExists(registry, ApolloValueProcessor.class.getName(),
+            ApolloValueProcessor.class);
+
+    BeanRegistrationUtil.registerBeanDefinitionIfNotExists(registry, SpringValueProcessor.class.getName(),
+            SpringValueProcessor.class);
+
   }
 }

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/config/PropertySourcesProcessor.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/config/PropertySourcesProcessor.java
@@ -1,5 +1,12 @@
 package com.ctrip.framework.apollo.spring.config;
 
+import com.ctrip.framework.apollo.ConfigChangeListener;
+import com.ctrip.framework.apollo.model.ConfigChange;
+import com.ctrip.framework.apollo.model.ConfigChangeEvent;
+import com.ctrip.framework.apollo.spring.annotation.ApolloAnnotationProcessor;
+import com.ctrip.framework.apollo.spring.annotation.ApolloValue;
+import com.ctrip.framework.apollo.spring.annotation.ApolloValueProcessor;
+import com.ctrip.framework.apollo.spring.auto.SpringValue;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Multimap;
@@ -16,9 +23,11 @@ import org.springframework.core.PriorityOrdered;
 import org.springframework.core.env.CompositePropertySource;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.Environment;
+import org.springframework.util.CollectionUtils;
 
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.Set;
 
 /**
  * Apollo Property Sources processor for Spring Annotation Based Application. <br /> <br />
@@ -59,7 +68,25 @@ public class PropertySourcesProcessor implements BeanFactoryPostProcessor, Envir
       int order = iterator.next();
       for (String namespace : NAMESPACE_NAMES.get(order)) {
         Config config = ConfigService.getConfig(namespace);
-
+        config.addChangeListener(new ConfigChangeListener() {
+          @Override
+          public void onChange(ConfigChangeEvent changeEvent) {
+            Set<String> keys = changeEvent.changedKeys();
+            if (CollectionUtils.isEmpty(keys)){
+              return;
+            }
+            for (String k:keys){
+              ConfigChange configChange = changeEvent.getChange(k);
+              Collection<SpringValue> targetValues = ApolloValueProcessor.monitor().get(k);
+              if (targetValues==null||targetValues.isEmpty()){
+                return;
+              }
+              for (SpringValue val:targetValues){
+                val.updateVal(configChange.getNewValue());
+              }
+            }
+          }
+        });
         composite.addPropertySource(new ConfigPropertySource(namespace, config));
       }
     }

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/spring/JavaConfigAnnotationTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/spring/JavaConfigAnnotationTest.java
@@ -88,7 +88,7 @@ public class JavaConfigAnnotationTest extends AbstractSpringIntegrationTest {
 
     TestApolloConfigChangeListenerBean1 bean = getBean(TestApolloConfigChangeListenerBean1.class, AppConfig3.class);
 
-    assertEquals(3, applicationListeners.size());
+    assertEquals(4, applicationListeners.size());
     assertEquals(1, fxApolloListeners.size());
 
     for (ConfigChangeListener listener : applicationListeners) {

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/spring/XMLConfigAnnotationTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/spring/XMLConfigAnnotationTest.java
@@ -86,7 +86,7 @@ public class XMLConfigAnnotationTest extends AbstractSpringIntegrationTest {
     TestApolloConfigChangeListenerBean1 bean = getBean("spring/XmlConfigAnnotationTest3.xml",
         TestApolloConfigChangeListenerBean1.class);
 
-    assertEquals(3, applicationListeners.size());
+    assertEquals(4, applicationListeners.size());
     assertEquals(1, fxApolloListeners.size());
 
     for (ConfigChangeListener listener : applicationListeners) {


### PR DESCRIPTION
1 由于很多配置项的值都是JSON格式的数据，这对这种格式的数据，apollo并没有很好的支持，业务方需要自己通过JAVA API的方式来获取Json串，再反序列化成相应的对象。不能享受Spring @Value注解带来的自动注入特性。所以我实现了一个@ApolloValue用来处理这种格式数据的注入
```
@ApolloValue("${someKey}")
List<SomeType> someList;
```
2 增加了@Value和@ApolloValue的自动更新特性，可以通过@DisableAutoUpdate注解来禁掉这一特性，这个参考了https://github.com/ctripcorp/apollo/pull/898
```
    @Value("${timeout:1000}")
    @DisableAutoUpdate
    private int timeout;

    @ApolloValue("${jsonProperty}")
    @DisableAutoUpdate
    private List<SomeType> someList;
```
