### PR TITLE
rollback spring boot maven plugin version to 1.3.5.RELEASE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -434,7 +434,7 @@
 				<plugin>
 					<groupId>org.springframework.boot</groupId>
 					<artifactId>spring-boot-maven-plugin</artifactId>
-					<version>1.3.8.RELEASE</version>
+					<version>1.3.5.RELEASE</version>
 					<executions>
 						<execution>
 							<goals>


### PR DESCRIPTION
To fix the potential startup issue of `chown: cannot access '': No such file or directory` in centos7