### PR TITLE
增加localCacheDir本地缓存配置路径可配置项

### DIFF
--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/LocalFileConfigRepository.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/LocalFileConfigRepository.java
@@ -65,7 +65,7 @@ public class LocalFileConfigRepository extends AbstractConfigRepository
 
   private File findLocalCacheDir() {
     try {
-      String defaultCacheDir = m_configUtil.getDefaultLocalCacheDir();
+      String defaultCacheDir = m_configUtil.getLocalCacheDir();
       Path path = Paths.get(defaultCacheDir);
       if (!Files.exists(path)) {
         Files.createDirectories(path);

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/util/ConfigUtil.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/util/ConfigUtil.java
@@ -1,5 +1,6 @@
 package com.ctrip.framework.apollo.util;
 
+import java.io.File;
 import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
@@ -34,6 +35,7 @@ public class ConfigUtil {
   private TimeUnit configCacheExpireTimeUnit = TimeUnit.MINUTES;//1 minute
   private long longPollingInitialDelayInMills = 2000;//2 seconds
   private boolean autoUpdateInjectedSpringProperties = true;
+  private String localCacheDir = this.getDefaultLocalCacheDir();
 
   public ConfigUtil() {
     initRefreshInterval();
@@ -44,6 +46,7 @@ public class ConfigUtil {
     initMaxConfigCacheSize();
     initLongPollingInitialDelayInMills();
     initAutoUpdateInjectedSpringProperties();
+    initLocalCacheDir();
   }
 
   /**
@@ -205,9 +208,25 @@ public class ConfigUtil {
     return onErrorRetryIntervalTimeUnit;
   }
 
-  public String getDefaultLocalCacheDir() {
+  private String getDefaultLocalCacheDir() {
     String cacheRoot = isOSWindows() ? "C:\\opt\\data\\%s" : "/opt/data/%s";
     return String.format(cacheRoot, getAppId());
+  }
+
+  private void initLocalCacheDir() {
+    // 1. Get from System Property
+    String cacheRoot = System.getProperty("apollo.localCacheDir");
+    if (Strings.isNullOrEmpty(cacheRoot)) {
+      // 2. Get from app.properties
+      cacheRoot = Foundation.app().getProperty("apollo.localCacheDir", null);
+    }
+    if (!Strings.isNullOrEmpty(cacheRoot)) {
+      this.localCacheDir = String.format(cacheRoot + File.separator + "%s", getAppId());
+    }
+  }
+
+  public String getLocalCacheDir() {
+    return this.localCacheDir;
   }
 
   public boolean isInLocalMode() {

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/BaseIntegrationTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/BaseIntegrationTest.java
@@ -178,7 +178,7 @@ public abstract class BaseIntegrationTest{
     }
 
     @Override
-    public String getDefaultLocalCacheDir() {
+    public String getLocalCacheDir() {
       return ClassLoaderUtil.getClassPath();
     }
 


### PR DESCRIPTION
默认的本地缓存目录在公司的所有线上机器都不存在，而且没有权限，需要运维在所有机器上都增加一个/opt/data目录，并且设置为work权限，运维工作量比较大，增加一个可以配置设置本地缓存的配置项，可以在本地app.properties中配置