### PR TITLE
Support displaying configs only to team members

### DIFF
--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/component/config/PortalConfig.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/component/config/PortalConfig.java
@@ -74,6 +74,18 @@ public class PortalConfig extends RefreshableConfig {
     return result;
   }
 
+  public boolean isConfigViewMemberOnly(String env) {
+    String[] configViewMemberOnlyEnvs = getArrayProperty("configView.memberOnly.envs", new String[0]);
+
+    for (String memberOnlyEnv : configViewMemberOnlyEnvs) {
+      if (memberOnlyEnv.equalsIgnoreCase(env)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
   /***
    * Level: normal
    **/

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/controller/CommitController.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/controller/CommitController.java
@@ -3,8 +3,10 @@ package com.ctrip.framework.apollo.portal.controller;
 import com.ctrip.framework.apollo.common.dto.CommitDTO;
 import com.ctrip.framework.apollo.common.utils.RequestPrecondition;
 import com.ctrip.framework.apollo.core.enums.Env;
+import com.ctrip.framework.apollo.portal.component.PermissionValidator;
 import com.ctrip.framework.apollo.portal.service.CommitService;
 
+import java.util.Collections;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,10 +23,16 @@ public class CommitController {
   @Autowired
   private CommitService commitService;
 
+  @Autowired
+  private PermissionValidator permissionValidator;
+
   @RequestMapping(value = "/apps/{appId}/envs/{env}/clusters/{clusterName}/namespaces/{namespaceName}/commits", method = RequestMethod.GET)
   public List<CommitDTO> find(@PathVariable String appId, @PathVariable String env,
                               @PathVariable String clusterName, @PathVariable String namespaceName,
                               @RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "10") int size) {
+    if (permissionValidator.shouldHideConfigToCurrentUser(appId, env, namespaceName)) {
+      return Collections.emptyList();
+    }
 
     RequestPrecondition.checkNumberPositive(size);
     RequestPrecondition.checkNumberNotNegative(page);

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/controller/NamespaceBranchController.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/controller/NamespaceBranchController.java
@@ -43,7 +43,13 @@ public class NamespaceBranchController {
                                 @PathVariable String env,
                                 @PathVariable String clusterName,
                                 @PathVariable String namespaceName) {
-    return namespaceBranchService.findBranch(appId, Env.valueOf(env), clusterName, namespaceName);
+    NamespaceBO namespaceBO = namespaceBranchService.findBranch(appId, Env.valueOf(env), clusterName, namespaceName);
+
+    if (namespaceBO != null && permissionValidator.shouldHideConfigToCurrentUser(appId, env, namespaceName)) {
+      namespaceBO.hideItems();
+    }
+
+    return namespaceBO;
   }
 
   @PreAuthorize(value = "@permissionValidator.hasModifyNamespacePermission(#appId, #namespaceName, #env)")

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/controller/ReleaseController.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/controller/ReleaseController.java
@@ -13,6 +13,7 @@ import com.ctrip.framework.apollo.portal.entity.bo.ReleaseBO;
 import com.ctrip.framework.apollo.portal.listener.ConfigPublishEvent;
 import com.ctrip.framework.apollo.portal.service.ReleaseService;
 
+import java.util.Collections;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.access.AccessDeniedException;
@@ -113,6 +114,9 @@ public class ReleaseController {
                                          @PathVariable String namespaceName,
                                          @RequestParam(defaultValue = "0") int page,
                                          @RequestParam(defaultValue = "5") int size) {
+    if (permissionValidator.shouldHideConfigToCurrentUser(appId, env, namespaceName)) {
+      return Collections.emptyList();
+    }
 
     RequestPrecondition.checkNumberPositive(size);
     RequestPrecondition.checkNumberNotNegative(page);
@@ -127,6 +131,10 @@ public class ReleaseController {
                                              @PathVariable String namespaceName,
                                              @RequestParam(defaultValue = "0") int page,
                                              @RequestParam(defaultValue = "5") int size) {
+
+    if (permissionValidator.shouldHideConfigToCurrentUser(appId, env, namespaceName)) {
+      return Collections.emptyList();
+    }
 
     RequestPrecondition.checkNumberPositive(size);
     RequestPrecondition.checkNumberNotNegative(page);

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/controller/ReleaseHistoryController.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/controller/ReleaseHistoryController.java
@@ -2,9 +2,11 @@ package com.ctrip.framework.apollo.portal.controller;
 
 
 import com.ctrip.framework.apollo.core.enums.Env;
+import com.ctrip.framework.apollo.portal.component.PermissionValidator;
 import com.ctrip.framework.apollo.portal.entity.bo.ReleaseHistoryBO;
 import com.ctrip.framework.apollo.portal.service.ReleaseHistoryService;
 
+import java.util.Collections;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,6 +21,8 @@ public class ReleaseHistoryController {
 
   @Autowired
   private ReleaseHistoryService releaseHistoryService;
+  @Autowired
+  private PermissionValidator permissionValidator;
 
   @RequestMapping(value = "/apps/{appId}/envs/{env}/clusters/{clusterName}/namespaces/{namespaceName}/releases/histories",
       method = RequestMethod.GET)
@@ -28,6 +32,10 @@ public class ReleaseHistoryController {
                                                                 @PathVariable String namespaceName,
                                                                 @RequestParam(value = "page", defaultValue = "0") int page,
                                                                 @RequestParam(value = "size", defaultValue = "10") int size) {
+
+    if (permissionValidator.shouldHideConfigToCurrentUser(appId, env, namespaceName)) {
+      return Collections.emptyList();
+    }
 
    return releaseHistoryService.findNamespaceReleaseHistory(appId, Env.valueOf(env), clusterName ,namespaceName, page, size);
   }

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/entity/bo/NamespaceBO.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/entity/bo/NamespaceBO.java
@@ -12,7 +12,8 @@ public class NamespaceBO {
   private boolean isPublic;
   private String parentAppId;
   private String comment;
-
+  // is the configs hidden to current user?
+  private boolean isConfigHidden;
 
   public NamespaceDTO getBaseInfo() {
     return baseInfo;
@@ -70,4 +71,17 @@ public class NamespaceBO {
     this.comment = comment;
   }
 
+  public boolean isConfigHidden() {
+    return isConfigHidden;
+  }
+
+  public void setConfigHidden(boolean hidden) {
+    isConfigHidden = hidden;
+  }
+
+  public void hideItems() {
+    setConfigHidden(true);
+    items.clear();
+    setItemModifiedCnt(0);
+  }
 }

--- a/apollo-portal/src/main/resources/static/config/history.html
+++ b/apollo-portal/src/main/resources/static/config/history.html
@@ -48,7 +48,7 @@
 
         </div>
 
-        <div class="release-history-container panel-body row" ng-show="releaseHistories && releaseHistories.length > 0">
+        <div class="release-history-container panel-body row" ng-show="!isConfigHidden && releaseHistories && releaseHistories.length > 0">
             <div class="release-history-list col-md-3">
 
                 <div class="media hover" ng-class="{'active': releaseHistory.id == selectedReleaseHistory}"
@@ -232,8 +232,9 @@
 
         </div>
 
-        <div class="panel-body" ng-show="!releaseHistories || releaseHistories.length == 0">
-            <h4 class="text-center empty-container">无发布历史信息</h4>
+        <div class="panel-body" ng-show="isConfigHidden || !releaseHistories || releaseHistories.length == 0">
+            <h4 class="text-center empty-container" ng-show="isConfigHidden">您不是该项目的管理员，也没有该Namespace的编辑或发布权限，无法查看发布历史</h4>
+            <h4 class="text-center empty-container" ng-show="!isConfigHidden">无发布历史信息</h4>
         </div>
     </section>
 

--- a/apollo-portal/src/main/resources/static/scripts/controller/config/ReleaseHistoryController.js
+++ b/apollo-portal/src/main/resources/static/scripts/controller/config/ReleaseHistoryController.js
@@ -26,6 +26,8 @@ function releaseHistoryController($scope, $location, AppUtil,
     $scope.hasLoadAll = false;
     $scope.selectedReleaseHistory = 0;
     $scope.isTextNamespace = false;
+    // whether current user can view config
+    $scope.isConfigHidden = false;
 
     $scope.showReleaseHistoryDetail = showReleaseHistoryDetail;
     $scope.switchConfigViewType = switchConfigViewType;
@@ -99,6 +101,7 @@ function releaseHistoryController($scope, $location, AppUtil,
                 if ($scope.isTextNamespace) {
                   fixTextNamespaceViewType();
                 }
+                $scope.isConfigHidden = result.isConfigHidden;
             })
     }
 

--- a/apollo-portal/src/main/resources/static/views/component/namespace-panel-branch-tab.html
+++ b/apollo-portal/src/main/resources/static/views/component/namespace-panel-branch-tab.html
@@ -53,8 +53,13 @@
     </header>
 
     <div id="BODY{{namespace.branch.id}}" class="collapse in">
+        <div class="J_namespace-release-tip well well-sm no-radius text-center"
+             ng-show="namespace.isConfigHidden">
+            <span style="color: red">您不是该项目的管理员，也没有该Namespace的编辑或发布权限，无法查看配置信息。</span>
+        </div>
+
         <!--second header-->
-        <header class="panel-heading second-panel-heading">
+        <header class="panel-heading second-panel-heading" ng-show="!namespace.isConfigHidden">
             <div class="row">
                 <div class="col-md-12 pull-left">
                     <ul class="nav nav-tabs">
@@ -92,7 +97,7 @@
             </div>
         </header>
         <!--namespace body-->
-        <section>
+        <section ng-show="!namespace.isConfigHidden">
             <!--items-->
             <div class="namespace-view-table" ng-show="namespace.branch.viewType == 'table'">
 

--- a/apollo-portal/src/main/resources/static/views/component/namespace-panel-master-tab.html
+++ b/apollo-portal/src/main/resources/static/views/component/namespace-panel-master-tab.html
@@ -92,9 +92,16 @@
         </div>
     </header>
 
+
+
     <div id="BODY{{namespace.id}}" class="collapse in">
+        <div class="J_namespace-release-tip well well-sm no-radius text-center"
+             ng-show="namespace.isConfigHidden">
+            <span style="color: red">您不是该项目的管理员，也没有该Namespace的编辑或发布权限，无法查看配置信息。</span>
+        </div>
+
         <!--second header-->
-        <header class="panel-heading second-panel-heading">
+        <header class="panel-heading second-panel-heading" ng-show="!namespace.isConfigHidden">
             <div class="row">
                 <div class="col-md-6 col-sm-6 pull-left">
                     <!--master branch nav tabs-->
@@ -182,7 +189,7 @@
         </header>
 
         <!--namespace body-->
-        <section>
+        <section ng-show="!namespace.isConfigHidden">
             <!--table view-->
             <div class="namespace-view-table" ng-show="namespace.viewType == 'table'">
 

--- a/scripts/apollo-on-kubernetes/db/portal-db/apolloportaldb.sql
+++ b/scripts/apollo-on-kubernetes/db/portal-db/apolloportaldb.sql
@@ -312,7 +312,8 @@ VALUES
     ('superAdmin', 'apollo', 'Portal超级管理员'),
     ('api.readTimeout', '10000', 'http接口read timeout'),
     ('consumer.token.salt', 'someSalt', 'consumer token salt'),
-    ('admin.createPrivateNamespace.switch', 'true', '是否允许项目管理员创建私有namespace');
+    ('admin.createPrivateNamespace.switch', 'true', '是否允许项目管理员创建私有namespace'),
+    ('configView.memberOnly.envs', 'pro', '只对项目成员显示配置信息的环境列表，多个env以英文逗号分隔');
 
 INSERT INTO `Users` (`Username`, `Password`, `Email`, `Enabled`)
 VALUES

--- a/scripts/sql/apolloportaldb.sql
+++ b/scripts/sql/apolloportaldb.sql
@@ -312,7 +312,9 @@ VALUES
     ('superAdmin', 'apollo', 'Portal超级管理员'),
     ('api.readTimeout', '10000', 'http接口read timeout'),
     ('consumer.token.salt', 'someSalt', 'consumer token salt'),
-    ('admin.createPrivateNamespace.switch', 'true', '是否允许项目管理员创建私有namespace');
+    ('admin.createPrivateNamespace.switch', 'true', '是否允许项目管理员创建私有namespace'),
+    ('configView.memberOnly.envs', 'pro', '只对项目成员显示配置信息的环境列表，多个env以英文逗号分隔');
+
 
 INSERT INTO `Users` (`Username`, `Password`, `Email`, `Enabled`)
 VALUES


### PR DESCRIPTION
# Purpose

To support displaying configs only to team members for some specific environments.

For some configs such as database connection strings, users would like to make them hidden from non-team members, especially in production environment.

# Brief Changes

1. Added a new config `configView.memberOnly.envs` to config which environments should hide private namespace configs from non-team memebers.
2. Adjusted apollo-portal's controller and front end logic to hide configs, release histories from non-team members.
3. For those environments configured in `configView.memberOnly.envs`, only super admin, app admin and those who have either modification or release permissons can see private namespace configs and release histories.
4. Public namespaces are always open to every user.

# Usage

Simply config `configView.memberOnly.envs` in system configuration page(/server_config.html).

![image](https://user-images.githubusercontent.com/837658/46456519-c155e100-c7e1-11e8-969b-8f332379fa29.png)

And non-team member will see the following page:

![image](https://user-images.githubusercontent.com/837658/46456636-24477800-c7e2-11e8-818d-a0ddcafc8d89.png)



