### PR TITLE
fix the issue brought by 0.10.0 that Spring related classes are mistakenly loaded via DefaultInjector

### DIFF
--- a/apollo-adminservice/pom.xml
+++ b/apollo-adminservice/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.ctrip.framework.apollo</groupId>
 		<artifactId>apollo</artifactId>
-		<version>0.10.0</version>
+		<version>0.10.1</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/apollo-adminservice/src/main/docker/Dockerfile
+++ b/apollo-adminservice/src/main/docker/Dockerfile
@@ -7,7 +7,7 @@
 FROM openjdk:8-jre-alpine
 MAINTAINER ameizi <sxyx2008@163.com>
 
-ENV VERSION 0.10.0
+ENV VERSION 0.10.1
 
 RUN echo "http://mirrors.aliyun.com/alpine/v3.6/main" > /etc/apk/repositories \
     && echo "http://mirrors.aliyun.com/alpine/v3.6/community" >> /etc/apk/repositories \

--- a/apollo-assembly/pom.xml
+++ b/apollo-assembly/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.ctrip.framework.apollo</groupId>
 		<artifactId>apollo</artifactId>
-		<version>0.10.0</version>
+		<version>0.10.1</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/apollo-biz/pom.xml
+++ b/apollo-biz/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.ctrip.framework.apollo</groupId>
 		<artifactId>apollo</artifactId>
-		<version>0.10.0</version>
+		<version>0.10.1</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>apollo-biz</artifactId>

--- a/apollo-buildtools/pom.xml
+++ b/apollo-buildtools/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.ctrip.framework.apollo</groupId>
 		<artifactId>apollo</artifactId>
-		<version>0.10.0</version>
+		<version>0.10.1</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/apollo-client/README.md
+++ b/apollo-client/README.md
@@ -88,7 +88,7 @@ If you need this functionality, you could specify the cluster as follows:
 		<dependency>
 			<groupId>com.ctrip.framework.apollo</groupId>
 			<artifactId>apollo-client</artifactId>
-			<version>0.10.0</version>
+			<version>0.10.1</version>
 		</dependency>
 
 ## III. Client Usage

--- a/apollo-client/pom.xml
+++ b/apollo-client/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.ctrip.framework.apollo</groupId>
 		<artifactId>apollo</artifactId>
