### PR TITLE
delete namespace

### DIFF
--- a/apollo-adminservice/src/main/java/com/ctrip/framework/apollo/adminservice/controller/NamespaceController.java
+++ b/apollo-adminservice/src/main/java/com/ctrip/framework/apollo/adminservice/controller/NamespaceController.java
@@ -101,5 +101,10 @@ public class NamespaceController {
     return namespaceService.namespacePublishInfo(appId);
   }
 
-
+  @RequestMapping(value = "/apps/{appId}/clusters/{clusterName}/namespaces/{namespaceName}/isExisted", method = RequestMethod.GET)
+  public boolean findExisted(@PathVariable("appId") String appId,
+		                     @PathVariable("clusterName") String clusterName,
+                             @PathVariable("namespaceName") String namespaceName) {  
+    return namespaceService.findNamespaceExited(appId, clusterName, namespaceName);
+  }
 }

--- a/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/repository/AppNamespaceRepository.java
+++ b/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/repository/AppNamespaceRepository.java
@@ -2,6 +2,8 @@ package com.ctrip.framework.apollo.biz.repository;
 
 import com.ctrip.framework.apollo.common.entity.AppNamespace;
 
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.PagingAndSortingRepository;
 
 import java.util.List;
@@ -23,5 +25,8 @@ public interface AppNamespaceRepository extends PagingAndSortingRepository<AppNa
   List<AppNamespace> findByAppId(String appId);
 
   List<AppNamespace> findFirst500ByIdGreaterThanOrderByIdAsc(long id);
-
+  
+  @Modifying
+  @Query("update AppNamespace set isdeleted=1,dataChange_LastModifiedBy = ?3 where isDeleted = 0 and appId= ?1 and name = ?2 ")
+  int batchDelete(String appId, String namespaceName, String operator);
 }

--- a/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/service/AppNamespaceService.java
+++ b/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/service/AppNamespaceService.java
@@ -137,4 +137,9 @@ public class AppNamespaceService {
       namespaceService.save(namespace);
     }
   }
+  
+  @Transactional
+  public int batchDelete(String appId, String namespaceName, String operator) {
+    return appNamespaceRepository.batchDelete(appId, namespaceName, operator);
+  }
 }

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/api/AdminServiceAPI.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/api/AdminServiceAPI.java
@@ -132,6 +132,12 @@ public class AdminServiceAPI {
       return count == null ? 0 : count;
     }
 
+    public boolean selectExistAppNamespace(Env env, String appId, String clusterName, String namespaceName) {
+        boolean flag =
+            restTemplate.get(env, "/apps/{appId}/clusters/{clusterName}/namespaces/{namespaceName}/isExisted",
+            		Boolean.class, appId, clusterName, namespaceName);
+        return flag;
+     }
   }
 
   @Service

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/entity/po/ServerConfig.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/entity/po/ServerConfig.java
@@ -17,6 +17,9 @@ import javax.persistence.Table;
 @SQLDelete(sql = "Update ServerConfig set isDeleted = 1 where id = ?")
 @Where(clause = "isDeleted = 0")
 public class ServerConfig extends BaseEntity {
+	
+  public final static String ENV_KEY = "apollo.portal.envs";
+	
   @Column(name = "Key", nullable = false)
   private String key;
 

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/repository/AppNamespaceRepository.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/repository/AppNamespaceRepository.java
@@ -2,6 +2,8 @@ package com.ctrip.framework.apollo.portal.repository;
 
 import com.ctrip.framework.apollo.common.entity.AppNamespace;
 
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.PagingAndSortingRepository;
 
 import java.util.List;
@@ -16,4 +18,7 @@ public interface AppNamespaceRepository extends PagingAndSortingRepository<AppNa
 
   List<AppNamespace> findByIsPublicTrue();
 
+  @Modifying
+  @Query("update AppNamespace set isdeleted=1,dataChange_LastModifiedBy = ?3 where isDeleted = 0 and appId= ?1 and name = ?2 ")
+  int batchDelete(String appId, String namespaceName, String operator);
 }

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/repository/PermissionRepository.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/repository/PermissionRepository.java
@@ -2,6 +2,8 @@ package com.ctrip.framework.apollo.portal.repository;
 
 import com.ctrip.framework.apollo.portal.entity.po.Permission;
 
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.PagingAndSortingRepository;
 
 import java.util.Collection;
