### PR TITLE
fix load remote config repo by wrong namespace

### DIFF
--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/DefaultConfigManager.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/DefaultConfigManager.java
@@ -55,7 +55,7 @@ public class DefaultConfigManager implements ConfigManager {
         if (configFile == null) {
           ConfigFactory factory = m_factoryManager.getFactory(namespaceFileName);
 
-          configFile = factory.createConfigFile(namespaceFileName, configFileFormat);
+          configFile = factory.createConfigFile(namespace, configFileFormat);
           m_configFiles.put(namespaceFileName, configFile);
         }
       }


### PR DESCRIPTION
case:
`
Config xmlConfigFile = ConfigService.getConfigFile("application", ConfigFileFormat.XML);
// will load namespace “application.xml” instead of "application"
`