-		<version>0.10.0</version>
+		<version>0.10.1</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/build/ApolloInjector.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/build/ApolloInjector.java
@@ -10,7 +10,7 @@ import com.ctrip.framework.foundation.internals.ServiceBootstrap;
  */
 public class ApolloInjector {
   private static volatile Injector s_injector;
-  private static Object lock = new Object();
+  private static final Object lock = new Object();
 
   private static Injector getInjector() {
     if (s_injector == null) {

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/DefaultInjector.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/DefaultInjector.java
@@ -7,9 +7,6 @@ import com.ctrip.framework.apollo.spi.ConfigRegistry;
 import com.ctrip.framework.apollo.spi.DefaultConfigFactory;
 import com.ctrip.framework.apollo.spi.DefaultConfigFactoryManager;
 import com.ctrip.framework.apollo.spi.DefaultConfigRegistry;
-import com.ctrip.framework.apollo.spring.config.ConfigPropertySourceFactory;
-import com.ctrip.framework.apollo.spring.property.PlaceholderHelper;
-import com.ctrip.framework.apollo.spring.property.SpringValueRegistry;
 import com.ctrip.framework.apollo.tracer.Tracer;
 import com.ctrip.framework.apollo.util.ConfigUtil;
 import com.ctrip.framework.apollo.util.http.HttpUtil;
@@ -63,9 +60,6 @@ public class DefaultInjector implements Injector {
       bind(HttpUtil.class).in(Singleton.class);
       bind(ConfigServiceLocator.class).in(Singleton.class);
       bind(RemoteConfigLongPollService.class).in(Singleton.class);
-      bind(PlaceholderHelper.class).in(Singleton.class);
-      bind(ConfigPropertySourceFactory.class).in(Singleton.class);
-      bind(SpringValueRegistry.class).in(Singleton.class);
     }
   }
 }

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/annotation/ApolloJsonValueProcessor.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/annotation/ApolloJsonValueProcessor.java
@@ -5,6 +5,7 @@ import com.ctrip.framework.apollo.spring.property.AutoUpdateConfigChangeListener
 import com.ctrip.framework.apollo.spring.property.PlaceholderHelper;
 import com.ctrip.framework.apollo.spring.property.SpringValue;
 import com.ctrip.framework.apollo.spring.property.SpringValueRegistry;
+import com.ctrip.framework.apollo.spring.util.SpringInjector;
 import com.ctrip.framework.apollo.util.ConfigUtil;
 import com.google.common.base.Preconditions;
 import com.google.gson.Gson;
@@ -37,8 +38,8 @@ public class ApolloJsonValueProcessor extends ApolloProcessor implements BeanFac
 
   public ApolloJsonValueProcessor() {
     configUtil = ApolloInjector.getInstance(ConfigUtil.class);
-    placeholderHelper = ApolloInjector.getInstance(PlaceholderHelper.class);
-    springValueRegistry = ApolloInjector.getInstance(SpringValueRegistry.class);
+    placeholderHelper = SpringInjector.getInstance(PlaceholderHelper.class);
+    springValueRegistry = SpringInjector.getInstance(SpringValueRegistry.class);
   }
 
   @Override

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/annotation/SpringValueProcessor.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/annotation/SpringValueProcessor.java
@@ -7,6 +7,7 @@ import com.ctrip.framework.apollo.spring.property.SpringValue;
 import com.ctrip.framework.apollo.spring.property.SpringValueDefinition;
 import com.ctrip.framework.apollo.spring.property.SpringValueDefinitionProcessor;
 import com.ctrip.framework.apollo.spring.property.SpringValueRegistry;
+import com.ctrip.framework.apollo.spring.util.SpringInjector;
 import com.ctrip.framework.apollo.util.ConfigUtil;
 import com.google.common.collect.LinkedListMultimap;
 import com.google.common.collect.Multimap;
@@ -43,8 +44,8 @@ public class SpringValueProcessor extends ApolloProcessor implements BeanFactory
 
   public SpringValueProcessor() {
     configUtil = ApolloInjector.getInstance(ConfigUtil.class);
-    placeholderHelper = ApolloInjector.getInstance(PlaceholderHelper.class);
-    springValueRegistry = ApolloInjector.getInstance(SpringValueRegistry.class);
+    placeholderHelper = SpringInjector.getInstance(PlaceholderHelper.class);
+    springValueRegistry = SpringInjector.getInstance(SpringValueRegistry.class);
   }
 
   @Override

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/boot/ApolloApplicationContextInitializer.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/boot/ApolloApplicationContextInitializer.java
@@ -6,6 +6,7 @@ import com.ctrip.framework.apollo.build.ApolloInjector;
 import com.ctrip.framework.apollo.core.ConfigConsts;
 import com.ctrip.framework.apollo.spring.config.ConfigPropertySourceFactory;
 import com.ctrip.framework.apollo.spring.config.PropertySourcesConstants;
+import com.ctrip.framework.apollo.spring.util.SpringInjector;
 import com.google.common.base.Splitter;
 import java.util.List;
 import org.slf4j.Logger;
@@ -37,7 +38,7 @@ public class ApolloApplicationContextInitializer implements
   private static final Logger logger = LoggerFactory.getLogger(ApolloApplicationContextInitializer.class);
   private static final Splitter NAMESPACE_SPLITTER = Splitter.on(",").omitEmptyStrings().trimResults();
 
-  private final ConfigPropertySourceFactory configPropertySourceFactory = ApolloInjector
+  private final ConfigPropertySourceFactory configPropertySourceFactory = SpringInjector
       .getInstance(ConfigPropertySourceFactory.class);
 
   @Override

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/config/PropertySourcesProcessor.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/config/PropertySourcesProcessor.java
@@ -2,6 +2,7 @@ package com.ctrip.framework.apollo.spring.config;
 
 import com.ctrip.framework.apollo.build.ApolloInjector;
 import com.ctrip.framework.apollo.spring.property.AutoUpdateConfigChangeListener;
+import com.ctrip.framework.apollo.spring.util.SpringInjector;
 import com.ctrip.framework.apollo.util.ConfigUtil;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.LinkedHashMultimap;
@@ -39,7 +40,7 @@ public class PropertySourcesProcessor implements BeanFactoryPostProcessor, Envir
   private static final Multimap<Integer, String> NAMESPACE_NAMES = LinkedHashMultimap.create();
   private static final AtomicBoolean INITIALIZED = new AtomicBoolean(false);
 
-  private final ConfigPropertySourceFactory configPropertySourceFactory = ApolloInjector
+  private final ConfigPropertySourceFactory configPropertySourceFactory = SpringInjector
       .getInstance(ConfigPropertySourceFactory.class);
   private final ConfigUtil configUtil = ApolloInjector.getInstance(ConfigUtil.class);
   private ConfigurableEnvironment environment;

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/property/AutoUpdateConfigChangeListener.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/property/AutoUpdateConfigChangeListener.java
@@ -6,6 +6,7 @@ import com.ctrip.framework.apollo.enums.PropertyChangeType;
 import com.ctrip.framework.apollo.model.ConfigChange;
 import com.ctrip.framework.apollo.model.ConfigChangeEvent;
 import com.ctrip.framework.apollo.spring.annotation.SpringValueProcessor;
+import com.ctrip.framework.apollo.spring.util.SpringInjector;
 import com.google.gson.Gson;
 import java.lang.reflect.Field;
 import java.lang.reflect.Type;
@@ -39,8 +40,8 @@ public class AutoUpdateConfigChangeListener implements ConfigChangeListener{
     this.beanFactory = beanFactory;
     this.typeConverter = this.beanFactory.getTypeConverter();
     this.environment = environment;
-    this.placeholderHelper = ApolloInjector.getInstance(PlaceholderHelper.class);
-    this.springValueRegistry = ApolloInjector.getInstance(SpringValueRegistry.class);
+    this.placeholderHelper = SpringInjector.getInstance(PlaceholderHelper.class);
+    this.springValueRegistry = SpringInjector.getInstance(SpringValueRegistry.class);
     this.gson = new Gson();
   }
 

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/property/SpringValueDefinitionProcessor.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/property/SpringValueDefinitionProcessor.java
@@ -1,5 +1,6 @@
 package com.ctrip.framework.apollo.spring.property;
 
+import com.ctrip.framework.apollo.spring.util.SpringInjector;
 import java.util.List;
 import java.util.Set;
 
@@ -38,7 +39,7 @@ public class SpringValueDefinitionProcessor implements BeanDefinitionRegistryPos
 
   public SpringValueDefinitionProcessor() {
     configUtil = ApolloInjector.getInstance(ConfigUtil.class);
-    placeholderHelper = ApolloInjector.getInstance(PlaceholderHelper.class);
+    placeholderHelper = SpringInjector.getInstance(PlaceholderHelper.class);
   }
 
   @Override

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/util/SpringInjector.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/util/SpringInjector.java
@@ -1,0 +1,53 @@
+package com.ctrip.framework.apollo.spring.util;
+
+import com.ctrip.framework.apollo.exceptions.ApolloConfigException;
+import com.ctrip.framework.apollo.spring.config.ConfigPropertySourceFactory;
+import com.ctrip.framework.apollo.spring.property.PlaceholderHelper;
+import com.ctrip.framework.apollo.spring.property.SpringValueRegistry;
+import com.ctrip.framework.apollo.tracer.Tracer;
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Singleton;
+
+public class SpringInjector {
+  private static volatile Injector s_injector;
+  private static final Object lock = new Object();
+
+  private static Injector getInjector() {
+    if (s_injector == null) {
+      synchronized (lock) {
+        if (s_injector == null) {
+          try {
+            s_injector = Guice.createInjector(new SpringModule());
+          } catch (Throwable ex) {
+            ApolloConfigException exception = new ApolloConfigException("Unable to initialize Apollo Spring Injector!", ex);
+            Tracer.logError(exception);
+            throw exception;
+          }
+        }
+      }
+    }
+
+    return s_injector;
+  }
+
+  public static <T> T getInstance(Class<T> clazz) {
+    try {
+      return getInjector().getInstance(clazz);
+    } catch (Throwable ex) {
+      Tracer.logError(ex);
+      throw new ApolloConfigException(
+          String.format("Unable to load instance for %s!", clazz.getName()), ex);
+    }
+  }
+
+  private static class SpringModule extends AbstractModule {
+    @Override
+    protected void configure() {
+      bind(PlaceholderHelper.class).in(Singleton.class);
+      bind(ConfigPropertySourceFactory.class).in(Singleton.class);
+      bind(SpringValueRegistry.class).in(Singleton.class);
+    }
+  }
+}

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/spring/JavaConfigPlaceholderAutoUpdateTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/spring/JavaConfigPlaceholderAutoUpdateTest.java
@@ -65,7 +65,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
 
     config.onRepositoryChange(ConfigConsts.NAMESPACE_APPLICATION, newProperties);
 
-    TimeUnit.MILLISECONDS.sleep(50);
+    TimeUnit.MILLISECONDS.sleep(100);
 
     assertEquals(newTimeout, bean.getTimeout());
     assertEquals(newBatch, bean.getBatch());
@@ -98,7 +98,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
 
     config.onRepositoryChange(ConfigConsts.NAMESPACE_APPLICATION, newProperties);
 
-    TimeUnit.MILLISECONDS.sleep(50);
+    TimeUnit.MILLISECONDS.sleep(100);
 
     assertEquals(newTimeout, javaConfigBean.getTimeout());
     assertEquals(newBatch, javaConfigBean.getBatch());
@@ -135,7 +135,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
 
     config.onRepositoryChange(ConfigConsts.NAMESPACE_APPLICATION, newProperties);
 
-    TimeUnit.MILLISECONDS.sleep(50);
+    TimeUnit.MILLISECONDS.sleep(100);
 
     assertEquals(initialTimeout, bean.getTimeout());
     assertEquals(initialBatch, bean.getBatch());
@@ -165,7 +165,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
 
     applicationConfig.onRepositoryChange(ConfigConsts.NAMESPACE_APPLICATION, newApplicationProperties);
 
-    TimeUnit.MILLISECONDS.sleep(50);
+    TimeUnit.MILLISECONDS.sleep(100);
 
     assertEquals(newTimeout, bean.getTimeout());
     assertEquals(initialBatch, bean.getBatch());
@@ -174,7 +174,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
 
     fxApolloConfig.onRepositoryChange(FX_APOLLO_NAMESPACE, newFxApolloProperties);
 
-    TimeUnit.MILLISECONDS.sleep(50);
+    TimeUnit.MILLISECONDS.sleep(100);
 
     assertEquals(newTimeout, bean.getTimeout());
     assertEquals(newBatch, bean.getBatch());
@@ -192,7 +192,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
     Properties fxApolloProperties =
         assembleProperties(TIMEOUT_PROPERTY, String.valueOf(someTimeout), BATCH_PROPERTY, String.valueOf(anotherBatch));
 
-    SimpleConfig applicationConfig = prepareConfig(ConfigConsts.NAMESPACE_APPLICATION, applicationProperties);
+    prepareConfig(ConfigConsts.NAMESPACE_APPLICATION, applicationProperties);
     SimpleConfig fxApolloConfig = prepareConfig(FX_APOLLO_NAMESPACE, fxApolloProperties);
 
     AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(AppConfig2.class);
@@ -207,7 +207,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
 
     fxApolloConfig.onRepositoryChange(FX_APOLLO_NAMESPACE, newFxApolloProperties);
 
-    TimeUnit.MILLISECONDS.sleep(50);
+    TimeUnit.MILLISECONDS.sleep(100);
 
     assertEquals(someNewTimeout, bean.getTimeout());
     assertEquals(someBatch, bean.getBatch());
@@ -235,7 +235,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
 
     applicationConfig.onRepositoryChange(ConfigConsts.NAMESPACE_APPLICATION, newApplicationProperties);
 
-    TimeUnit.MILLISECONDS.sleep(50);
+    TimeUnit.MILLISECONDS.sleep(100);
 
     assertEquals(newTimeout, bean.getTimeout());
     assertEquals(newBatch, bean.getBatch());
@@ -268,7 +268,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
 
     applicationConfig.onRepositoryChange(ConfigConsts.NAMESPACE_APPLICATION, newApplicationProperties);
 
-    TimeUnit.MILLISECONDS.sleep(50);
+    TimeUnit.MILLISECONDS.sleep(100);
 
     assertEquals(initialTimeout, bean.getTimeout());
     assertEquals(DEFAULT_BATCH, bean.getBatch());
@@ -295,7 +295,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
 
     config.onRepositoryChange(ConfigConsts.NAMESPACE_APPLICATION, newProperties);
 
-    TimeUnit.MILLISECONDS.sleep(50);
+    TimeUnit.MILLISECONDS.sleep(100);
 
     assertEquals(DEFAULT_TIMEOUT, bean.getTimeout());
     assertEquals(DEFAULT_BATCH, bean.getBatch());
@@ -312,7 +312,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
         assembleProperties(TIMEOUT_PROPERTY, String.valueOf(someTimeout), BATCH_PROPERTY, String.valueOf(anotherBatch));
 
     SimpleConfig applicationConfig = prepareConfig(ConfigConsts.NAMESPACE_APPLICATION, applicationProperties);
-    SimpleConfig fxApolloConfig = prepareConfig(FX_APOLLO_NAMESPACE, fxApolloProperties);
+    prepareConfig(FX_APOLLO_NAMESPACE, fxApolloProperties);
 
     AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(AppConfig2.class);
 
@@ -325,7 +325,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
 
     applicationConfig.onRepositoryChange(ConfigConsts.NAMESPACE_APPLICATION, newProperties);
 
-    TimeUnit.MILLISECONDS.sleep(50);
+    TimeUnit.MILLISECONDS.sleep(100);
 
     assertEquals(someTimeout, bean.getTimeout());
     assertEquals(anotherBatch, bean.getBatch());
@@ -353,7 +353,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
 
     config.onRepositoryChange(ConfigConsts.NAMESPACE_APPLICATION, newProperties);
 
-    TimeUnit.MILLISECONDS.sleep(50);
+    TimeUnit.MILLISECONDS.sleep(100);
 
     assertEquals(newTimeout, bean.getTimeout());
     assertEquals(initialBatch, bean.getBatch());
@@ -383,7 +383,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
 
     config.onRepositoryChange(ConfigConsts.NAMESPACE_APPLICATION, newProperties);
 
-    TimeUnit.MILLISECONDS.sleep(50);
+    TimeUnit.MILLISECONDS.sleep(100);
 
     assertEquals(newTimeout, bean.getTimeout());
     assertEquals(initialBatch, bean.getBatch());
@@ -413,7 +413,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
 
     config.onRepositoryChange(ConfigConsts.NAMESPACE_APPLICATION, newProperties);
 
-    TimeUnit.MILLISECONDS.sleep(50);
+    TimeUnit.MILLISECONDS.sleep(100);
 
     // Does not support this scenario
     assertEquals(initialTimeout, bean.getTimeout());
@@ -444,7 +444,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
 
     config.onRepositoryChange(ConfigConsts.NAMESPACE_APPLICATION, newProperties);
 
-    TimeUnit.MILLISECONDS.sleep(50);
+    TimeUnit.MILLISECONDS.sleep(100);
 
     // Does not support this scenario
     assertEquals(initialTimeout, bean.getTimeout());
@@ -475,7 +475,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
 
     config.onRepositoryChange(ConfigConsts.NAMESPACE_APPLICATION, newProperties);
 
-    TimeUnit.MILLISECONDS.sleep(50);
+    TimeUnit.MILLISECONDS.sleep(100);
 
     // Does not support this scenario
     assertEquals(initialTimeout, bean.getTimeout());
@@ -506,7 +506,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
 
     config.onRepositoryChange(ConfigConsts.NAMESPACE_APPLICATION, newProperties);
 
-    TimeUnit.MILLISECONDS.sleep(50);
+    TimeUnit.MILLISECONDS.sleep(100);
 
     // Does not support this scenario
     assertEquals(initialTimeout, bean.getTimeout());
@@ -537,7 +537,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
 
     config.onRepositoryChange(ConfigConsts.NAMESPACE_APPLICATION, newProperties);
 
-    TimeUnit.MILLISECONDS.sleep(50);
+    TimeUnit.MILLISECONDS.sleep(100);
 
     assertEquals(someNewValue, bean.getNestedProperty());
   }
