### PR TITLE
优化Properties#stringPropertyNames处理，jdk9以下版本此方法cpu消耗相对过高.

### DIFF
--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/DefaultConfig.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/DefaultConfig.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
+import java.util.HashMap;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.slf4j.Logger;
@@ -101,7 +102,20 @@ public class DefaultConfig extends AbstractConfig implements RepositoryChangeLis
       return Collections.emptySet();
     }
 
-    return properties.stringPropertyNames();
+    return stringPropertyNames(properties);
+  }
+
+  private Set<String> stringPropertyNames(Properties properties) {
+    //jdk9以下版本Properties#enumerateStringProperties方法存在性能问题，keys() + get(k) 重复迭代, jdk9之后改为entrySet遍历.
+    Map<String, String> h = new HashMap<>();
+    for (Map.Entry<Object, Object> e : properties.entrySet()) {
+      Object k = e.getKey();
+      Object v = e.getValue();
+      if (k instanceof String && v instanceof String) {
+        h.put((String) k, (String) v);
+      }
+    }
+    return h.keySet();
   }
 
   @Override

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/internals/DefaultConfigTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/internals/DefaultConfigTest.java
@@ -11,6 +11,8 @@ import java.io.File;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Properties;
+import java.util.Set;
+import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.After;
@@ -643,6 +645,39 @@ public class DefaultConfigTest {
     assertEquals(null, newKeyChange.getOldValue());
     assertEquals(newValue, newKeyChange.getNewValue());
     assertEquals(PropertyChangeType.ADDED, newKeyChange.getChangeType());
+  }
+
+  @Test
+  public void testGetPropertyNames() {
+    String someKeyPrefix = "someKey";
+    String someValuePrefix = "someValue";
+
+    //set up config repo
+    someProperties = new Properties();
+    for (int i = 0; i < 10; i++) {
+      someProperties.setProperty(someKeyPrefix + i, someValuePrefix + i);
+    }
+
+    when(configRepository.getConfig()).thenReturn(someProperties);
+
+    DefaultConfig defaultConfig =
+            new DefaultConfig(someNamespace, configRepository);
+
+    Set<String> propertyNames = defaultConfig.getPropertyNames();
+
+    assertEquals(10, propertyNames.size());
+    assertEquals(someProperties.stringPropertyNames(), propertyNames);
+  }
+
+  @Test
+  public void testGetPropertyNamesWithNullProp() {
+    when(configRepository.getConfig()).thenReturn(null);
+
+    DefaultConfig defaultConfig =
+            new DefaultConfig(someNamespace, configRepository);
+
+    Set<String> propertyNames = defaultConfig.getPropertyNames();
+    assertEquals(Collections.emptySet(), propertyNames);
   }
 
   private void checkDatePropertyWithFormat(Config config, Date expected, String propertyName, String format, Date


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5037807/39290590-b4650474-4962-11e8-8575-9769dd85b7b0.png)

参考相关修改, http://hg.openjdk.java.net/jdk9/jdk9/jdk/rev/01a8615439f0#l2.164