### PR TITLE
support setting apollo system properties via application.properties

### DIFF
--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/boot/ApolloApplicationContextInitializer.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/boot/ApolloApplicationContextInitializer.java
@@ -7,6 +7,7 @@ import com.ctrip.framework.apollo.spring.config.ConfigPropertySourceFactory;
 import com.ctrip.framework.apollo.spring.config.PropertySourcesConstants;
 import com.ctrip.framework.apollo.spring.util.SpringInjector;
 import com.google.common.base.Splitter;
+import com.google.common.base.Strings;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,17 +17,22 @@ import org.springframework.core.env.CompositePropertySource;
 import org.springframework.core.env.ConfigurableEnvironment;
 
 /**
- * Inject the Apollo config in Spring Boot bootstrap phase
+ * Initialize apollo system properties and inject the Apollo config in Spring Boot bootstrap phase
  *
  * <p>Configuration example:</p>
  * <pre class="code">
- *   # will inject 'application' namespace in bootstrap phase
+ *   # set app.id
+ *   app.id = 100004458
+ *   # enable apollo bootstrap config and inject 'application' namespace in bootstrap phase
  *   apollo.bootstrap.enabled = true
  * </pre>
  *
  * or
  *
  * <pre class="code">
+ *   # set app.id
+ *   app.id = 100004458
+ *   # enable apollo bootstrap config
  *   apollo.bootstrap.enabled = true
  *   # will inject 'application' and 'FX.apollo' namespaces in bootstrap phase
  *   apollo.bootstrap.namespaces = application,FX.apollo
@@ -36,6 +42,8 @@ public class ApolloApplicationContextInitializer implements
     ApplicationContextInitializer<ConfigurableApplicationContext> {
   private static final Logger logger = LoggerFactory.getLogger(ApolloApplicationContextInitializer.class);
   private static final Splitter NAMESPACE_SPLITTER = Splitter.on(",").omitEmptyStrings().trimResults();
+  private static final String[] APOLLO_SYSTEM_PROPERTIES = {"app.id", ConfigConsts.APOLLO_CLUSTER_KEY,
+      "apollo.cacheDir", ConfigConsts.APOLLO_META_KEY};
 
   private final ConfigPropertySourceFactory configPropertySourceFactory = SpringInjector
       .getInstance(ConfigPropertySourceFactory.class);
@@ -43,6 +51,9 @@ public class ApolloApplicationContextInitializer implements
   @Override
   public void initialize(ConfigurableApplicationContext context) {
     ConfigurableEnvironment environment = context.getEnvironment();
+
+    initializeSystemProperty(environment);
+
     String enabled = environment.getProperty(PropertySourcesConstants.APOLLO_BOOTSTRAP_ENABLED, "false");
     if (!Boolean.valueOf(enabled)) {
       logger.debug("Apollo bootstrap config is not enabled for context {}, see property: ${{}}", context, PropertySourcesConstants.APOLLO_BOOTSTRAP_ENABLED);
@@ -67,5 +78,28 @@ public class ApolloApplicationContextInitializer implements
     }
 
     environment.getPropertySources().addFirst(composite);
+  }
+
+  /**
+   * To fill system properties from environment config
+   */
+  void initializeSystemProperty(ConfigurableEnvironment environment) {
+    for (String propertyName : APOLLO_SYSTEM_PROPERTIES) {
+      fillSystemPropertyFromEnvironment(environment, propertyName);
+    }
+  }
+
+  private void fillSystemPropertyFromEnvironment(ConfigurableEnvironment environment, String propertyName) {
+    if (System.getProperty(propertyName) != null) {
+      return;
+    }
+
+    String propertyValue = environment.getProperty(propertyName);
+
+    if (Strings.isNullOrEmpty(propertyValue)) {
+      return;
+    }
+
+    System.setProperty(propertyName, propertyValue);
   }
 }

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/spring/boot/ApolloApplicationContextInitializerTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/spring/boot/ApolloApplicationContextInitializerTest.java
@@ -1,0 +1,95 @@
+package com.ctrip.framework.apollo.spring.boot;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.ctrip.framework.apollo.core.ConfigConsts;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.core.env.ConfigurableEnvironment;
+
+public class ApolloApplicationContextInitializerTest {
+
+  private ApolloApplicationContextInitializer apolloApplicationContextInitializer;
+
+  @Before
+  public void setUp() throws Exception {
+    apolloApplicationContextInitializer = new ApolloApplicationContextInitializer();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    System.clearProperty("app.id");
+    System.clearProperty(ConfigConsts.APOLLO_CLUSTER_KEY);
+    System.clearProperty("apollo.cacheDir");
+    System.clearProperty(ConfigConsts.APOLLO_META_KEY);
+  }
+
+  @Test
+  public void testFillFromEnvironment() throws Exception {
+    String someAppId = "someAppId";
+    String someCluster = "someCluster";
+    String someCacheDir = "someCacheDir";
+    String someApolloMeta = "someApolloMeta";
+
+    ConfigurableEnvironment environment = mock(ConfigurableEnvironment.class);
+
+    when(environment.getProperty("app.id")).thenReturn(someAppId);
+    when(environment.getProperty(ConfigConsts.APOLLO_CLUSTER_KEY)).thenReturn(someCluster);
+    when(environment.getProperty("apollo.cacheDir")).thenReturn(someCacheDir);
+    when(environment.getProperty(ConfigConsts.APOLLO_META_KEY)).thenReturn(someApolloMeta);
+
+    apolloApplicationContextInitializer.initializeSystemProperty(environment);
+
+    assertEquals(someAppId, System.getProperty("app.id"));
+    assertEquals(someCluster, System.getProperty(ConfigConsts.APOLLO_CLUSTER_KEY));
+    assertEquals(someCacheDir, System.getProperty("apollo.cacheDir"));
+    assertEquals(someApolloMeta, System.getProperty(ConfigConsts.APOLLO_META_KEY));
+  }
+
+  @Test
+  public void testFillFromEnvironmentWithSystemPropertyAlreadyFilled() throws Exception {
+    String someAppId = "someAppId";
+    String someCluster = "someCluster";
+    String someCacheDir = "someCacheDir";
+    String someApolloMeta = "someApolloMeta";
+
+    System.setProperty("app.id", someAppId);
+    System.setProperty(ConfigConsts.APOLLO_CLUSTER_KEY, someCluster);
+    System.setProperty("apollo.cacheDir", someCacheDir);
+    System.setProperty(ConfigConsts.APOLLO_META_KEY, someApolloMeta);
+
+    String anotherAppId = "anotherAppId";
+    String anotherCluster = "anotherCluster";
+    String anotherCacheDir = "anotherCacheDir";
+    String anotherApolloMeta = "anotherApolloMeta";
+
+    ConfigurableEnvironment environment = mock(ConfigurableEnvironment.class);
+
+    when(environment.getProperty("app.id")).thenReturn(anotherAppId);
+    when(environment.getProperty(ConfigConsts.APOLLO_CLUSTER_KEY)).thenReturn(anotherCluster);
+    when(environment.getProperty("apollo.cacheDir")).thenReturn(anotherCacheDir);
+    when(environment.getProperty(ConfigConsts.APOLLO_META_KEY)).thenReturn(anotherApolloMeta);
+
+    apolloApplicationContextInitializer.initializeSystemProperty(environment);
+
+    assertEquals(someAppId, System.getProperty("app.id"));
+    assertEquals(someCluster, System.getProperty(ConfigConsts.APOLLO_CLUSTER_KEY));
+    assertEquals(someCacheDir, System.getProperty("apollo.cacheDir"));
+    assertEquals(someApolloMeta, System.getProperty(ConfigConsts.APOLLO_META_KEY));
+  }
+
+  @Test
+  public void testFillFromEnvironmentWithNoPropertyFromEnvironment() throws Exception {
+    ConfigurableEnvironment environment = mock(ConfigurableEnvironment.class);
+
+    apolloApplicationContextInitializer.initializeSystemProperty(environment);
+
+    assertNull(System.getProperty("app.id"));
+    assertNull(System.getProperty(ConfigConsts.APOLLO_CLUSTER_KEY));
+    assertNull(System.getProperty("apollo.cacheDir"));
+    assertNull(System.getProperty(ConfigConsts.APOLLO_META_KEY));
+  }
+}

--- a/apollo-core/src/main/java/com/ctrip/framework/foundation/internals/provider/DefaultApplicationProvider.java
+++ b/apollo-core/src/main/java/com/ctrip/framework/foundation/internals/provider/DefaultApplicationProvider.java
@@ -28,9 +28,6 @@ public class DefaultApplicationProvider implements ApplicationProvider {
         in = DefaultApplicationProvider.class.getResourceAsStream(APP_PROPERTIES_CLASSPATH);
       }
 
-      if (in == null) {
-        logger.warn("{} not found from classpath!", APP_PROPERTIES_CLASSPATH);
-      }
       initialize(in);
     } catch (Throwable ex) {
       logger.error("Initialize DefaultApplicationProvider failed.", ex);


### PR DESCRIPTION
support setting apollo.meta, app.id, apollo.cacheDir and apollo.cluster from spring boot configuration files, e.g. application.properties, bootstrap.properties, etc