@@ -565,7 +565,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
 
     config.onRepositoryChange(ConfigConsts.NAMESPACE_APPLICATION, newProperties);
 
-    TimeUnit.MILLISECONDS.sleep(50);
+    TimeUnit.MILLISECONDS.sleep(100);
 
     // Does not support this scenario
     assertEquals(someValue, bean.getNestedProperty());
@@ -594,7 +594,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
 
     config.onRepositoryChange(ConfigConsts.NAMESPACE_APPLICATION, newProperties);
 
-    TimeUnit.MILLISECONDS.sleep(50);
+    TimeUnit.MILLISECONDS.sleep(100);
 
     assertEquals(someNewValue, bean.getNestedProperty());
   }
@@ -631,7 +631,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
 
     config.onRepositoryChange(ConfigConsts.NAMESPACE_APPLICATION, newProperties);
 
-    TimeUnit.MILLISECONDS.sleep(50);
+    TimeUnit.MILLISECONDS.sleep(100);
 
     assertEquals(someNewValue, bean.getNestedProperty());
   }
@@ -713,7 +713,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
 
     config.onRepositoryChange(ConfigConsts.NAMESPACE_APPLICATION, newProperties);
 
-    TimeUnit.MILLISECONDS.sleep(50);
+    TimeUnit.MILLISECONDS.sleep(100);
 
     assertEquals(someNewInt, bean.getIntProperty());
     assertArrayEquals(someNewIntArray, bean.getIntArrayProperty());
