### PR TITLE
externalize application-github.properties and apollo-env.properties

### DIFF
--- a/apollo-adminservice/src/assembly/assembly-descriptor.xml
+++ b/apollo-adminservice/src/assembly/assembly-descriptor.xml
@@ -23,6 +23,7 @@
 			<outputDirectory>config</outputDirectory>
 			<excludes>
 				<exclude>apollo-adminservice.conf</exclude>
+				<exclude>application-github.properties</exclude>
 			</excludes>
 			<lineEnding>unix</lineEnding>
 		</fileSet>
@@ -33,6 +34,13 @@
 				<include>apollo-adminservice.conf</include>
 			</includes>
 			<lineEnding>unix</lineEnding>
+		</fileSet>
+		<fileSet>
+			<directory>target/classes</directory>
+			<outputDirectory>/config</outputDirectory>
+			<includes>
+				<include>application-github.properties</include>
+			</includes>
 		</fileSet>
 		<!--artifact -->
 		<fileSet>

--- a/apollo-adminservice/src/main/config/application-github.properties
+++ b/apollo-adminservice/src/main/config/application-github.properties
@@ -1,0 +1,4 @@
+# DataSource
+spring.datasource.url = ${spring_datasource_url}
+spring.datasource.username = ${spring_datasource_username}
+spring.datasource.password = ${spring_datasource_password}

--- a/apollo-configservice/src/assembly/assembly-descriptor.xml
+++ b/apollo-configservice/src/assembly/assembly-descriptor.xml
@@ -23,6 +23,7 @@
 			<outputDirectory>config</outputDirectory>
 			<excludes>
 				<exclude>apollo-configservice.conf</exclude>
+				<exclude>application-github.properties</exclude>
 			</excludes>
 			<lineEnding>unix</lineEnding>
 		</fileSet>
@@ -33,6 +34,13 @@
 				<include>apollo-configservice.conf</include>
 			</includes>
 			<lineEnding>unix</lineEnding>
+		</fileSet>
+		<fileSet>
+			<directory>target/classes</directory>
+			<outputDirectory>/config</outputDirectory>
+			<includes>
+				<include>application-github.properties</include>
+			</includes>
 		</fileSet>
 		<!--artifact -->
 		<fileSet>

--- a/apollo-configservice/src/main/config/application-github.properties
+++ b/apollo-configservice/src/main/config/application-github.properties
@@ -1,0 +1,4 @@
+# DataSource
+spring.datasource.url = ${spring_datasource_url}
+spring.datasource.username = ${spring_datasource_username}
+spring.datasource.password = ${spring_datasource_password}

