### PR TITLE
allow public namespaces created with no org prefix

### DIFF
--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/controller/NamespaceController.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/controller/NamespaceController.java
@@ -161,16 +161,18 @@ public class NamespaceController {
 
   @PreAuthorize(value = "@permissionValidator.hasCreateAppNamespacePermission(#appId, #appNamespace)")
   @RequestMapping(value = "/apps/{appId}/appnamespaces", method = RequestMethod.POST)
-  public AppNamespace createAppNamespace(@PathVariable String appId, @RequestBody AppNamespace appNamespace) {
+  public AppNamespace createAppNamespace(@PathVariable String appId,
+      @RequestParam(defaultValue = "true") boolean appendNamespacePrefix,
+      @RequestBody AppNamespace appNamespace) {
 
     RequestPrecondition.checkArgumentsNotEmpty(appNamespace.getAppId(), appNamespace.getName());
     if (!InputValidator.isValidAppNamespace(appNamespace.getName())) {
       throw new BadRequestException(String.format("Namespace格式错误: %s",
-              InputValidator.INVALID_CLUSTER_NAMESPACE_MESSAGE + " & "
-                      + InputValidator.INVALID_NAMESPACE_NAMESPACE_MESSAGE));
+          InputValidator.INVALID_CLUSTER_NAMESPACE_MESSAGE + " & "
+              + InputValidator.INVALID_NAMESPACE_NAMESPACE_MESSAGE));
     }
 
-    AppNamespace createdAppNamespace = appNamespaceService.createAppNamespaceInLocal(appNamespace);
+    AppNamespace createdAppNamespace = appNamespaceService.createAppNamespaceInLocal(appNamespace, appendNamespacePrefix);
 
     if (portalConfig.canAppAdminCreatePrivateNamespace() || createdAppNamespace.isPublic()) {
       assignNamespaceRoleToOperator(appId, appNamespace.getName());

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/repository/AppNamespaceRepository.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/repository/AppNamespaceRepository.java
@@ -12,7 +12,7 @@ public interface AppNamespaceRepository extends PagingAndSortingRepository<AppNa
 
   AppNamespace findByName(String namespaceName);
 
-  AppNamespace findByNameAndIsPublic(String namespaceName, boolean isPublic);
+  List<AppNamespace> findByNameAndIsPublic(String namespaceName, boolean isPublic);
 
   List<AppNamespace> findByIsPublicTrue();
 

--- a/apollo-portal/src/main/resources/static/namespace.html
+++ b/apollo-portal/src/main/resources/static/namespace.html
@@ -95,9 +95,9 @@
                             <label class="col-sm-3 control-label">
                                 <apollorequiredfield></apollorequiredfield>
                                 名称</label>
-                            <div class="col-sm-4" valdr-form-group>
-                                <div ng-class="{'input-group':appNamespace.isPublic}">
-                                    <span class="input-group-addon" ng-show="appNamespace.isPublic"
+                            <div class="col-sm-5" valdr-form-group>
+                                <div ng-class="{'input-group':appNamespace.isPublic && appendNamespacePrefix}">
+                                    <span class="input-group-addon" ng-show="appNamespace.isPublic && appendNamespacePrefix"
                                           ng-bind="appBaseInfo.namespacePrefix"></span>
                                     <input type="text" name="namespaceName" class="form-control"
                                            ng-model="appNamespace.name">
@@ -116,9 +116,25 @@
                             </div>
 
                             &nbsp;&nbsp;
-                            <span ng-show="appNamespace.isPublic" ng-bind="concatNamespace()"
+                            <span ng-show="appNamespace.isPublic && appendNamespacePrefix" ng-bind="concatNamespace()"
                                   style="line-height: 34px;"></span>
                         </div>
+
+                        <div class="form-group" ng-show="type == 'create' && appNamespace.isPublic">
+                            <label class="col-sm-3 control-label">
+                                自动添加部门前缀
+                            </label>
+                            <div class="col-sm-6" valdr-form-group>
+                                <div>
+                                    <label class="checkbox-inline">
+                                        <input type="checkbox" ng-model="appendNamespacePrefix" />
+                                        {{appBaseInfo.namespacePrefix}}
+                                    </label>
+                                </div>
+                                <small>(公共Namespace的名称需要全局唯一，添加部门前缀有助于保证全局唯一性)</small>
+                            </div>
+                        </div>
+
                         <div class="form-group" ng-show="type == 'create' && (pageSetting.canAppAdminCreatePrivateNamespace || hasRootPermission)">
                             <label class="col-sm-3 control-label">
                                 <apollorequiredfield></apollorequiredfield>

--- a/apollo-portal/src/main/resources/static/scripts/controller/NamespaceController.js
+++ b/apollo-portal/src/main/resources/static/scripts/controller/NamespaceController.js
@@ -11,6 +11,7 @@ namespace_module.controller("LinkNamespaceController",
                                  $scope.step = 1;
 
                                  $scope.submitBtnDisabled = false;
+                                 $scope.appendNamespacePrefix = true;
 
                                  PermissionService.has_root_permission().then(function (result) {
                                      $scope.hasRootPermission = result.hasPermission;
@@ -125,7 +126,9 @@ namespace_module.controller("LinkNamespaceController",
                                          }
 
                                          $scope.submitBtnDisabled = true;
-                                         NamespaceService.createAppNamespace($scope.appId, $scope.appNamespace).then(
+                                         //only append namespace prefix for public app namespace
+                                         var appendNamespacePrefix = $scope.appNamespace.isPublic ? $scope.appendNamespacePrefix : false;
+                                         NamespaceService.createAppNamespace($scope.appId, $scope.appNamespace, appendNamespacePrefix).then(
                                              function (result) {
                                                  $scope.step = 2;
                                                  setTimeout(function () {

--- a/apollo-portal/src/main/resources/static/scripts/services/NamespaceService.js
+++ b/apollo-portal/src/main/resources/static/scripts/services/NamespaceService.js
@@ -12,7 +12,7 @@ appService.service("NamespaceService", ['$resource', '$q', function ($resource, 
         },
         createAppNamespace: {
             method: 'POST',
-            url: '/apps/:appId/appnamespaces',
+            url: '/apps/:appId/appnamespaces?appendNamespacePrefix=:appendNamespacePrefix',
             isArray: false
         },
         getNamespacePublishInfo: {
@@ -60,11 +60,12 @@ appService.service("NamespaceService", ['$resource', '$q', function ($resource, 
         return d.promise;
     }
 
-    function createAppNamespace(appId, appnamespace) {
+    function createAppNamespace(appId, appnamespace, appendNamespacePrefix) {
         var d = $q.defer();
         namespace_source.createAppNamespace({
-                                                appId: appId
-                                            }, appnamespace, function (result) {
+            appId: appId,
+            appendNamespacePrefix: appendNamespacePrefix
+          }, appnamespace, function (result) {
             d.resolve(result);
         }, function (result) {
             d.reject(result);

--- a/apollo-portal/src/test/java/com/ctrip/framework/apollo/portal/service/AppNamespaceServiceTest.java
+++ b/apollo-portal/src/test/java/com/ctrip/framework/apollo/portal/service/AppNamespaceServiceTest.java
@@ -79,6 +79,31 @@ public class AppNamespaceServiceTest extends AbstractIntegrationTest {
   @Test
   @Sql(scripts = "/sql/appnamespaceservice/init-appnamespace.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
   @Sql(scripts = "/sql/cleanup.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
+  public void testCreatePublicAppNamespaceNotExistedWithNoAppendnamespacePrefix() {
+    AppNamespace appNamespace = assmbleBaseAppNamespace();
+    appNamespace.setPublic(true);
+    appNamespace.setName("old");
+
+    AppNamespace createdAppNamespace = appNamespaceService.createAppNamespaceInLocal(appNamespace, false);
+
+    Assert.assertNotNull(createdAppNamespace);
+    Assert.assertEquals(appNamespace.getName(), createdAppNamespace.getName());
+  }
+
+  @Test(expected = BadRequestException.class)
+  @Sql(scripts = "/sql/appnamespaceservice/init-appnamespace.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+  @Sql(scripts = "/sql/cleanup.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
+  public void testCreatePublicAppNamespaceExistedWithNoAppendnamespacePrefix() {
+    AppNamespace appNamespace = assmbleBaseAppNamespace();
+    appNamespace.setPublic(true);
+    appNamespace.setName("datasource");
+
+    appNamespaceService.createAppNamespaceInLocal(appNamespace, false);
+  }
+
+  @Test
+  @Sql(scripts = "/sql/appnamespaceservice/init-appnamespace.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+  @Sql(scripts = "/sql/cleanup.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
   public void testCreatePublicAppNamespaceNotExisted() {
     AppNamespace appNamespace = assmbleBaseAppNamespace();
     appNamespace.setPublic(true);


### PR DESCRIPTION
# Purpose

To allow the user create public namespaces with no org prefix

# Brief changes

1. Added a `append org prefix checkbox` in the namespace creation page
2. Will check public namespace name **_global_** uniqueness before creation
    * global uniqueness means the name is not used as any public namespace as well as any private namespace

# Effect

#### 1. when `append org prefix checkbox` is checked (default behavior)

![image](https://user-images.githubusercontent.com/837658/45437251-0c9b3900-b6e7-11e8-9ccf-0bd6d809d9e3.png)

#### 2. when `append org prefix checkbox` is unchecked

![image](https://user-images.githubusercontent.com/837658/45437180-f42b1e80-b6e6-11e8-9fb1-7da3761fa877.png)