@@ -751,7 +751,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
 
     config.onRepositoryChange(ConfigConsts.NAMESPACE_APPLICATION, newProperties);
 
-    TimeUnit.MILLISECONDS.sleep(50);
+    TimeUnit.MILLISECONDS.sleep(100);
 
     // should not change anything
     assertTrue(jsonBean == bean.getJsonBean());
@@ -778,7 +778,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
 
     config.onRepositoryChange(ConfigConsts.NAMESPACE_APPLICATION, newProperties);
 
-    TimeUnit.MILLISECONDS.sleep(50);
+    TimeUnit.MILLISECONDS.sleep(100);
 
     // should not change anything
     assertTrue(jsonBean == bean.getJsonBean());
@@ -805,7 +805,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
 
     config.onRepositoryChange(ConfigConsts.NAMESPACE_APPLICATION, newProperties);
 
-    TimeUnit.MILLISECONDS.sleep(50);
+    TimeUnit.MILLISECONDS.sleep(100);
 
     JsonBean newJsonBean = bean.getJsonBean();
 

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/spring/XmlConfigPlaceholderAutoUpdateTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/spring/XmlConfigPlaceholderAutoUpdateTest.java
@@ -49,7 +49,7 @@ public class XmlConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegratio
 
     config.onRepositoryChange(ConfigConsts.NAMESPACE_APPLICATION, newProperties);
 
