### PR TITLE
新增查看配置权限

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ target
 
 # git
 *.orig
+.idea*

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/constant/PermissionType.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/constant/PermissionType.java
@@ -23,5 +23,9 @@ public interface PermissionType {
 
   String RELEASE_NAMESPACE = "ReleaseNamespace";
 
+  /**
+   * 查看配置的权限
+   */
+  String BROWSE_CONFIG = "BorwseConfig";
 
 }

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/constant/PermissionType.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/constant/PermissionType.java
@@ -1,13 +1,15 @@
 package com.ctrip.framework.apollo.portal.constant;
 
+/**
+ * 权限类型
+ */
 public interface PermissionType {
 
+
   /**
-   * APP level permission
+   * 应用级别的权限
    */
-
   String CREATE_NAMESPACE = "CreateNamespace";
-
   String CREATE_CLUSTER = "CreateCluster";
 
   /**
@@ -15,17 +17,16 @@ public interface PermissionType {
    */
   String ASSIGN_ROLE = "AssignRole";
 
+
   /**
-   * namespace level permission
+   * namespace级别的权限
    */
-
   String MODIFY_NAMESPACE = "ModifyNamespace";
-
   String RELEASE_NAMESPACE = "ReleaseNamespace";
 
   /**
    * 查看配置的权限
    */
-  String BROWSE_CONFIG = "BorwseConfig";
+  String BROWSE_CONFIG = "BrowseConfig";
 
 }

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/constant/RoleType.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/constant/RoleType.java
@@ -20,10 +20,10 @@ public class RoleType {
   /**
    * 配置查看角色
    */
-  public static final String VIEWER = "Viewer";
+  public static final String VIEW = "View";
 
   public static boolean isValidRoleType(String roleType) {
-    return MASTER.equals(roleType) || MODIFY_NAMESPACE.equals(roleType) || RELEASE_NAMESPACE.equals(roleType) || VIEWER.equals(roleType);
+    return MASTER.equals(roleType) || MODIFY_NAMESPACE.equals(roleType) || RELEASE_NAMESPACE.equals(roleType) || VIEW.equals(roleType);
   }
 
 }

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/constant/RoleType.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/constant/RoleType.java
@@ -17,10 +17,13 @@ public class RoleType {
    */
   public static final String RELEASE_NAMESPACE = "ReleaseNamespace";
 
-
+  /**
+   * 配置查看角色
+   */
+  public static final String VIEWER = "Viewer";
 
   public static boolean isValidRoleType(String roleType) {
-    return MASTER.equals(roleType) || MODIFY_NAMESPACE.equals(roleType) || RELEASE_NAMESPACE.equals(roleType);
+    return MASTER.equals(roleType) || MODIFY_NAMESPACE.equals(roleType) || RELEASE_NAMESPACE.equals(roleType) || VIEWER.equals(roleType);
   }
 
 }

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/constant/RoleType.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/constant/RoleType.java
@@ -2,11 +2,22 @@ package com.ctrip.framework.apollo.portal.constant;
 
 public class RoleType {
 
+  /**
+   * 超级管理员角色
+   */
   public static final String MASTER = "Master";
 
+  /**
+   * 修改Namespace角色
+   */
   public static final String MODIFY_NAMESPACE = "ModifyNamespace";
 
+  /**
+   * 发布配置角色
+   */
   public static final String RELEASE_NAMESPACE = "ReleaseNamespace";
+
+
 
   public static boolean isValidRoleType(String roleType) {
     return MASTER.equals(roleType) || MODIFY_NAMESPACE.equals(roleType) || RELEASE_NAMESPACE.equals(roleType);

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/controller/PermissionController.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/controller/PermissionController.java
@@ -78,7 +78,7 @@ public class PermissionController {
     PermissionCondition permissionCondition = new PermissionCondition();
 
     permissionCondition.setHasPermission(
-            rolePermissionService.userHasPermission(userInfoHolder.getUser().getUserId(), permissionType, RoleUtils.buildViewverTargetId(appId, env)));
+            rolePermissionService.userHasPermission(userInfoHolder.getUser().getUserId(), permissionType, RoleUtils.buildViewTargetId(appId, env)));
 
     return ResponseEntity.ok().body(permissionCondition);
   }
@@ -148,8 +148,8 @@ public class PermissionController {
     assignedUsers.setModifyRoleUsers(modifyNamespaceUsers);
 
     // 具有当前配置查看权限的用户
-    Set<UserInfo> viewerUsers = rolePermissionService.queryUsersWithRole(RoleUtils.buildViewerAppEnvRoleName(appId, env));
-    assignedUsers.setViewerRoleUsers(viewerUsers);
+    Set<UserInfo> viewUsers = rolePermissionService.queryUsersWithRole(RoleUtils.buildViewAppEnvRoleName(appId, env));
+    assignedUsers.setViewRoleUsers(viewUsers);
 
     return assignedUsers;
   }
@@ -219,8 +219,8 @@ public class PermissionController {
     assignedUsers.setModifyRoleUsers(modifyNamespaceUsers);
 
     // 具有当前配置查看权限的用户
-    Set<UserInfo> viewerUsers = rolePermissionService.queryUsersWithRole(RoleUtils.buildViewerAppRoleName(appId));
-    assignedUsers.setViewerRoleUsers(viewerUsers);
+    Set<UserInfo> viewUsers = rolePermissionService.queryUsersWithRole(RoleUtils.buildViewAppRoleName(appId));
+    assignedUsers.setViewRoleUsers(viewUsers);
 
     return assignedUsers;
   }

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/controller/PermissionController.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/controller/PermissionController.java
@@ -65,6 +65,24 @@ public class PermissionController {
     return ResponseEntity.ok().body(permissionCondition);
   }
 
+
+  /**
+   * 是否拥有App级别的以环境区分的权限
+   * @param appId
+   * @param env
+   * @param permissionType
+   * @return
+   */
+  @GetMapping("/apps/{appId}/envs/{env}/permissions/{permissionType}")
+  public ResponseEntity<PermissionCondition> hasEnvPermission(@PathVariable String appId, @PathVariable String env, @PathVariable String permissionType) {
+    PermissionCondition permissionCondition = new PermissionCondition();
+
+    permissionCondition.setHasPermission(
+            rolePermissionService.userHasPermission(userInfoHolder.getUser().getUserId(), permissionType, RoleUtils.buildViewverTargetId(appId, env)));
+
+    return ResponseEntity.ok().body(permissionCondition);
+  }
+
   @GetMapping("/apps/{appId}/namespaces/{namespaceName}/permissions/{permissionType}")
   public ResponseEntity<PermissionCondition> hasPermission(@PathVariable String appId, @PathVariable String namespaceName,
                                                            @PathVariable String permissionType) {

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/controller/UserInfoController.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/controller/UserInfoController.java
@@ -75,5 +75,14 @@ public class UserInfoController {
     return userService.findByUserId(userId);
   }
 
+  /**
+   * 查询用户列表
+   * @return
+   */
+  @GetMapping("/users/list")
+  public List<UserInfo> getUserList() {
+    return userService.selectUserList();
+  }
+
 
 }

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/entity/vo/NamespaceRolesAssignedUsers.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/entity/vo/NamespaceRolesAssignedUsers.java
@@ -11,7 +11,7 @@ public class NamespaceRolesAssignedUsers {
 
   private Set<UserInfo> modifyRoleUsers;
   private Set<UserInfo> releaseRoleUsers;
-  private Set<UserInfo> viewerRoleUsers;
+  private Set<UserInfo> viewRoleUsers;
 
   public String getAppId() {
     return appId;
@@ -47,11 +47,11 @@ public class NamespaceRolesAssignedUsers {
     this.releaseRoleUsers = releaseRoleUsers;
   }
 
-  public Set<UserInfo> getViewerRoleUsers() {
-    return viewerRoleUsers;
+  public Set<UserInfo> getViewRoleUsers() {
+    return viewRoleUsers;
   }
 
-  public void setViewerRoleUsers(Set<UserInfo> viewerRoleUsers) {
-    this.viewerRoleUsers = viewerRoleUsers;
+  public void setViewRoleUsers(Set<UserInfo> viewRoleUsers) {
+    this.viewRoleUsers = viewRoleUsers;
   }
 }

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/entity/vo/NamespaceRolesAssignedUsers.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/entity/vo/NamespaceRolesAssignedUsers.java
@@ -11,6 +11,7 @@ public class NamespaceRolesAssignedUsers {
 
   private Set<UserInfo> modifyRoleUsers;
   private Set<UserInfo> releaseRoleUsers;
+  private Set<UserInfo> viewerRoleUsers;
 
   public String getAppId() {
     return appId;
@@ -44,5 +45,13 @@ public class NamespaceRolesAssignedUsers {
   public void setReleaseRoleUsers(
       Set<UserInfo> releaseRoleUsers) {
     this.releaseRoleUsers = releaseRoleUsers;
+  }
+
+  public Set<UserInfo> getViewerRoleUsers() {
+    return viewerRoleUsers;
+  }
+
+  public void setViewerRoleUsers(Set<UserInfo> viewerRoleUsers) {
+    this.viewerRoleUsers = viewerRoleUsers;
   }
 }

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/repository/UserRepository.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/repository/UserRepository.java
@@ -2,6 +2,7 @@ package com.ctrip.framework.apollo.portal.repository;
 
 import com.ctrip.framework.apollo.portal.entity.po.UserPO;
 
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.PagingAndSortingRepository;
 
 import java.util.List;
@@ -18,4 +19,6 @@ public interface UserRepository extends PagingAndSortingRepository<UserPO, Long>
   UserPO findByUsername(String username);
 
   List<UserPO> findByUsernameIn(List<String> userNames);
+
+  List<UserPO> findAll();
 }

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/UserService.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/UserService.java
@@ -14,4 +14,10 @@ public interface UserService {
 
   List<UserInfo> findByUserIds(List<String> userIds);
 
+  /**
+   * 查询所有用户列表
+   * @return
+   */
+  List<UserInfo> selectUserList();
+
 }

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/ctrip/CtripUserService.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/ctrip/CtripUserService.java
@@ -96,6 +96,16 @@ public class CtripUserService implements UserService {
     return result;
   }
 
+  /**
+   * 查询所有用户列表
+   *
+   * @return
+   */
+  @Override
+  public List<UserInfo> selectUserList() {
+    return null;
+  }
+
   private UserInfo transformUserServiceResponseToUserInfo(UserServiceResponse userServiceResponse) {
     UserInfo userInfo = new UserInfo();
     userInfo.setUserId(userServiceResponse.getEmpaccount());

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/defaultimpl/DefaultRoleInitializationService.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/defaultimpl/DefaultRoleInitializationService.java
@@ -175,13 +175,14 @@ public class DefaultRoleInitializationService implements RoleInitializationServi
    */
   private void createAppViewerEnvRole(String appId, String operator, String env) {
 
-    Set<Permission> appPermissions = FluentIterable.from(Lists.newArrayList(PermissionType.BROWSE_CONFIG)).transform(permissionType -> createPermission(appId, permissionType, operator)).toSet();
-    Set<Permission> createdAppPermissions = rolePermissionService.createPermissions(appPermissions);
-    Set<Long> appPermissionIds = FluentIterable.from(createdAppPermissions).transform(permission -> permission.getId()).toSet();
-
+    Permission permission = createPermission(RoleUtils.buildViewverTargetId(appId, env), PermissionType.BROWSE_CONFIG, operator);
+    Permission createdPermission = rolePermissionService.createPermission(permission);
     // 创建查看角色
     Role appViewerRole = createRole(RoleUtils.buildViewerAppEnvRoleName(appId, env), operator);
-    rolePermissionService.createRoleWithPermissions(appViewerRole, appPermissionIds);
+    rolePermissionService.createRoleWithPermissions(appViewerRole, Sets.newHashSet(createdPermission.getId()));
+
+
+
   }
 
   private Permission createPermission(String targetId, String permissionType, String operator) {

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/defaultimpl/DefaultRoleInitializationService.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/defaultimpl/DefaultRoleInitializationService.java
@@ -57,18 +57,18 @@ public class DefaultRoleInitializationService implements RoleInitializationServi
     createAppMasterRole(appId, operator);
 
     // 初始化查看角色
-    createAppViewerRole(appId, operator);
+    createAppViewRole(appId, operator);
     List<Env> portalEnvs = portalConfig.portalSupportedEnvs();
     for (Env env : portalEnvs) {
       // 根据环境初始化查看角色
-      createAppViewerEnvRole(appId, operator, env.toString());
+      createAppViewEnvRole(appId, operator, env.toString());
     }
 
 
     //assign master role to user
     rolePermissionService.assignRoleToUsers(RoleUtils.buildAppMasterRoleName(appId), Sets.newHashSet(app.getOwnerName()), operator);
     // 授予查看角色
-    rolePermissionService.assignRoleToUsers(RoleUtils.buildViewerAppRoleName(appId), Sets.newHashSet(app.getOwnerName()), operator);
+    rolePermissionService.assignRoleToUsers(RoleUtils.buildViewAppRoleName(appId), Sets.newHashSet(app.getOwnerName()), operator);
 
     initNamespaceRoles(appId, ConfigConsts.NAMESPACE_APPLICATION, operator);
     initNamespaceEnvRoles(appId, ConfigConsts.NAMESPACE_APPLICATION, operator);
@@ -128,9 +128,9 @@ public class DefaultRoleInitializationService implements RoleInitializationServi
           releaseNamespaceEnvRoleName, operator);
     }
 
-    String viewerEnvRoleName = RoleUtils.buildViewerAppEnvRoleName(appId, env);
-    if(rolePermissionService.findRoleByRoleName(viewerEnvRoleName) == null) {
-      createAppViewerEnvRole(appId, operator, env);
+    String viewEnvRoleName = RoleUtils.buildViewAppEnvRoleName(appId, env);
+    if(rolePermissionService.findRoleByRoleName(viewEnvRoleName) == null) {
+      createAppViewEnvRole(appId, operator, env);
     }
   }
 
@@ -155,16 +155,16 @@ public class DefaultRoleInitializationService implements RoleInitializationServi
    * @param appId
    * @param operator
    */
-  private void createAppViewerRole(String appId, String operator) {
+  private void createAppViewRole(String appId, String operator) {
 
     Set<Permission> appPermissions = FluentIterable.from(Lists.newArrayList(PermissionType.BROWSE_CONFIG)).transform(permissionType -> createPermission(appId, permissionType, operator)).toSet();
     Set<Permission> createdAppPermissions = rolePermissionService.createPermissions(appPermissions);
     Set<Long> appPermissionIds = FluentIterable.from(createdAppPermissions).transform(permission -> permission.getId()).toSet();
 
     // 创建查看角色
-    Role appViewerRole = createRole(RoleUtils.buildViewerAppRoleName(appId), operator);
+    Role appViewRole = createRole(RoleUtils.buildViewAppRoleName(appId), operator);
 
-    rolePermissionService.createRoleWithPermissions(appViewerRole, appPermissionIds);
+    rolePermissionService.createRoleWithPermissions(appViewRole, appPermissionIds);
   }
 
   /**
@@ -173,13 +173,13 @@ public class DefaultRoleInitializationService implements RoleInitializationServi
    * @param operator
    * @param env
    */
-  private void createAppViewerEnvRole(String appId, String operator, String env) {
+  private void createAppViewEnvRole(String appId, String operator, String env) {
 
-    Permission permission = createPermission(RoleUtils.buildViewverTargetId(appId, env), PermissionType.BROWSE_CONFIG, operator);
+    Permission permission = createPermission(RoleUtils.buildViewTargetId(appId, env), PermissionType.BROWSE_CONFIG, operator);
     Permission createdPermission = rolePermissionService.createPermission(permission);
     // 创建查看角色
-    Role appViewerRole = createRole(RoleUtils.buildViewerAppEnvRoleName(appId, env), operator);
-    rolePermissionService.createRoleWithPermissions(appViewerRole, Sets.newHashSet(createdPermission.getId()));
+    Role appViewRole = createRole(RoleUtils.buildViewAppEnvRoleName(appId, env), operator);
+    rolePermissionService.createRoleWithPermissions(appViewRole, Sets.newHashSet(createdPermission.getId()));
 
 
 

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/defaultimpl/DefaultRoleInitializationService.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/defaultimpl/DefaultRoleInitializationService.java
@@ -23,6 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.*;
 
 /**
+ * 初始化角色
  * Created by timothy on 2017/4/26.
  */
 public class DefaultRoleInitializationService implements RoleInitializationService {
@@ -34,6 +35,11 @@ public class DefaultRoleInitializationService implements RoleInitializationServi
   @Autowired
   private PortalConfig portalConfig;
 
+  /**
+   * 初始化应用角色
+   * @param app
+   */
+  @Override
   @Transactional
   public void initAppRoles(App app) {
     String appId = app.getAppId();
@@ -66,6 +72,14 @@ public class DefaultRoleInitializationService implements RoleInitializationServi
 
   }
 
+
+  /**
+   * 初始化配置角色
+   * @param appId
+   * @param namespaceName
+   * @param operator
+   */
+  @Override
   @Transactional
   public void initNamespaceRoles(String appId, String namespaceName, String operator) {
 
@@ -82,6 +96,7 @@ public class DefaultRoleInitializationService implements RoleInitializationServi
     }
   }
 
+  @Override
   @Transactional
   public void initNamespaceEnvRoles(String appId, String namespaceName, String operator) {
     List<Env> portalEnvs = portalConfig.portalSupportedEnvs();
@@ -91,6 +106,7 @@ public class DefaultRoleInitializationService implements RoleInitializationServi
     }
   }
 
+  @Override
   @Transactional
   public void initNamespaceSpecificEnvRoles(String appId, String namespaceName, String env, String operator) {
     String modifyNamespaceEnvRoleName = RoleUtils.buildModifyNamespaceRoleName(appId, namespaceName, env);
@@ -109,7 +125,7 @@ public class DefaultRoleInitializationService implements RoleInitializationServi
   private void createAppMasterRole(String appId, String operator) {
     Set<Permission> appPermissions =
         FluentIterable.from(Lists.newArrayList(
-            PermissionType.CREATE_CLUSTER, PermissionType.CREATE_NAMESPACE, PermissionType.ASSIGN_ROLE))
+            PermissionType.CREATE_CLUSTER, PermissionType.CREATE_NAMESPACE, PermissionType.ASSIGN_ROLE, PermissionType.BROWSE_CONFIG))
             .transform(permissionType -> createPermission(appId, permissionType, operator)).toSet();
     Set<Permission> createdAppPermissions = rolePermissionService.createPermissions(appPermissions);
     Set<Long>

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/defaultimpl/DefaultRolePermissionService.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/defaultimpl/DefaultRolePermissionService.java
@@ -198,7 +198,7 @@ public class DefaultRolePermissionService implements RolePermissionService {
     }
 
     public boolean isSuperAdmin(String userId) {
-        return portalConfig.superAdmins().contains(userId);
+                return portalConfig.superAdmins().contains(userId);
     }
 
     /**

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/defaultimpl/DefaultRolePermissionService.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/defaultimpl/DefaultRolePermissionService.java
@@ -230,7 +230,7 @@ public class DefaultRolePermissionService implements RolePermissionService {
             Collection<String> permissionTypes = targetIdPermissionTypes.get(targetId);
             List<Permission> current =
                     permissionRepository.findByPermissionTypeInAndTargetId(permissionTypes, targetId);
-            Preconditions.checkState(CollectionUtils.isEmpty(current),
+             Preconditions.checkState(CollectionUtils.isEmpty(current),
                     "Permission with permissionType %s targetId %s already exists!", permissionTypes,
                     targetId);
         }

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/defaultimpl/DefaultUserService.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/defaultimpl/DefaultUserService.java
@@ -34,6 +34,16 @@ public class DefaultUserService implements UserService {
     return null;
   }
 
+  /**
+   * 查询所有用户列表
+   *
+   * @return
+   */
+  @Override
+  public List<UserInfo> selectUserList() {
+    return null;
+  }
+
   private UserInfo assembleDefaultUser() {
     UserInfo defaultUser = new UserInfo();
     defaultUser.setUserId("apollo");

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/ldap/LdapUserService.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/ldap/LdapUserService.java
@@ -90,4 +90,14 @@ public class LdapUserService implements UserService {
     }
   }
 
+  /**
+   * 查询所有用户列表
+   *
+   * @return
+   */
+  @Override
+  public List<UserInfo> selectUserList() {
+    return null;
+  }
+
 }

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/springsecurity/SpringSecurityUserService.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/springsecurity/SpringSecurityUserService.java
@@ -102,5 +102,21 @@ public class SpringSecurityUserService implements UserService {
     return result;
   }
 
+  /**
+   * 查询所有用户列表
+   *
+   * @return
+   */
+  @Override
+  public List<UserInfo> selectUserList() {
+
+    List<UserPO> userList = userRepository.findAll();
+
+    List<UserInfo> result = Lists.newArrayList();
+    result.addAll(userList.stream().map(UserPO::toUserInfo).collect(Collectors.toList()));
+
+    return result;
+  }
+
 
 }

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/util/RoleUtils.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/util/RoleUtils.java
@@ -86,5 +86,14 @@ public class RoleUtils {
     return STRING_JOINER.join(appId, ConfigConsts.NAMESPACE_APPLICATION);
   }
 
+  /**
+   * 创建查看角色
+   * @param appId
+   * @return
+   */
+  public static String buildViewerAppRoleName(String appId) {
+    return STRING_JOINER.join(RoleType.VIEWER, appId);
+  }
+
 
 }

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/util/RoleUtils.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/util/RoleUtils.java
@@ -110,4 +110,9 @@ public class RoleUtils {
   }
 
 
+  public static String buildViewverTargetId(String appId, String env) {
+    return STRING_JOINER.join(appId, env);
+  }
+
+
 }

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/util/RoleUtils.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/util/RoleUtils.java
@@ -95,8 +95,8 @@ public class RoleUtils {
    * @param appId
    * @return
    */
-  public static String buildViewerAppRoleName(String appId) {
-    return buildViewerAppEnvRoleName(appId, null);
+  public static String buildViewAppRoleName(String appId) {
+    return buildViewAppEnvRoleName(appId, null);
   }
 
   /**
@@ -105,12 +105,12 @@ public class RoleUtils {
    * @param env
    * @return
    */
-  public static String buildViewerAppEnvRoleName(String appId, String env) {
-    return STRING_JOINER.join(RoleType.VIEWER, appId, env);
+  public static String buildViewAppEnvRoleName(String appId, String env) {
+    return STRING_JOINER.join(RoleType.VIEW, appId, env);
   }
 
 
-  public static String buildViewverTargetId(String appId, String env) {
+  public static String buildViewTargetId(String appId, String env) {
     return STRING_JOINER.join(appId, env);
   }
 

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/util/RoleUtils.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/util/RoleUtils.java
@@ -39,7 +39,11 @@ public class RoleUtils {
   }
 
   public static String buildAppRoleName(String appId, String roleType) {
-    return STRING_JOINER.join(roleType, appId);
+    return buildAppEnvRoleName(appId, roleType, null);
+  }
+
+  public static String buildAppEnvRoleName(String appId, String roleType, String env) {
+    return STRING_JOINER.join(roleType, appId, env);
   }
 
   public static String buildModifyNamespaceRoleName(String appId, String namespaceName) {
@@ -92,7 +96,17 @@ public class RoleUtils {
    * @return
    */
   public static String buildViewerAppRoleName(String appId) {
-    return STRING_JOINER.join(RoleType.VIEWER, appId);
+    return buildViewerAppEnvRoleName(appId, null);
+  }
+
+  /**
+   * 创建查看角色（区分环境）
+   * @param appId
+   * @param env
+   * @return
+   */
+  public static String buildViewerAppEnvRoleName(String appId, String env) {
+    return STRING_JOINER.join(RoleType.VIEWER, appId, env);
   }
 
 

--- a/apollo-portal/src/main/resources/apollo-env.properties
+++ b/apollo-portal/src/main/resources/apollo-env.properties
@@ -3,4 +3,4 @@ dev.meta=${dev_meta}
 fat.meta=${fat_meta}
 uat.meta=${uat_meta}
 lpt.meta=${lpt_meta}
-pro.meta=${pro_meta}
+pro.meta=http://localhost:8080

--- a/apollo-portal/src/main/resources/static/config.html
+++ b/apollo-portal/src/main/resources/static/config.html
@@ -264,6 +264,10 @@
                              apollo-detail="'您没有发布权限哦~ 请找项目管理员 ' + masterUsers + ' 分配发布权限'"
                              apollo-show-cancel-btn="false"></apolloconfirmdialog>
 
+        <apolloconfirmdialog apollo-dialog-id="'viewNoPermissionDialog'" apollo-title="'申请查看配置的权限'"
+                             apollo-detail="'请找项目管理员 ' + masterUsers + ' 分配'"
+                             apollo-show-cancel-btn="false"></apolloconfirmdialog>
+
         <apolloconfirmdialog apollo-dialog-id="'modifyNoPermissionDialog'" apollo-title="'申请配置权限'"
                              apollo-detail="'请找项目管理员 ' + masterUsers + ' 分配编辑或发布权限'"
                              apollo-show-cancel-btn="false"></apolloconfirmdialog>

--- a/apollo-portal/src/main/resources/static/config.html
+++ b/apollo-portal/src/main/resources/static/config.html
@@ -264,9 +264,6 @@
                              apollo-detail="'您没有发布权限哦~ 请找项目管理员 ' + masterUsers + ' 分配发布权限'"
                              apollo-show-cancel-btn="false"></apolloconfirmdialog>
 
-        <apolloconfirmdialog apollo-dialog-id="'viewNoPermissionDialog'" apollo-title="'申请查看配置的权限'"
-                             apollo-detail="'请找项目管理员 ' + masterUsers + ' 分配'"
-                             apollo-show-cancel-btn="false"></apolloconfirmdialog>
 
         <apolloconfirmdialog apollo-dialog-id="'modifyNoPermissionDialog'" apollo-title="'申请配置权限'"
                              apollo-detail="'请找项目管理员 ' + masterUsers + ' 分配编辑或发布权限'"

--- a/apollo-portal/src/main/resources/static/index.html
+++ b/apollo-portal/src/main/resources/static/index.html
@@ -30,15 +30,17 @@
                     <h5>创建项目</h5>
                 </div>
             </div>
-            <div class="app-panel col-md-2 text-center" ng-repeat="app in createdApps"
-                 ng-click="goToAppHomePage(app.appId)">
+
+            <!-- 应用列表 -->
+            <div class="app-panel col-md-2 text-center" ng-repeat="app in createdApps" ng-click="goToAppHomePage(app.appId)">
                 <div href="#" class="thumbnail hover cursor-pointer">
                     <h4 ng-bind="app.appId"></h4>
                     <h5 ng-bind="app.name"></h5>
                 </div>
             </div>
-            <div class="app-panel col-md-2 text-center" ng-show="hasMoreCreatedApps"
-                 ng-click="getUserCreatedApps()">
+
+            <!-- 加载更多 -->
+            <div class="app-panel col-md-2 text-center" ng-show="hasMoreCreatedApps" ng-click="getUserCreatedApps()">
                 <div href="#" class="thumbnail hover cursor-pointer">
                     <img class="more-img" src="img/more.png"/>
                     <h5>加载更多</h5>

--- a/apollo-portal/src/main/resources/static/namespace/role.html
+++ b/apollo-portal/src/main/resources/static/namespace/role.html
@@ -39,23 +39,23 @@
                         <label class="control-label">查看配置权限<br><small>(仅可以查看配置)</small></label>
                     </div>
                     <div class="col-sm-8">
-                        <form class="form-inline" ng-submit="assignRoleToUser('Viewer')">
+                        <form class="form-inline" ng-submit="assignRoleToUser('View')">
                             <div class="form-group">
-                                <apollouserselector apollo-id="viewerRoleWidgetId"></apollouserselector>
-                                <select class="form-control input-sm" ng-model="viewerRoleSelectedEnv">
+                                <apollouserselector apollo-id="viewRoleWidgetId"></apollouserselector>
+                                <select class="form-control input-sm" ng-model="viewRoleSelectedEnv">
                                     <option value="">所有环境</option>
                                     <option ng-repeat="env in envs" ng-value="env">{{env}}</option>
                                 </select>
                             </div>
-                            <button type="submit" class="btn btn-default" style="margin-left: 20px;" ng-disabled="viewerRoleSubmitBtnDisabled">添加</button>
+                            <button type="submit" class="btn btn-default" style="margin-left: 20px;" ng-disabled="viewRoleSubmitBtnDisabled">添加</button>
                         </form>
                         <!-- Split button -->
                         <div class="item-container">
                             <h5>所有环境</h5>
-                            <div class="btn-group item-info" ng-repeat="user in rolesAssignedUsers.viewerRoleUsers">
+                            <div class="btn-group item-info" ng-repeat="user in rolesAssignedUsers.viewRoleUsers">
                                 <button type="button" class="btn btn-default" ng-bind="user.userId"></button>
                                 <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown"
-                                        aria-haspopup="true" aria-expanded="false" ng-click="removeUserRole('Viewer', user.userId, null)">
+                                        aria-haspopup="true" aria-expanded="false" ng-click="removeUserRole('View', user.userId, null)">
                                     <span class="glyphicon glyphicon-remove"></span>
                                 </button>
                             </div>
@@ -63,10 +63,10 @@
 
                         <div class="item-container" ng-repeat="env in envs">
                             <h5>{{env}}</h5>
-                            <div class="btn-group item-info" ng-repeat="user in envRolesAssignedUsers[env].viewerRoleUsers">
+                            <div class="btn-group item-info" ng-repeat="user in envRolesAssignedUsers[env].viewRoleUsers">
                                 <button type="button" class="btn btn-default" ng-bind="user.userId"></button>
                                 <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown"
-                                        aria-haspopup="true" aria-expanded="false" ng-click="removeUserRole('Viewer', user.userId, env)">
+                                        aria-haspopup="true" aria-expanded="false" ng-click="removeUserRole('View', user.userId, env)">
                                     <span class="glyphicon glyphicon-remove"></span>
                                 </button>
                             </div>

--- a/apollo-portal/src/main/resources/static/namespace/role.html
+++ b/apollo-portal/src/main/resources/static/namespace/role.html
@@ -31,7 +31,54 @@
                 </div>
             </div>
         </header>
+
         <div class="panel-body" ng-show="hasAssignUserPermission">
+            <div class="row" style="margin-top: 10px;">
+                <div class="form-horizontal">
+                    <div class="col-sm-2 text-right">
+                        <label class="control-label">查看配置权限<br><small>(仅可以查看配置)</small></label>
+                    </div>
+                    <div class="col-sm-8">
+                        <form class="form-inline" ng-submit="assignRoleToUser('Viewer')">
+                            <div class="form-group">
+                                <apollouserselector apollo-id="viewerRoleWidgetId"></apollouserselector>
+                                <select class="form-control input-sm" ng-model="viewerRoleSelectedEnv">
+                                    <option value="">所有环境</option>
+                                    <option ng-repeat="env in envs" ng-value="env">{{env}}</option>
+                                </select>
+                            </div>
+                            <button type="submit" class="btn btn-default" style="margin-left: 20px;" ng-disabled="viewerRoleSubmitBtnDisabled">添加</button>
+                        </form>
+                        <!-- Split button -->
+                        <div class="item-container">
+                            <h5>所有环境</h5>
+                            <div class="btn-group item-info" ng-repeat="user in rolesAssignedUsers.viewerRoleUsers">
+                                <button type="button" class="btn btn-default" ng-bind="user.userId"></button>
+                                <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown"
+                                        aria-haspopup="true" aria-expanded="false" ng-click="removeUserRole('Viewer', user.userId, null)">
+                                    <span class="glyphicon glyphicon-remove"></span>
+                                </button>
+                            </div>
+                        </div>
+
+                        <div class="item-container" ng-repeat="env in envs">
+                            <h5>{{env}}</h5>
+                            <div class="btn-group item-info" ng-repeat="user in envRolesAssignedUsers[env].viewerRoleUsers">
+                                <button type="button" class="btn btn-default" ng-bind="user.userId"></button>
+                                <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown"
+                                        aria-haspopup="true" aria-expanded="false" ng-click="removeUserRole('Viewer', user.userId, env)">
+                                    <span class="glyphicon glyphicon-remove"></span>
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+            </div>
+
+
+
+
             <div class="row">
                 <div class="form-horizontal">
                     <div class="form-group">

--- a/apollo-portal/src/main/resources/static/scripts/AppUtils.js
+++ b/apollo-portal/src/main/resources/static/scripts/AppUtils.js
@@ -42,7 +42,6 @@ appUtil.service('AppUtil', ['toastr', '$window', '$q', function (toastr, $window
             if (!query) {
                 //如果不传这个参数或者false则返回到首页(参数出错)
                 if (!notJumpToHomePage) {
-                    debugger;
                     $window.location.href = '/index.html';
                 } else {
                     return {};

--- a/apollo-portal/src/main/resources/static/scripts/AppUtils.js
+++ b/apollo-portal/src/main/resources/static/scripts/AppUtils.js
@@ -42,6 +42,7 @@ appUtil.service('AppUtil', ['toastr', '$window', '$q', function (toastr, $window
             if (!query) {
                 //如果不传这个参数或者false则返回到首页(参数出错)
                 if (!notJumpToHomePage) {
+                    debugger;
                     $window.location.href = '/index.html';
                 } else {
                     return {};

--- a/apollo-portal/src/main/resources/static/scripts/controller/IndexController.js
+++ b/apollo-portal/src/main/resources/static/scripts/controller/IndexController.js
@@ -33,6 +33,9 @@ function IndexController($scope, $window, toastr, AppUtil, AppService, UserServi
         initUserVisitedApps();
     });
 
+    /**
+     * 获取当前用户创建的应用列表
+     */
     function getUserCreatedApps() {
         var size = 10;
         AppService.find_app_by_owner($scope.userId, $scope.createdAppPage, size)

--- a/apollo-portal/src/main/resources/static/scripts/controller/config/ConfigNamespaceController.js
+++ b/apollo-portal/src/main/resources/static/scripts/controller/config/ConfigNamespaceController.js
@@ -17,6 +17,7 @@ function controller($rootScope, $scope, toastr, AppUtil, EventManager, ConfigSer
     $scope.preCreateBranch = preCreateBranch;
     $scope.preDeleteBranch = preDeleteBranch;
     $scope.deleteBranch = deleteBranch;
+    $scope.showNoViewPermissionDialog = showNoViewPermissionDialog;
     $scope.showNoModifyPermissionDialog = showNoModifyPermissionDialog;
     $scope.lockCheck = lockCheck;
     $scope.emergencyPublish = emergencyPublish;
@@ -261,6 +262,10 @@ function controller($rootScope, $scope, toastr, AppUtil, EventManager, ConfigSer
     function showText(text) {
         $scope.text = text;
         $('#showTextModal').modal('show');
+    }
+
+    function showNoViewPermissionDialog() {
+        $("#viewNoPermissionDialog").modal('show');
     }
 
     function showNoModifyPermissionDialog() {

--- a/apollo-portal/src/main/resources/static/scripts/controller/config/ConfigNamespaceController.js
+++ b/apollo-portal/src/main/resources/static/scripts/controller/config/ConfigNamespaceController.js
@@ -17,7 +17,6 @@ function controller($rootScope, $scope, toastr, AppUtil, EventManager, ConfigSer
     $scope.preCreateBranch = preCreateBranch;
     $scope.preDeleteBranch = preDeleteBranch;
     $scope.deleteBranch = deleteBranch;
-    $scope.showNoViewPermissionDialog = showNoViewPermissionDialog;
     $scope.showNoModifyPermissionDialog = showNoModifyPermissionDialog;
     $scope.lockCheck = lockCheck;
     $scope.emergencyPublish = emergencyPublish;
@@ -262,10 +261,6 @@ function controller($rootScope, $scope, toastr, AppUtil, EventManager, ConfigSer
     function showText(text) {
         $scope.text = text;
         $('#showTextModal').modal('show');
-    }
-
-    function showNoViewPermissionDialog() {
-        $("#viewNoPermissionDialog").modal('show');
     }
 
     function showNoModifyPermissionDialog() {

--- a/apollo-portal/src/main/resources/static/scripts/controller/role/NamespaceRoleController.js
+++ b/apollo-portal/src/main/resources/static/scripts/controller/role/NamespaceRoleController.js
@@ -12,15 +12,15 @@ role_module.controller('NamespaceRoleController',
 
             $scope.modifyRoleSubmitBtnDisabled = false;
             $scope.ReleaseRoleSubmitBtnDisabled = false;
-            $scope.viewerRoleSubmitBtnDisabled = false;
+            $scope.viewRoleSubmitBtnDisabled = false;
 
             $scope.releaseRoleWidgetId = 'releaseRoleWidgetId';
             $scope.modifyRoleWidgetId = 'modifyRoleWidgetId';
-            $scope.viewerRoleWidgetId = 'viewerRoleWidgetId';
+            $scope.viewRoleWidgetId = 'viewRoleWidgetId';
 
             $scope.modifyRoleSelectedEnv = "";
             $scope.releaseRoleSelectedEnv = "";
-            $scope.viewerRoleSelectedEnv = "";
+            $scope.viewRoleSelectedEnv = "";
 
             PermissionService.init_app_namespace_permission($scope.pageContext.appId, $scope.pageContext.namespaceName)
                 .then(function (result) {
@@ -147,39 +147,39 @@ role_module.controller('NamespaceRoleController',
                 }
 
                 // 查看权
-                if("Viewer" === roleType) {
+                if("View" === roleType) {
                     // 获取选中的用户ID
-                    var user = $('.' + $scope.viewerRoleWidgetId).select2('data')[0];
+                    var user = $('.' + $scope.viewRoleWidgetId).select2('data')[0];
                     if (!user) {
                         toastr.warning("请选择用户");
                         return;
                     }
                     // 设置按钮可用
-                    $scope.viewerRoleSubmitBtnDisabled = true;
+                    $scope.viewRoleSubmitBtnDisabled = true;
 
                     // 需要授权的用户id
-                    var toAssignViewerRoleUser = user.id;
+                    var toAssignViewRoleUser = user.id;
                     // 授权函数
-                    var assignViewerRoleFunc =  $scope.viewerRoleSelectedEnv === "" ? PermissionService.assign_viewer_role :
+                    var assignViewRoleFunc =  $scope.viewRoleSelectedEnv === "" ? PermissionService.assign_view_role :
                         function(appId, user) {
-                            return PermissionService.assign_viewer_env_role(appId, $scope.viewerRoleSelectedEnv,user);
+                            return PermissionService.assign_view_env_role(appId, $scope.viewRoleSelectedEnv,user);
                         };
 
-                    assignViewerRoleFunc($scope.pageContext.appId, toAssignViewerRoleUser).then(function (result) {
+                    assignViewRoleFunc($scope.pageContext.appId, toAssignViewRoleUser).then(function (result) {
                             toastr.success("添加成功");
-                            $scope.viewerRoleSubmitBtnDisabled = false;
-                            if($scope.viewerRoleSelectedEnv === "") {
-                                $scope.rolesAssignedUsers.viewerRoleUsers.push({userId: toAssignViewerRoleUser});
+                            $scope.viewRoleSubmitBtnDisabled = false;
+                            if($scope.viewRoleSelectedEnv === "") {
+                                $scope.rolesAssignedUsers.viewRoleUsers.push({userId: toAssignViewRoleUser});
                             } else {
-                                $scope.envRolesAssignedUsers[$scope.viewerRoleSelectedEnv].viewerRoleUsers.push(
-                                    {userId: toAssignViewerRoleUser});
+                                $scope.envRolesAssignedUsers[$scope.viewRoleSelectedEnv].viewRoleUsers.push(
+                                    {userId: toAssignViewRoleUser});
                             }
 
-                            $('.' + $scope.viewerRoleWidgetId).select2("val", "");
-                            $scope.viewerRoleSelectedEnv = "";
+                            $('.' + $scope.viewRoleWidgetId).select2("val", "");
+                            $scope.viewRoleSelectedEnv = "";
 
                         }, function (result) {
-                            $scope.viewerRoleSubmitBtnDisabled = false;
+                            $scope.viewRoleSubmitBtnDisabled = false;
                             toastr.error(AppUtil.errorMsg(result), "添加失败");
                         });
                 }
@@ -231,18 +231,18 @@ role_module.controller('NamespaceRoleController',
                         });
                 }
 
-                if('Viewer' === roleType) {
-                    var removeViewerRoleFunc = !env ? PermissionService.remove_viewer_role :
+                if('View' === roleType) {
+                    var removeViewRoleFunc = !env ? PermissionService.remove_view_role :
                         function (appId, user) {
-                            return PermissionService.remove_viewer_env_role(appId, env, user);
+                            return PermissionService.remove_view_env_role(appId, env, user);
                         }
 
-                    removeViewerRoleFunc($scope.pageContext.appId, user).then(function (result) {
+                    removeViewRoleFunc($scope.pageContext.appId, user).then(function (result) {
                             toastr.success("删除成功");
                             if(!env) {
-                                removeUserFromList($scope.rolesAssignedUsers.viewerRoleUsers, user);
+                                removeUserFromList($scope.rolesAssignedUsers.viewRoleUsers, user);
                             } else {
-                                removeUserFromList($scope.envRolesAssignedUsers[env].viewerRoleUsers, user);
+                                removeUserFromList($scope.envRolesAssignedUsers[env].viewRoleUsers, user);
                             }
 
                         }, function (result) {

--- a/apollo-portal/src/main/resources/static/scripts/directive/directive.js
+++ b/apollo-portal/src/main/resources/static/scripts/directive/directive.js
@@ -1,131 +1,129 @@
 /** navbar */
-directive_module.directive('apollonav',
-                           function ($compile, $window, toastr, AppUtil, AppService, EnvService,
-                           UserService, CommonService, PermissionService) {
-                               return {
-                                   restrict: 'E',
-                                   templateUrl: '../../views/common/nav.html',
-                                   transclude: true,
-                                   replace: true,
-                                   link: function (scope, element, attrs) {
+directive_module.directive('apollonav', function ($compile, $window, toastr, AppUtil, AppService, EnvService, UserService, CommonService, PermissionService) {
+    return {
+       restrict: 'E',
+       templateUrl: '../../views/common/nav.html',
+       transclude: true,
+       replace: true,
+       link: function (scope, element, attrs) {
 
-                                       CommonService.getPageSetting().then(function (setting) {
-                                           scope.pageSetting = setting;
-                                       });
+           CommonService.getPageSetting().then(function (setting) {
+               scope.pageSetting = setting;
+           });
 
-                                       scope.sourceApps = [];
-                                       scope.copiedApps = [];
+           scope.sourceApps = [];
+           scope.copiedApps = [];
 
-                                       AppService.find_apps().then(function (result) {
-                                           result.forEach(function (app) {
-                                               app.selected = false;
-                                               scope.sourceApps.push(app);
-                                           });
-                                           scope.copiedApps = angular.copy(scope.sourceApps);
-                                       }, function (result) {
-                                           toastr.error(AppUtil.errorMsg(result), "load apps error");
-                                       });
+           AppService.find_apps().then(function (result) {
+               result.forEach(function (app) {
+                   app.selected = false;
+                   scope.sourceApps.push(app);
+               });
+               scope.copiedApps = angular.copy(scope.sourceApps);
+           }, function (result) {
+               toastr.error(AppUtil.errorMsg(result), "load apps error");
+           });
 
-                                       scope.searchKey = '';
-                                       scope.shouldShowAppList = false;
+           scope.searchKey = '';
+           scope.shouldShowAppList = false;
 
-                                       var selectedApp = {};
-                                       scope.selectApp = function (app) {
-                                           select(app);
-                                           scope.jumpToConfigPage();
-                                       };
+           var selectedApp = {};
+           scope.selectApp = function (app) {
+               select(app);
+               scope.jumpToConfigPage();
+           };
 
-                                       scope.changeSearchKey = function () {
-                                           scope.copiedApps = [];
-                                           var searchKey = scope.searchKey.toLocaleLowerCase();
-                                           scope.sourceApps.forEach(function (app) {
-                                               if (app.name.toLocaleLowerCase().indexOf(searchKey) > -1
-                                                   || app.appId.toLocaleLowerCase().indexOf(searchKey) > -1) {
-                                                   scope.copiedApps.push(app);
-                                               }
-                                           });
-                                           scope.shouldShowAppList = true;
-                                       };
+           scope.changeSearchKey = function () {
+               scope.copiedApps = [];
+               var searchKey = scope.searchKey.toLocaleLowerCase();
+               scope.sourceApps.forEach(function (app) {
+                   if (app.name.toLocaleLowerCase().indexOf(searchKey) > -1
+                       || app.appId.toLocaleLowerCase().indexOf(searchKey) > -1) {
+                       scope.copiedApps.push(app);
+                   }
+               });
+               scope.shouldShowAppList = true;
+           };
 
-                                       scope.jumpToConfigPage = function () {
-                                           if (selectedApp.appId) {
-                                               if ($window.location.href.indexOf("config.html") > -1) {
-                                                   $window.location.hash = "appid=" + selectedApp.appId;
-                                                   $window.location.reload();
-                                               } else {
-                                                   $window.location.href = '/config.html?#appid=' + selectedApp.appId;
-                                               }
-                                           }
-                                       };
+           scope.jumpToConfigPage = function () {
+               if (selectedApp.appId) {
+                   if ($window.location.href.indexOf("config.html") > -1) {
+                       $window.location.hash = "appid=" + selectedApp.appId;
+                       $window.location.reload();
+                   } else {
+                       $window.location.href = '/config.html?#appid=' + selectedApp.appId;
+                   }
+               }
+           };
 
-                                       //up:38 down:40 enter:13
-                                       var selectedAppIdx = -1;
-                                       element.bind("keydown keypress", function (event) {
+           //up:38 down:40 enter:13
+           var selectedAppIdx = -1;
+           element.bind("keydown keypress", function (event) {
 
-                                           if (event.keyCode == 40) {
-                                               if (selectedAppIdx < scope.copiedApps.length - 1) {
-                                                   clearAppsSelectedStatus();
-                                                   scope.copiedApps[++selectedAppIdx].selected = true;
-                                               }
-                                           } else if (event.keyCode == 38) {
-                                               if (selectedAppIdx >= 1) {
-                                                   clearAppsSelectedStatus();
-                                                   scope.copiedApps[--selectedAppIdx].selected = true;
-                                               }
-                                           } else if (event.keyCode == 13) {
-                                               if (scope.shouldShowAppList && selectedAppIdx > -1) {
-                                                   select(scope.copiedApps[selectedAppIdx]);
-                                                   event.preventDefault();
-                                               } else {
-                                                   scope.jumpToConfigPage();
-                                               }
+               if (event.keyCode == 40) {
+                   if (selectedAppIdx < scope.copiedApps.length - 1) {
+                       clearAppsSelectedStatus();
+                       scope.copiedApps[++selectedAppIdx].selected = true;
+                   }
+               } else if (event.keyCode == 38) {
+                   if (selectedAppIdx >= 1) {
+                       clearAppsSelectedStatus();
+                       scope.copiedApps[--selectedAppIdx].selected = true;
+                   }
+               } else if (event.keyCode == 13) {
+                   if (scope.shouldShowAppList && selectedAppIdx > -1) {
+                       select(scope.copiedApps[selectedAppIdx]);
+                       event.preventDefault();
+                   } else {
+                       scope.jumpToConfigPage();
+                   }
 
-                                           }
-                                           //强制刷新
-                                           scope.$apply(function () {
-                                               scope.copiedApps = scope.copiedApps;
-                                           });
-                                       });
+               }
+               //强制刷新
+               scope.$apply(function () {
+                   scope.copiedApps = scope.copiedApps;
+               });
+           });
 
-                                       $(".search-input").on("click", function (event) {
-                                           event.stopPropagation();
-                                       });
+           $(".search-input").on("click", function (event) {
+               event.stopPropagation();
+           });
 
-                                       $(document).on('click', function () {
-                                           scope.$apply(function () {
-                                               scope.shouldShowAppList = false;
-                                           });
-                                       });
+           $(document).on('click', function () {
+               scope.$apply(function () {
+                   scope.shouldShowAppList = false;
+               });
+           });
 
-                                       function clearAppsSelectedStatus() {
-                                           scope.copiedApps.forEach(function (app) {
-                                               app.selected = false;
-                                           })
+           function clearAppsSelectedStatus() {
+               scope.copiedApps.forEach(function (app) {
+                   app.selected = false;
+               })
 
-                                       }
+           }
 
-                                       function select(app) {
-                                           selectedApp = app;
-                                           scope.searchKey = app.name;
-                                           scope.shouldShowAppList = false;
-                                           clearAppsSelectedStatus();
-                                           selectedAppIdx = -1;
+           function select(app) {
+               selectedApp = app;
+               scope.searchKey = app.name;
+               scope.shouldShowAppList = false;
+               clearAppsSelectedStatus();
+               selectedAppIdx = -1;
 
-                                       }
+           }
 
-                                       UserService.load_user().then(function (result) {
-                                           scope.userName = result.userId;
-                                       }, function (result) {
+           UserService.load_user().then(function (result) {
+               scope.userName = result.userId;
+           }, function (result) {
 
-                                       });
+           });
 
-                                       PermissionService.has_root_permission().then(function(result) {
-                                           scope.hasRootPermission = result.hasPermission;
-                                       })
-                                   }
-                               }
+           PermissionService.has_root_permission().then(function(result) {
+               scope.hasRootPermission = result.hasPermission;
+           })
+       }
+    }
 
-                           });
+});
 
 /** env cluster selector*/
 directive_module.directive('apolloclusterselector', function ($compile, $window, AppService, AppUtil, toastr) {

--- a/apollo-portal/src/main/resources/static/scripts/directive/namespace-panel-directive.js
+++ b/apollo-portal/src/main/resources/static/scripts/directive/namespace-panel-directive.js
@@ -288,6 +288,26 @@ function directive($window, toastr, AppUtil, EventManager, PermissionService, Na
                                 }
                             }
                         });
+
+                    // 配置查看权限
+                    PermissionService.has_viewer_permission(scope.appId).then(function (result) {
+                        if (!result.hasPermission) {
+                            PermissionService.has_viewer_env_permission(scope.appId, scope.env).then(function (result) {
+                                //branch has same permission
+                                namespace.hasViewerPermission = result.hasPermission;
+                                if (namespace.branch) {
+                                    namespace.branch.hasViewerPermission = result.hasPermission;
+                                }
+                            });
+                        }
+                        else {
+                            //branch has same permission
+                            namespace.hasViewerPermission = result.hasPermission;
+                            if (namespace.branch) {
+                                namespace.branch.hasViewerPermission = result.hasPermission;
+                            }
+                        }
+                    });
                 }
 
                 function initLinkedNamespace(namespace) {

--- a/apollo-portal/src/main/resources/static/scripts/directive/namespace-panel-directive.js
+++ b/apollo-portal/src/main/resources/static/scripts/directive/namespace-panel-directive.js
@@ -289,22 +289,21 @@ function directive($window, toastr, AppUtil, EventManager, PermissionService, Na
                             }
                         });
 
-                    // 配置查看权限
-                    PermissionService.has_viewer_permission(scope.appId).then(function (result) {
+                    PermissionService.has_view_permission(scope.appId).then(function (result) {
                         if (!result.hasPermission) {
-                            PermissionService.has_viewer_env_permission(scope.appId, scope.env).then(function (result) {
+                            PermissionService.has_view_env_permission(scope.appId, scope.env).then(function (result) {
                                 //branch has same permission
-                                namespace.hasViewerPermission = result.hasPermission;
+                                namespace.hasViewPermission = result.hasPermission;
                                 if (namespace.branch) {
-                                    namespace.branch.hasViewerPermission = result.hasPermission;
+                                    namespace.branch.hasViewPermission = result.hasPermission;
                                 }
                             });
                         }
                         else {
                             //branch has same permission
-                            namespace.hasViewerPermission = result.hasPermission;
+                            namespace.hasViewPermission = result.hasPermission;
                             if (namespace.branch) {
-                                namespace.branch.hasViewerPermission = result.hasPermission;
+                                namespace.branch.hasViewPermission = result.hasPermission;
                             }
                         }
                     });

--- a/apollo-portal/src/main/resources/static/scripts/services/AppService.js
+++ b/apollo-portal/src/main/resources/static/scripts/services/AppService.js
@@ -64,10 +64,10 @@ appService.service('AppService', ['$resource', '$q', function ($resource, $q) {
         find_app_by_owner: function (owner, page, size) {
             var d = $q.defer();
             app_resource.find_app_by_owner({
-                                               owner: owner,
-                                               page: page,
-                                               size: size
-                                           }, function (result) {
+               owner: owner,
+               page: page,
+               size: size
+            }, function (result) {
                 d.resolve(result);
             }, function (result) {
                 d.reject(result);

--- a/apollo-portal/src/main/resources/static/scripts/services/PermissionService.js
+++ b/apollo-portal/src/main/resources/static/scripts/services/PermissionService.js
@@ -175,6 +175,23 @@ appService.service('PermissionService', ['$resource', '$q', function ($resource,
         return d.promise;
     }
 
+
+    function removeViewerRoleFromUser(appId, namespaceName, roleType, user) {
+        var d = $q.defer();
+        permission_resource.remove_app_role_from_user({
+                                                                appId: appId,
+                                                                namespaceName: namespaceName,
+                                                                roleType: roleType,
+                                                                user: user
+                                                            },
+                                                            function (result) {
+                                                                d.resolve(result);
+                                                            }, function (result) {
+                d.reject(result);
+            });
+        return d.promise;
+    }
+
     function removeNamespaceEnvRoleFromUser(appId, env, namespaceName, roleType, user) {
         var d = $q.defer();
         permission_resource.remove_namespace_env_role_from_user({
@@ -231,6 +248,7 @@ appService.service('PermissionService', ['$resource', '$q', function ($resource,
         assign_modify_namespace_role: function (appId, namespaceName, user) {
             return assignNamespaceRoleToUser(appId, namespaceName, 'ModifyNamespace', user);
         },
+
         assign_modify_namespace_env_role: function (appId, env, namespaceName, user) {
             return assignNamespaceEnvRoleToUser(appId, env, namespaceName, 'ModifyNamespace', user);
         },
@@ -317,6 +335,33 @@ appService.service('PermissionService', ['$resource', '$q', function ($resource,
                     d.reject(result);
                 });
             return d.promise;
-        }
+        },
+        assign_viewer_role: function (appId, user) {
+            var d = $q.defer();
+            permission_resource.assign_app_role_to_user({
+                    appId: appId,
+                    roleType: 'Viewer'
+                }, user,
+                function (result) {
+                    d.resolve(result);
+                }, function (result) {
+                    d.reject(result);
+                });
+            return d.promise;
+        },
+        remove_viewer_role: function (appId, user) {
+        var d = $q.defer();
+        permission_resource.remove_app_role_from_user({
+                appId: appId,
+                roleType: 'Viewer',
+                user: user
+            },
+            function (result) {
+                d.resolve(result);
+            }, function (result) {
+                d.reject(result);
+            });
+        return d.promise;
+    }
     }
 }]);

--- a/apollo-portal/src/main/resources/static/scripts/services/PermissionService.js
+++ b/apollo-portal/src/main/resources/static/scripts/services/PermissionService.js
@@ -31,6 +31,14 @@ appService.service('PermissionService', ['$resource', '$q', function ($resource,
             method: 'GET',
             url: '/apps/:appId/namespaces/:namespaceName/role_users'
         },
+        get_app_role_users: {
+            method: 'GET',
+            url: '/apps/:appId/role_users'
+        },
+        get_app_env_role_users: {
+            method: 'GET',
+            url: '/apps/:appId/envs/:env/role_users'
+        },
         get_namespace_env_role_users: {
             method: 'GET',
             url: '/apps/:appId/envs/:env/namespaces/:namespaceName/role_users'
@@ -57,17 +65,6 @@ appService.service('PermissionService', ['$resource', '$q', function ($resource,
             method: 'DELETE',
             url: '/apps/:appId/envs/:env/namespaces/:namespaceName/roles/:roleType?user=:user'
         },
-        // 获取所有环境的授权
-        get_app_role_users: {
-            method: 'GET',
-            url: '/apps/:appId/role_users'    
-        },
-        // 根据环境获取授权
-        get_app_env_role_users: {
-            method: 'GET',
-            url: '/apps/:appId/envs/:env/role_users'
-        },
-        // 所有环境授权
         assign_app_role_to_user: {
             method: 'POST',
             url: '/apps/:appId/roles/:roleType',
@@ -75,7 +72,6 @@ appService.service('PermissionService', ['$resource', '$q', function ($resource,
                  'Content-Type': 'text/plain;charset=UTF-8'
             }
         },
-        // 根据环境授权
         assign_app_env_role_to_user: {
             method: 'POST',
             url: '/apps/:appId/envs/:env/roles/:roleType',
@@ -87,7 +83,6 @@ appService.service('PermissionService', ['$resource', '$q', function ($resource,
             method: 'DELETE',
             url: '/apps/:appId/roles/:roleType?user=:user'
         },
-        // 删除指定环境的授权
         remove_app_env_role_from_user: {
             method: 'DELETE',
             url: '/apps/:appId/envs/:env/roles/:roleType?user=:user'
@@ -231,12 +226,11 @@ appService.service('PermissionService', ['$resource', '$q', function ($resource,
      * @param user
      * @returns {*|promise|d}
      */
-    function assignViewerRoleToUser(appId, roleType, user) {
+    function assignViewRoleToUser(appId, roleType, user) {
         var d = $q.defer();
         permission_resource.assign_app_role_to_user({
                 appId: appId,
-                roleType: roleType,
-                env: env
+                roleType: roleType
             }, user,
             function (result) {
                 d.resolve(result);
@@ -246,7 +240,7 @@ appService.service('PermissionService', ['$resource', '$q', function ($resource,
         return d.promise;
     }
 
-    function assignViewerEnvRoleToUser(appId, roleType, env, user) {
+    function assignViewEnvRoleToUser(appId, roleType, env, user) {
         var d = $q.defer();
         permission_resource.assign_app_env_role_to_user({
                 appId: appId,
@@ -269,7 +263,7 @@ appService.service('PermissionService', ['$resource', '$q', function ($resource,
      * @param user
      * @returns {*|promise|d}
      */
-    function removeViewerRoleFromUser(appId, roleType, user) {
+    function removeViewRoleFromUser(appId, roleType, user) {
         var d = $q.defer();
         permission_resource.remove_app_role_from_user({
             appId: appId,
@@ -285,7 +279,7 @@ appService.service('PermissionService', ['$resource', '$q', function ($resource,
         return d.promise;
     }
 
-    function removeViewerEnvRoleFromUser(appId, roleType, env, user) {
+    function removeViewEnvRoleFromUser(appId, roleType, env, user) {
         var d = $q.defer();
         permission_resource.remove_app_env_role_from_user({
                 appId: appId,
@@ -344,10 +338,10 @@ appService.service('PermissionService', ['$resource', '$q', function ($resource,
         has_release_namespace_env_permission: function (appId, env, namespaceName) {
             return hasNamespaceEnvPermission(appId, env, namespaceName, 'ReleaseNamespace');
         },
-        has_viewer_permission: function(appId){
+        has_view_permission: function(appId){
             return hasAppPermission(appId, 'BrowseConfig');
         },
-        has_viewer_env_permission: function(appId, env) {
+        has_view_env_permission: function(appId, env) {
             return hasAppEnvPermission(appId, env, 'BrowseConfig');
         },
         has_root_permission: function () {
@@ -393,11 +387,11 @@ appService.service('PermissionService', ['$resource', '$q', function ($resource,
          * @param user
          * @returns {*|promise|d}
          */
-        assign_viewer_role: function (appId, user) {
-          return assignViewerRoleToUser(appId, 'Viewer', user);
+        assign_view_role: function (appId, user) {
+          return assignViewRoleToUser(appId, 'View', user);
         },
-        assign_viewer_env_role: function(appId, env, user) {
-            return assignViewerEnvRoleToUser(appId, "Viewer", env, user);
+        assign_view_env_role: function(appId, env, user) {
+            return assignViewEnvRoleToUser(appId, "View", env, user);
         },
 
         /**
@@ -405,12 +399,12 @@ appService.service('PermissionService', ['$resource', '$q', function ($resource,
          * @param appId
          * @param user
          */
-        remove_viewer_role: function (appId, user) {
-            return removeViewerRoleFromUser(appId, 'Viewer', user);
+        remove_view_role: function (appId, user) {
+            return removeViewRoleFromUser(appId, 'View', user);
         },
 
-        remove_viewer_env_role: function(appId, env, user) {
-            return removeViewerEnvRoleFromUser(appId, 'Viewer', env, user);
+        remove_view_env_role: function(appId, env, user) {
+            return removeViewEnvRoleFromUser(appId, 'View', env, user);
         },
 
         get_namespace_role_users: function (appId, namespaceName) {

--- a/apollo-portal/src/main/resources/static/scripts/services/PermissionService.js
+++ b/apollo-portal/src/main/resources/static/scripts/services/PermissionService.js
@@ -11,6 +11,10 @@ appService.service('PermissionService', ['$resource', '$q', function ($resource,
             method: 'GET',
             url: '/apps/:appId/permissions/:permissionType'
         },
+        has_app_env_permission: {
+            method: 'GET',
+            url: '/apps/:appId/envs/:env/permissions/:permissionType'
+        },
         has_namespace_permission: {
             method: 'GET',
             url: '/apps/:appId/namespaces/:namespaceName/permissions/:permissionType'
@@ -117,6 +121,28 @@ appService.service('PermissionService', ['$resource', '$q', function ($resource,
         return d.promise;
     }
 
+    /**
+     * 是否拥有app级别的以环境区分的权限
+     * @param appId
+     * @param env
+     * @param permissionType
+     * @returns {*|promise|d}
+     */
+    function hasAppEnvPermission(appId, env, permissionType) {
+        var d = $q.defer();
+        permission_resource.has_app_env_permission({
+                appId: appId,
+                permissionType: permissionType,
+                env: env
+            },
+            function (result) {
+                d.resolve(result);
+            }, function (result) {
+                d.reject(result);
+            });
+        return d.promise;
+    }
+
     function hasNamespacePermission(appId, namespaceName, permissionType) {
         var d = $q.defer();
         permission_resource.has_namespace_permission({
@@ -147,6 +173,8 @@ appService.service('PermissionService', ['$resource', '$q', function ($resource,
             });
         return d.promise;
     }
+
+
 
     function assignNamespaceRoleToUser(appId, namespaceName, roleType, user) {
         var d = $q.defer();
@@ -315,6 +343,12 @@ appService.service('PermissionService', ['$resource', '$q', function ($resource,
         },
         has_release_namespace_env_permission: function (appId, env, namespaceName) {
             return hasNamespaceEnvPermission(appId, env, namespaceName, 'ReleaseNamespace');
+        },
+        has_viewer_permission: function(appId){
+            return hasAppPermission(appId, 'BrowseConfig');
+        },
+        has_viewer_env_permission: function(appId, env) {
+            return hasAppEnvPermission(appId, env, 'BrowseConfig');
         },
         has_root_permission: function () {
             var d = $q.defer();

--- a/apollo-portal/src/main/resources/static/scripts/services/PermissionService.js
+++ b/apollo-portal/src/main/resources/static/scripts/services/PermissionService.js
@@ -478,33 +478,6 @@ appService.service('PermissionService', ['$resource', '$q', function ($resource,
                     d.reject(result);
                 });
             return d.promise;
-        },
-        assign_viewer_role: function (appId, user) {
-            var d = $q.defer();
-            permission_resource.assign_app_role_to_user({
-                    appId: appId,
-                    roleType: 'Viewer'
-                }, user,
-                function (result) {
-                    d.resolve(result);
-                }, function (result) {
-                    d.reject(result);
-                });
-            return d.promise;
-        },
-        remove_viewer_role: function (appId, user) {
-        var d = $q.defer();
-        permission_resource.remove_app_role_from_user({
-                appId: appId,
-                roleType: 'Viewer',
-                user: user
-            },
-            function (result) {
-                d.resolve(result);
-            }, function (result) {
-                d.reject(result);
-            });
-        return d.promise;
-    }
+        }
     }
 }]);

--- a/apollo-portal/src/main/resources/static/scripts/services/UserService.js
+++ b/apollo-portal/src/main/resources/static/scripts/services/UserService.js
@@ -8,6 +8,10 @@ appService.service('UserService', ['$resource', '$q', function ($resource, $q) {
             method: 'GET',
             url: '/users'
         },
+        find_user_list: {
+            method: 'GET',
+            url: '/user/list'
+        },
         create_or_update_user: {
             method: 'POST',
             url: '/users'
@@ -39,6 +43,17 @@ appService.service('UserService', ['$resource', '$q', function ($resource, $q) {
                                      function (result) {
                                          d.reject(result);
                                      });
+            return d.promise;
+        },
+        find_user_list: function () {
+            var d = $q.defer();
+            user_resource.find_user_list(
+                function (result) {
+                    d.resolve(result);
+                },
+                function (result) {
+                    d.reject(result);
+                });
             return d.promise;
         },
         createOrUpdateUser: function (user) {

--- a/apollo-portal/src/main/resources/static/views/common/nav.html
+++ b/apollo-portal/src/main/resources/static/views/common/nav.html
@@ -25,10 +25,9 @@
                         <span class="glyphicon glyphicon-question-sign"></span> 帮助
                     </a>
                 </li>
-                <li class="dropdown" ng-if="hasRootPermission">
+                <li class="dropdown" >
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
-                        <span class="glyphicon glyphicon-cog"></span>&nbsp;管理员工具
-                        <span class="caret"></span></a>
+                        <span class="glyphicon glyphicon-cog"></span>&nbsp;管理员工具<span class="caret"></span></a>
                     <ul class="dropdown-menu">
                         <li><a href="/user-manage.html" target="_blank">用户管理</a></li>
                         <li><a href="/open/manage.html" target="_blank">开放平台授权管理</a></li>
@@ -42,6 +41,7 @@
                         <span class="glyphicon glyphicon-user"></span>&nbsp;{{userName}}
                         <span class="caret"></span></a>
                     <ul class="dropdown-menu">
+                        <li><a href="/user/logout">个人信息</a></li>
                         <li><a href="/user/logout">退出</a></li>
                     </ul>
                 </li>

--- a/apollo-portal/src/main/resources/static/views/common/nav.html
+++ b/apollo-portal/src/main/resources/static/views/common/nav.html
@@ -41,7 +41,6 @@
                         <span class="glyphicon glyphicon-user"></span>&nbsp;{{userName}}
                         <span class="caret"></span></a>
                     <ul class="dropdown-menu">
-                        <li><a href="/user/logout">个人信息</a></li>
                         <li><a href="/user/logout">退出</a></li>
                     </ul>
                 </li>

--- a/apollo-portal/src/main/resources/static/views/component/namespace-panel-master-tab.html
+++ b/apollo-portal/src/main/resources/static/views/component/namespace-panel-master-tab.html
@@ -84,13 +84,6 @@
                 </a>
 
                 <a type="button" class="btn btn-default btn-sm J_tableview_btn"
-                   data-tooltip="tooltip" data-placement="bottom" title="您没有查看配置的权限,请申请"
-                   ng-click="showNoViewPermissionDialog()"
-                   ng-show="!namespace.hasViewerPermission">
-                    申请查看权限
-                </a>
-
-                <a type="button" class="btn btn-default btn-sm J_tableview_btn"
                    data-tooltip="tooltip" data-placement="bottom" title="您没有任何配置权限,请申请"
                    ng-click="showNoModifyPermissionDialog()"
                    ng-show="!namespace.hasModifyPermission && !namespace.hasReleasePermission">
@@ -955,6 +948,12 @@
                         无实例信息
                     </div>
                 </div>
+            </div>
+        </section>
+
+        <section class="context" ng-show="!namespace.hasViewerPermission">
+            <div class="panel-body text-center">
+                <h4>您没有权限查看该配置，请找管理员授权</h4>
             </div>
         </section>
     </div>

--- a/apollo-portal/src/main/resources/static/views/component/namespace-panel-master-tab.html
+++ b/apollo-portal/src/main/resources/static/views/component/namespace-panel-master-tab.html
@@ -40,14 +40,17 @@
 
             <div class="col-md-6 col-sm-6 text-right header-buttons">
 
+                <!-- 拥有发布权限的时候才显示发布按钮 -->
                 <button type="button" class="btn btn-success btn-sm"
                         data-tooltip="tooltip" data-placement="bottom" title="发布配置"
-                        ng-show="(namespace.hasReleasePermission || namespace.hasModifyPermission)"
+                        ng-show="(namespace.hasReleasePermission)"
                         ng-disabled="namespace.isTextEditing"
                         ng-click="publish(namespace)">
                     <img src="img/release.png">
                     发布
                 </button>
+
+                <!-- 拥有发布权限的时候才显示发布回滚按钮 -->
                 <button type="button" class="btn btn-default btn-sm"
                         data-tooltip="tooltip" data-placement="bottom" title="回滚已发布配置"
                         ng-show="namespace.hasReleasePermission"
@@ -55,7 +58,10 @@
                     <img src="img/rollback.png">
                     回滚
                 </button>
-                <a type="button" class="btn btn-default btn-sm"
+
+
+                <!-- 拥有发布权限的时候才显示发布历史按钮 -->
+                <a type="button" class="btn btn-default btn-sm" ng-show="(namespace.hasReleasePermission)"
                    data-tooltip="tooltip" data-placement="bottom" title="查看发布历史"
                    href="/config/history.html?#/appid={{appId}}&env={{env}}&clusterName={{cluster}}&namespaceName={{namespace.baseInfo.namespaceName}}">
                     <img src="img/release-history.png">

--- a/apollo-portal/src/main/resources/static/views/component/namespace-panel-master-tab.html
+++ b/apollo-portal/src/main/resources/static/views/component/namespace-panel-master-tab.html
@@ -84,6 +84,13 @@
                 </a>
 
                 <a type="button" class="btn btn-default btn-sm J_tableview_btn"
+                   data-tooltip="tooltip" data-placement="bottom" title="您没有查看配置的权限,请申请"
+                   ng-click="showNoViewPermissionDialog()"
+                   ng-show="!namespace.hasViewerPermission">
+                    申请查看权限
+                </a>
+
+                <a type="button" class="btn btn-default btn-sm J_tableview_btn"
                    data-tooltip="tooltip" data-placement="bottom" title="您没有任何配置权限,请申请"
                    ng-click="showNoModifyPermissionDialog()"
                    ng-show="!namespace.hasModifyPermission && !namespace.hasReleasePermission">
@@ -205,7 +212,8 @@
         </header>
 
         <!--namespace body-->
-        <section ng-show="!namespace.isConfigHidden">
+        <!-- 拥有查看权限才给显示 -->
+        <section ng-show="!namespace.isConfigHidden && namespace.hasViewerPermission">
             <!--table view-->
             <div class="namespace-view-table" ng-show="namespace.viewType == 'table'">
 

--- a/apollo-portal/src/main/resources/static/views/component/namespace-panel-master-tab.html
+++ b/apollo-portal/src/main/resources/static/views/component/namespace-panel-master-tab.html
@@ -206,7 +206,7 @@
 
         <!--namespace body-->
         <!-- 拥有查看权限才给显示 -->
-        <section ng-show="!namespace.isConfigHidden && namespace.hasViewerPermission">
+        <section ng-show="!namespace.isConfigHidden && namespace.hasViewPermission">
             <!--table view-->
             <div class="namespace-view-table" ng-show="namespace.viewType == 'table'">
 
@@ -951,7 +951,7 @@
             </div>
         </section>
 
-        <section class="context" ng-show="!namespace.hasViewerPermission">
+        <section class="context" ng-show="!namespace.hasViewPermission">
             <div class="panel-body text-center">
                 <h4>您没有权限查看该配置，请找管理员授权</h4>
             </div>


### PR DESCRIPTION
1.新增查看权限，新增后系统对配置的操作权限分为："查看配置", "修改配置", "发布配置";经过测试的"查看权限"有：
	1.1 按照不同环境授权用户是否可以查看配置
	1.2 按照不同集群授权用户是否可以查看配置
2.将发布按钮的显示权限由(namespace.hasReleasePermission || namespace.hasModifyPermission)改为(namespace.hasReleasePermission)，即拥有发布权限的时候才显示
3.将发布历史按钮新增了显示权限，修改为namespace.hasReleasePermission，即拥有发布权限的时候才允许查看发布历史