--- a/apollo-demo/src/main/java/com/ctrip/framework/apollo/demo/api/SimpleApolloConfigDemo.java
+++ b/apollo-demo/src/main/java/com/ctrip/framework/apollo/demo/api/SimpleApolloConfigDemo.java
@@ -27,6 +27,9 @@ public class SimpleApolloConfigDemo {
     ConfigChangeListener changeListener = new ConfigChangeListener() {
       @Override
       public void onChange(ConfigChangeEvent changeEvent) {
+        if (!changeEvent.isChanged("someKey")) {
+          return;
+        }
         logger.info("Changes for namespace {}", changeEvent.getNamespace());
         for (String key : changeEvent.changedKeys()) {
           ConfigChange change = changeEvent.getChange(key);

--- a/apollo-demo/src/main/java/com/ctrip/framework/apollo/demo/spring/springBootDemo/refresh/SpringBootApolloRefreshConfig.java
+++ b/apollo-demo/src/main/java/com/ctrip/framework/apollo/demo/spring/springBootDemo/refresh/SpringBootApolloRefreshConfig.java
@@ -29,6 +29,7 @@ public class SpringBootApolloRefreshConfig {
   public void onChange(ConfigChangeEvent changeEvent) {
     boolean redisCacheKeysChanged = false;
     for (String changedKey : changeEvent.changedKeys()) {
+      if (changeEvent.isChanged("someKey"))
       if (changedKey.startsWith("redis.cache")) {
         redisCacheKeysChanged = true;
         break;

--- a/apollo-portal/src/assembly/assembly-descriptor.xml
+++ b/apollo-portal/src/assembly/assembly-descriptor.xml
@@ -21,9 +21,9 @@
 		<fileSet>
 			<directory>src/main/config</directory>
 			<outputDirectory>config</outputDirectory>
-			<excludes>
-				<exclude>apollo-portal.conf</exclude>
-			</excludes>
+			<includes>
+				<include>app.properties</include>
+			</includes>
 			<lineEnding>unix</lineEnding>
 		</fileSet>
 		<fileSet>
@@ -33,6 +33,14 @@
 				<include>apollo-portal.conf</include>
 			</includes>
 			<lineEnding>unix</lineEnding>
+		</fileSet>
+		<fileSet>
+			<directory>target/classes</directory>
+			<outputDirectory>/config</outputDirectory>
+			<includes>
+				<include>application-github.properties</include>
+				<include>apollo-env.properties</include>
+			</includes>
 		</fileSet>
 		<!--artifact -->
 		<fileSet>

--- a/apollo-portal/src/main/config/apollo-env.properties
+++ b/apollo-portal/src/main/config/apollo-env.properties
@@ -1,0 +1,6 @@
+local.meta=http://localhost:8080
+dev.meta=${dev_meta}
+fat.meta=${fat_meta}
+uat.meta=${uat_meta}
+lpt.meta=${lpt_meta}
+pro.meta=${pro_meta}

--- a/apollo-portal/src/main/config/application-github.properties
+++ b/apollo-portal/src/main/config/application-github.properties
@@ -1,0 +1,4 @@
+# DataSource
+spring.datasource.url = ${spring_datasource_url}
+spring.datasource.username = ${spring_datasource_username}
+spring.datasource.password = ${spring_datasource_password}

--- a/apollo-portal/src/main/scripts/startup.sh
+++ b/apollo-portal/src/main/scripts/startup.sh
@@ -3,7 +3,7 @@ SERVICE_NAME=apollo-portal
 ## Adjust log dir if necessary
 LOG_DIR=/opt/logs/100003173
 ## Adjust server port if necessary
-SERVER_PORT=8080
+SERVER_PORT=8070
 
 ## Adjust memory settings if necessary
 #export JAVA_OPTS="-Xms2560m -Xmx2560m -Xss256k -XX:MetaspaceSize=128m -XX:MaxMetaspaceSize=384m -XX:NewSize=1536m -XX:MaxNewSize=1536m -XX:SurvivorRatio=8"

--- a/pom.xml
+++ b/pom.xml
@@ -526,6 +526,22 @@
 					<exclude>**/*.xml</exclude>
 				</excludes>
 			</resource>
+			<resource>
+				<directory>src/main/config</directory>
+				<filtering>true</filtering>
+				<includes>
+					<include>application-github.properties</include>
+					<include>apollo-env.properties</include>
+				</includes>
+			</resource>
+			<resource>
+				<directory>src/main/config</directory>
+				<filtering>false</filtering>
+				<excludes>
+					<exclude>application-github.properties</exclude>
+					<exclude>apollo-env.properties</exclude>
+				</excludes>
+			</resource>
 		</resources>
 	</build>
 	<profiles>

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,20 +1,20 @@
 #!/bin/sh
 
 # apollo config db info
-apollo_config_db_url=jdbc:mysql://localhost:3306/ApolloConfigDB?characterEncoding=utf8
-apollo_config_db_username=root
-apollo_config_db_password=
+apollo_config_db_url=jdbc:mysql://fill-in-the-correct-server:3306/ApolloConfigDB?characterEncoding=utf8
+apollo_config_db_username=FillInCorrectUser
+apollo_config_db_password=FillInCorrectPassword
 
 # apollo portal db info
-apollo_portal_db_url=jdbc:mysql://localhost:3306/ApolloPortalDB?characterEncoding=utf8
-apollo_portal_db_username=root
-apollo_portal_db_password=
+apollo_portal_db_url=jdbc:mysql://fill-in-the-correct-server:3306/ApolloPortalDB?characterEncoding=utf8
+apollo_portal_db_username=FillInCorrectUser
+apollo_portal_db_password=FillInCorrectPassword
 
 # meta server url, different environments should have different meta server addresses
-dev_meta=http://localhost:8080
-fat_meta=http://someIp:8080
-uat_meta=http://anotherIp:8080
-pro_meta=http://yetAnotherIp:8080
+dev_meta=http://fill-in-dev-meta-server:8080
+fat_meta=http://fill-in-fat-meta-server:8080
+uat_meta=http://fill-in-uat-meta-server:8080
+pro_meta=http://fill-in-pro-meta-server:8080
 
 META_SERVERS_OPTS="-Ddev_meta=$dev_meta -Dfat_meta=$fat_meta -Duat_meta=$uat_meta -Dpro_meta=$pro_meta"
 


### PR DESCRIPTION
By externalizing application-github.properties and apollo-env.properties, we could upload apollo-configservice, apollo-adminservice and apollo-portal installation files with releases.

So our users don't need to package them locally anymore, instead they could simply download them from our releases, do some simple configuration, and start apollo services easily!