-    TimeUnit.MILLISECONDS.sleep(50);
+    TimeUnit.MILLISECONDS.sleep(100);
 
     assertEquals(newTimeout, bean.getTimeout());
     assertEquals(newBatch, bean.getBatch());
@@ -84,7 +84,7 @@ public class XmlConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegratio
 
     config.onRepositoryChange(ConfigConsts.NAMESPACE_APPLICATION, newProperties);
 
-    TimeUnit.MILLISECONDS.sleep(50);
+    TimeUnit.MILLISECONDS.sleep(100);
 
     assertEquals(initialTimeout, bean.getTimeout());
     assertEquals(initialBatch, bean.getBatch());
@@ -119,7 +119,7 @@ public class XmlConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegratio
     applicationConfig
         .onRepositoryChange(ConfigConsts.NAMESPACE_APPLICATION, newApplicationProperties);
 
-    TimeUnit.MILLISECONDS.sleep(50);
+    TimeUnit.MILLISECONDS.sleep(100);
 
     assertEquals(newTimeout, bean.getTimeout());
     assertEquals(initialBatch, bean.getBatch());
@@ -128,7 +128,7 @@ public class XmlConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegratio
 
     fxApolloConfig.onRepositoryChange(FX_APOLLO_NAMESPACE, newFxApolloProperties);
 
