### PR TITLE
Update ApolloMetaServiceConfig.java

### DIFF
--- a/apollo-configservice/src/main/java/com/ctrip/framework/apollo/metaservice/ApolloMetaServiceConfig.java
+++ b/apollo-configservice/src/main/java/com/ctrip/framework/apollo/metaservice/ApolloMetaServiceConfig.java
@@ -3,10 +3,16 @@ package com.ctrip.framework.apollo.metaservice;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.web.firewall.DefaultHttpFirewall;
+import org.springframework.security.web.firewall.HttpFirewall;
 
 @EnableAutoConfiguration
 @Configuration
 @ComponentScan(basePackageClasses = ApolloMetaServiceConfig.class)
 public class ApolloMetaServiceConfig {
-
+    @Bean
+    public HttpFirewall allowUrlEncodedSlashHttpFirewall() {
+        return new DefaultHttpFirewall();
+    }
 }


### PR DESCRIPTION
使用DefaultHttpFirewall替换spring security默认的StrictHttpFirewall，用于解决客户端配置meta url时加上/，抛The request was rejected because the URL was not normalized.异常的问题