### PR TITLE
Adjust long polling timeout

### DIFF
--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/RemoteConfigLongPollService.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/RemoteConfigLongPollService.java
@@ -54,6 +54,8 @@ public class RemoteConfigLongPollService {
   private static final Joiner.MapJoiner MAP_JOINER = Joiner.on("&").withKeyValueSeparator("=");
   private static final Escaper queryParamEscaper = UrlEscapers.urlFormParameterEscaper();
   private static final long INIT_NOTIFICATION_ID = ConfigConsts.NOTIFICATION_ID_PLACEHOLDER;
+  //90 seconds, should be longer than server side's long polling timeout, which is now 60 seconds
+  private static final int LONG_POLLING_READ_TIMEOUT = 90 * 1000;
   private final ExecutorService m_longPollingService;
   private final AtomicBoolean m_longPollingStopped;
   private SchedulePolicy m_longPollFailSchedulePolicyInSecond;
@@ -161,8 +163,7 @@ public class RemoteConfigLongPollService {
 
         logger.debug("Long polling from {}", url);
         HttpRequest request = new HttpRequest(url);
-        //longer timeout for read - 10 minutes
-        request.setReadTimeout(600000);
+        request.setReadTimeout(LONG_POLLING_READ_TIMEOUT);
 
         transaction.addData("Url", url);
 

--- a/apollo-configservice/src/main/java/com/ctrip/framework/apollo/configservice/wrapper/DeferredResultWrapper.java
+++ b/apollo-configservice/src/main/java/com/ctrip/framework/apollo/configservice/wrapper/DeferredResultWrapper.java
@@ -17,7 +17,7 @@ import java.util.Map;
  * @author Jason Song(song_s@ctrip.com)
  */
 public class DeferredResultWrapper {
-  private static final long TIMEOUT = 30 * 1000;//30 seconds
+  private static final long TIMEOUT = 60 * 1000;//60 seconds
   private static final ResponseEntity<List<ApolloConfigNotification>>
       NOT_MODIFIED_RESPONSE_LIST = new ResponseEntity<>(HttpStatus.NOT_MODIFIED);
 


### PR DESCRIPTION
1. adjust server side's long polling timeout from 30 seconds to 60 seconds
2. adjust client side's long polling timeout from 600 seconds to 90 seconds