### PR TITLE
Multimap并未严格保持@EnableApolloConfig注解中namespace定义的顺序。

### DIFF
--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/config/PropertySourcesProcessor.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/config/PropertySourcesProcessor.java
@@ -1,6 +1,5 @@
 package com.ctrip.framework.apollo.spring.config;
 
-import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Multimap;

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/config/PropertySourcesProcessor.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/config/PropertySourcesProcessor.java
@@ -2,6 +2,7 @@ package com.ctrip.framework.apollo.spring.config;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Multimap;
 
 import com.ctrip.framework.apollo.Config;
@@ -31,7 +32,7 @@ import java.util.Iterator;
  * @author Jason Song(song_s@ctrip.com)
  */
 public class PropertySourcesProcessor implements BeanFactoryPostProcessor, EnvironmentAware, PriorityOrdered {
-  private static final Multimap<Integer, String> NAMESPACE_NAMES = HashMultimap.create();
+  private static final Multimap<Integer, String> NAMESPACE_NAMES = LinkedHashMultimap.create();
 
   private ConfigurableEnvironment environment;
 

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/spring/JavaConfigPlaceholderTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/spring/JavaConfigPlaceholderTest.java
@@ -96,6 +96,26 @@ public class JavaConfigPlaceholderTest extends AbstractSpringIntegrationTest {
     check(someTimeout, someBatch, AppConfig3.class);
   }
 
+
+  @Test
+  public void testMultiplePropertySourcesCoverWithSameProperties() throws Exception {
+    //Multimap does not maintain the strict input order of namespace.
+    int someTimeout = 1000;
+    int anotherTimeout = someTimeout + 1;
+    int someBatch = 2000;
+
+    Config fxApollo = mock(Config.class);
+    when(fxApollo.getProperty(eq(TIMEOUT_PROPERTY), anyString())).thenReturn(String.valueOf(someTimeout));
+    when(fxApollo.getProperty(eq(BATCH_PROPERTY), anyString())).thenReturn(String.valueOf(someBatch));
+    mockConfig(FX_APOLLO_NAMESPACE, fxApollo);
+
+    Config application = mock(Config.class);
+    when(application.getProperty(eq(TIMEOUT_PROPERTY), anyString())).thenReturn(String.valueOf(anotherTimeout));
+    mockConfig(ConfigConsts.NAMESPACE_APPLICATION, application);
+
+    check(someTimeout, someBatch, AppConfig6.class);
+  }
+
   @Test
   public void testMultiplePropertySourcesWithSamePropertiesWithWeight() throws Exception {
     int someTimeout = 1000;
@@ -185,6 +205,15 @@ public class JavaConfigPlaceholderTest extends AbstractSpringIntegrationTest {
       bean.setBatch(batch);
 
       return bean;
+    }
+  }
+
+  @Configuration
+  @EnableApolloConfig({"FX.apollo", "application"})
+  static class AppConfig6 {
+    @Bean
+    TestJavaConfigBean testJavaConfigBean() {
+      return new TestJavaConfigBean();
     }
   }
 


### PR DESCRIPTION
e.g:
@EnableApolloConfig({"application","FX.apollo"})情况下，最终environment.getPropertySources取出的顺序为"application","FX.apollo"，然而在@EnableApolloConfig({"FX.apollo","application"})情况下，取出的顺序为"application","FX.apollo"。