-    TimeUnit.MILLISECONDS.sleep(50);
+    TimeUnit.MILLISECONDS.sleep(100);
 
     assertEquals(newTimeout, bean.getTimeout());
     assertEquals(newBatch, bean.getBatch());
@@ -147,8 +147,7 @@ public class XmlConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegratio
     Properties fxApolloProperties = assembleProperties(TIMEOUT_PROPERTY,
         String.valueOf(someTimeout), BATCH_PROPERTY, String.valueOf(anotherBatch));
 
-    SimpleConfig applicationConfig = prepareConfig(ConfigConsts.NAMESPACE_APPLICATION,
-        applicationProperties);
+    prepareConfig(ConfigConsts.NAMESPACE_APPLICATION, applicationProperties);
     SimpleConfig fxApolloConfig = prepareConfig(FX_APOLLO_NAMESPACE, fxApolloProperties);
 
     ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("spring/XmlConfigPlaceholderTest3.xml");
@@ -163,7 +162,7 @@ public class XmlConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegratio
 
     fxApolloConfig.onRepositoryChange(FX_APOLLO_NAMESPACE, newFxApolloProperties);
 
-    TimeUnit.MILLISECONDS.sleep(50);
+    TimeUnit.MILLISECONDS.sleep(100);
 
     assertEquals(someNewTimeout, bean.getTimeout());
     assertEquals(someBatch, bean.getBatch());