@@ -21,4 +23,17 @@ public interface PermissionRepository extends PagingAndSortingRepository<Permiss
    */
   List<Permission> findByPermissionTypeInAndTargetId(Collection<String> permissionTypes,
                                                      String targetId);
+  
+  /**
+   * find permissionsId by targetId
+   */
+  @Query("select id from Permission where targetId = CONCAT(?1, '+', ?2)  and isDeleted = 0")
+  List<String> findListByTargetId(String appId, String namespaceName);
+  
+  /**
+   * delete permissions by ids
+   */
+  @Modifying
+  @Query("update Permission set isdeleted = 1,DataChange_LastModifiedBy = ?2 where isDeleted = 0 and id in ?1")
+  int batchDelete(List<String> ids, String operator);
 }

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/repository/RolePermissionRepository.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/repository/RolePermissionRepository.java
@@ -2,6 +2,8 @@ package com.ctrip.framework.apollo.portal.repository;
 
 import com.ctrip.framework.apollo.portal.entity.po.RolePermission;
 
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.PagingAndSortingRepository;
 
 import java.util.Collection;
@@ -17,4 +19,10 @@ public interface RolePermissionRepository extends PagingAndSortingRepository<Rol
    */
   List<RolePermission> findByRoleIdIn(Collection<Long> roleId);
 
+  /**
+   * Delete rolePermissions By ids
+   */
+  @Modifying
+  @Query("update RolePermission set isdeleted = 1,DataChange_LastModifiedBy = ?2 where isDeleted = 0 and id in ?1")
+  public int batchDelete(List<String> ids, String operator);
 }

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/repository/RoleRepository.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/repository/RoleRepository.java
@@ -2,6 +2,10 @@ package com.ctrip.framework.apollo.portal.repository;
 
 import com.ctrip.framework.apollo.portal.entity.po.Role;
 
+import java.util.List;
+
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.PagingAndSortingRepository;
 
 /**
@@ -12,4 +16,31 @@ public interface RoleRepository extends PagingAndSortingRepository<Role, Long> {
    * find role by role name
    */
   Role findTopByRoleName(String roleName);
+  
+  /**
+   * find ids by role name
+   */
+  @Query("select id from Role where (RoleName = CONCAT('ModifyNamespace+', ?1, '+', ?2) or RoleName = CONCAT('ReleaseNamespace+', ?1, '+', ?2)) and IsDeleted = 0")
+  List<String> findIdsByRoleName(String appId, String namespaceName);
+  
+  /**
+   * delete role by ids
+   */
+  @Modifying
+  @Query("update Role set isdeleted = 1,DataChange_LastModifiedBy = ?2 where isDeleted = 0 and id in ?1")
+  int batchDeleteRole(List<String> ids, String operator);
+  
+  /**
+   * delete userRole by ids
+   */
+  @Modifying
+  @Query("update UserRole set isdeleted = 1,DataChange_LastModifiedBy = ?2 where isDeleted = 0 and roleId in ?1")
+  int batchDeleteUserRole(List<String> ids, String operator);
+  
+  /**
+   * delete consumerRole by ids
+   */
+  @Modifying
+  @Query("update ConsumerRole set isdeleted = 1,DataChange_LastModifiedBy = ?2 where isDeleted = 0 and roleId in ?1")
+  int batchDeleteConsumerRole(List<String> ids, String operator);
 }

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/service/AppNamespaceService.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/service/AppNamespaceService.java
@@ -1,21 +1,20 @@
 package com.ctrip.framework.apollo.portal.service;
 