@@ -194,7 +193,7 @@ public class XmlConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegratio
     applicationConfig
         .onRepositoryChange(ConfigConsts.NAMESPACE_APPLICATION, newApplicationProperties);
 
-    TimeUnit.MILLISECONDS.sleep(50);
+    TimeUnit.MILLISECONDS.sleep(100);
 
     assertEquals(newTimeout, bean.getTimeout());
     assertEquals(newBatch, bean.getBatch());
@@ -229,7 +228,7 @@ public class XmlConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegratio
     applicationConfig
         .onRepositoryChange(ConfigConsts.NAMESPACE_APPLICATION, newApplicationProperties);
 
-    TimeUnit.MILLISECONDS.sleep(50);
+    TimeUnit.MILLISECONDS.sleep(100);
 
     assertEquals(initialTimeout, bean.getTimeout());
     assertEquals(DEFAULT_BATCH, bean.getBatch());
@@ -256,7 +255,7 @@ public class XmlConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegratio
 
     config.onRepositoryChange(ConfigConsts.NAMESPACE_APPLICATION, newProperties);
 
-    TimeUnit.MILLISECONDS.sleep(50);
+    TimeUnit.MILLISECONDS.sleep(100);
 
     assertEquals(DEFAULT_TIMEOUT, bean.getTimeout());
     assertEquals(DEFAULT_BATCH, bean.getBatch());
@@ -275,7 +274,7 @@ public class XmlConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegratio
 
     SimpleConfig applicationConfig = prepareConfig(ConfigConsts.NAMESPACE_APPLICATION,
         applicationProperties);
-    SimpleConfig fxApolloConfig = prepareConfig(FX_APOLLO_NAMESPACE, fxApolloProperties);
+    prepareConfig(FX_APOLLO_NAMESPACE, fxApolloProperties);
 
     ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("spring/XmlConfigPlaceholderTest3.xml");
 
@@ -288,7 +287,7 @@ public class XmlConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegratio
 
     applicationConfig.onRepositoryChange(ConfigConsts.NAMESPACE_APPLICATION, newProperties);
 
-    TimeUnit.MILLISECONDS.sleep(50);
+    TimeUnit.MILLISECONDS.sleep(100);
 
     assertEquals(someTimeout, bean.getTimeout());
     assertEquals(anotherBatch, bean.getBatch());
@@ -316,7 +315,7 @@ public class XmlConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegratio
 
     config.onRepositoryChange(ConfigConsts.NAMESPACE_APPLICATION, newProperties);
 
-    TimeUnit.MILLISECONDS.sleep(50);
+    TimeUnit.MILLISECONDS.sleep(100);
 
     assertEquals(newTimeout, bean.getTimeout());
     assertEquals(initialBatch, bean.getBatch());
@@ -346,7 +345,7 @@ public class XmlConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegratio
 
     config.onRepositoryChange(ConfigConsts.NAMESPACE_APPLICATION, newProperties);
 