-import com.ctrip.framework.apollo.common.entity.App;
-import com.ctrip.framework.apollo.common.entity.AppNamespace;
-import com.ctrip.framework.apollo.common.exception.BadRequestException;
-import com.ctrip.framework.apollo.common.exception.ServiceException;
-import com.ctrip.framework.apollo.core.ConfigConsts;
-import com.ctrip.framework.apollo.core.enums.ConfigFileFormat;
-import com.ctrip.framework.apollo.core.utils.StringUtils;
-import com.ctrip.framework.apollo.portal.repository.AppNamespaceRepository;
-import com.ctrip.framework.apollo.portal.spi.UserInfoHolder;
+import java.util.List;
+import java.util.Objects;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-import java.util.Objects;
+import com.ctrip.framework.apollo.common.entity.App;
+import com.ctrip.framework.apollo.common.entity.AppNamespace;
+import com.ctrip.framework.apollo.common.exception.BadRequestException;
+import com.ctrip.framework.apollo.core.ConfigConsts;
+import com.ctrip.framework.apollo.core.enums.ConfigFileFormat;
+import com.ctrip.framework.apollo.core.utils.StringUtils;
+import com.ctrip.framework.apollo.portal.repository.AppNamespaceRepository;
+import com.ctrip.framework.apollo.portal.spi.UserInfoHolder;
 
 @Service
 public class AppNamespaceService {
@@ -119,4 +118,8 @@ public class AppNamespaceService {
     return createdAppNamespace;
   }
 
+  @Transactional
+  public int batchDelete(String appId, String namespaceName, String operator) {
+    return appNamespaceRepository.batchDelete(appId, namespaceName, operator);
+  }
 }

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/service/PermissionService.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/service/PermissionService.java
@@ -1,0 +1,25 @@
+package com.ctrip.framework.apollo.portal.service;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ctrip.framework.apollo.portal.repository.PermissionRepository;
+
+@Service
+public class PermissionService {
+
+	@Autowired
+	private PermissionRepository permissionRepository;
+	
+	public List<String> findIdsByTargetId(String appId, String namespaceName){
+		return permissionRepository.findListByTargetId(appId, namespaceName);
+	}
+	
+	@Transactional
+	public int batchDelete(List<String> ids, String operator) {
+	    return permissionRepository.batchDelete(ids,operator);
+	}
+}

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/service/RolePermissionService.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/service/RolePermissionService.java
@@ -4,6 +4,7 @@ import com.ctrip.framework.apollo.portal.entity.bo.UserInfo;
 import com.ctrip.framework.apollo.portal.entity.po.Permission;
 import com.ctrip.framework.apollo.portal.entity.po.Role;
 
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -56,4 +57,8 @@ public interface RolePermissionService {
    */
   public Set<Permission> createPermissions(Set<Permission> permissions);
 
+  /**
+   * Delete rolePermissions By ids
+   */
+  public int batchDelete(List<String> ids, String operator);
 }

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/service/RoleService.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/service/RoleService.java
@@ -1,0 +1,35 @@
+package com.ctrip.framework.apollo.portal.service;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ctrip.framework.apollo.portal.repository.RoleRepository;
+
+@Service
+public class RoleService {
+
+	@Autowired
+	private RoleRepository roleRepository;
+	
+	public List<String> findIdsByRoleName(String appId, String namespaceName){
+		return roleRepository.findIdsByRoleName(appId, namespaceName);
+	}
+	
+	@Transactional
+	public int batchDeleteRole(List<String> ids, String operator) {
+	    return roleRepository.batchDeleteRole(ids,operator);
+	}
+	
+	@Transactional
+	public int batchDeleteUserRole(List<String> ids, String operator) {
+	    return roleRepository.batchDeleteUserRole(ids,operator);
+	}
+
+	@Transactional
+	public int batchDeleteConsumerRole(List<String> ids, String operator) {
+	    return roleRepository.batchDeleteConsumerRole(ids,operator);
+	}
+}

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/defaultimpl/DefaultRolePermissionService.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/defaultimpl/DefaultRolePermissionService.java
@@ -219,5 +219,10 @@ public class DefaultRolePermissionService implements RolePermissionService {
         Iterable<Permission> results = permissionRepository.save(permissions);
         return FluentIterable.from(results).toSet();
     }
+    
+	@Transactional
+	public int batchDelete(List<String> ids, String operator) {
+	    return rolePermissionRepository.batchDelete(ids,operator);
+	}
 
 }

--- a/apollo-portal/src/main/resources/static/scripts/directive/delete-namespace-modal-directive.js
+++ b/apollo-portal/src/main/resources/static/scripts/directive/delete-namespace-modal-directive.js
@@ -19,9 +19,9 @@ function deleteNamespaceModalDirective($window, $q, toastr, AppUtil, EventManage
                 scope.toDeleteNamespace = toDeleteNamespace;
 
                 //1. check namespace is not private
-                if (!checkNotPrivateNamespace(toDeleteNamespace)) {
-                    return;
-                }
+                //if (!checkNotPrivateNamespace(toDeleteNamespace)) {
+                //    return;
+                //}
 
                 //2. check operator has master permission
                 checkPermission(toDeleteNamespace).then(function () {


### PR DESCRIPTION
修改了逻辑删除公有namespace功能，新增了逻辑删除私有namespace功能。
删除时优先删除本环境的namespace（即ConfigDB中的数据），并查询其他环境中的namespace是否存在，如果不存在，再删除PortalDB中的数据，此时，该namespace完全删除。