-    TimeUnit.MILLISECONDS.sleep(50);
+    TimeUnit.MILLISECONDS.sleep(100);
 
     assertEquals(newTimeout, bean.getTimeout());
     assertEquals(initialBatch, bean.getBatch());
@@ -376,7 +375,7 @@ public class XmlConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegratio
 
     config.onRepositoryChange(ConfigConsts.NAMESPACE_APPLICATION, newProperties);
 
-    TimeUnit.MILLISECONDS.sleep(50);
+    TimeUnit.MILLISECONDS.sleep(100);
 
     // Does not support this scenario
     assertEquals(initialTimeout, bean.getTimeout());
@@ -407,7 +406,7 @@ public class XmlConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegratio
 
     config.onRepositoryChange(ConfigConsts.NAMESPACE_APPLICATION, newProperties);
 
-    TimeUnit.MILLISECONDS.sleep(50);
+    TimeUnit.MILLISECONDS.sleep(100);
 
     assertEquals(newTimeout, bean.getTimeout());
     assertEquals(newBatch, bean.getBatch());
@@ -483,7 +482,7 @@ public class XmlConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegratio
 
     config.onRepositoryChange(ConfigConsts.NAMESPACE_APPLICATION, newProperties);
 
-    TimeUnit.MILLISECONDS.sleep(50);
+    TimeUnit.MILLISECONDS.sleep(100);
 
     assertEquals(someNewInt, bean.getIntProperty());
     assertArrayEquals(someNewIntArray, bean.getIntArrayProperty());

--- a/apollo-common/pom.xml
+++ b/apollo-common/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.ctrip.framework.apollo</groupId>
         <artifactId>apollo</artifactId>
-        <version>0.10.0</version>
+        <version>0.10.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/apollo-configservice/pom.xml
+++ b/apollo-configservice/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.ctrip.framework.apollo</groupId>
 		<artifactId>apollo</artifactId>
-		<version>0.10.0</version>
+		<version>0.10.1</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/apollo-configservice/src/main/docker/Dockerfile
+++ b/apollo-configservice/src/main/docker/Dockerfile
@@ -7,7 +7,7 @@
 FROM openjdk:8-jre-alpine
 MAINTAINER ameizi <sxyx2008@163.com>
 
-ENV VERSION 0.10.0
+ENV VERSION 0.10.1
 
 RUN echo "http://mirrors.aliyun.com/alpine/v3.6/main" > /etc/apk/repositories \
     && echo "http://mirrors.aliyun.com/alpine/v3.6/community" >> /etc/apk/repositories \

--- a/apollo-core/pom.xml
+++ b/apollo-core/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.ctrip.framework.apollo</groupId>
 		<artifactId>apollo</artifactId>
-		<version>0.10.0</version>
+		<version>0.10.1</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/apollo-demo/pom.xml
+++ b/apollo-demo/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>apollo</artifactId>
 		<groupId>com.ctrip.framework.apollo</groupId>
-		<version>0.10.0</version>
+		<version>0.10.1</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>apollo-demo</artifactId>

--- a/apollo-portal/pom.xml
+++ b/apollo-portal/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.ctrip.framework.apollo</groupId>
 		<artifactId>apollo</artifactId>
-		<version>0.10.0</version>
+		<version>0.10.1</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/apollo-portal/src/main/docker/Dockerfile
+++ b/apollo-portal/src/main/docker/Dockerfile
@@ -9,7 +9,7 @@
 FROM openjdk:8-jre-alpine
 MAINTAINER ameizi <sxyx2008@163.com>
 
-ENV VERSION 0.10.0
+ENV VERSION 0.10.1
 
 RUN echo "http://mirrors.aliyun.com/alpine/v3.6/main" > /etc/apk/repositories \
     && echo "http://mirrors.aliyun.com/alpine/v3.6/community" >> /etc/apk/repositories \

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>com.ctrip.framework.apollo</groupId>
 	<artifactId>apollo</artifactId>
-	<version>0.10.0</version>
+	<version>0.10.1</version>
 	<name>Apollo</name>
 	<packaging>pom</packaging>
 	<description>Ctrip Configuration Center</description>


### PR DESCRIPTION
which causes exceptions when there is no Spring libraries available.