### PR TITLE
add other info to printLog when an exception occurs to an HTTP reques…

### DIFF
--- a/apollo-common/src/main/java/com/ctrip/framework/apollo/common/controller/GlobalDefaultExceptionHandler.java
+++ b/apollo-common/src/main/java/com/ctrip/framework/apollo/common/controller/GlobalDefaultExceptionHandler.java
@@ -8,6 +8,7 @@ import com.google.gson.reflect.TypeToken;
 import java.lang.reflect.Type;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -75,7 +76,7 @@ public class GlobalDefaultExceptionHandler {
 
   @ExceptionHandler(MethodArgumentNotValidException.class)
   public ResponseEntity<Map<String, Object>> handleMethodArgumentNotValidException(
-      HttpServletRequest request, MethodArgumentNotValidException ex
+          HttpServletRequest request, MethodArgumentNotValidException ex
   ) {
     final Optional<ObjectError> firstError = ex.getBindingResult().getAllErrors().stream().findFirst();
     if (firstError.isPresent()) {
@@ -87,7 +88,7 @@ public class GlobalDefaultExceptionHandler {
 
   @ExceptionHandler(ConstraintViolationException.class)
   public ResponseEntity<Map<String, Object>> handleConstraintViolationException(
-      HttpServletRequest request, ConstraintViolationException ex
+          HttpServletRequest request, ConstraintViolationException ex
   ) {
     return handleError(request, BAD_REQUEST, new BadRequestException(ex.getMessage()));
   }
@@ -100,7 +101,7 @@ public class GlobalDefaultExceptionHandler {
   private ResponseEntity<Map<String, Object>> handleError(HttpServletRequest request,
                                                           HttpStatus status, Throwable ex, Level logLevel) {
     String message = ex.getMessage();
-    printLog(message, ex, logLevel);
+    printLog(message, ex, logLevel, request);
 
     Map<String, Object> errorAttributes = new HashMap<>();
     boolean errorHandled = false;
@@ -120,7 +121,7 @@ public class GlobalDefaultExceptionHandler {
       errorAttributes.put("status", status.value());
       errorAttributes.put("message", message);
       errorAttributes.put("timestamp",
-          LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME));
+              LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME));
       errorAttributes.put("exception", ex.getClass().getName());
 
     }
@@ -131,7 +132,9 @@ public class GlobalDefaultExceptionHandler {
   }
 
   //打印日志, 其中logLevel为日志级别: ERROR/WARN/DEBUG/INFO/TRACE
-  private void printLog(String message, Throwable ex, Level logLevel) {
+  private void printLog(String message, Throwable ex, Level logLevel, HttpServletRequest request) {
+    message = String.format("message:%s;url:%s,httpInputParams:%s,ip:%s",
+            message, request.getRequestURL(), getInputParams(request), getIpAddr(request));
     switch (logLevel) {
       case ERROR:
         logger.error(message, ex);
@@ -151,6 +154,46 @@ public class GlobalDefaultExceptionHandler {
     }
 
     Tracer.logError(ex);
+  }
+
+  /**
+   * 获取请求参数
+   * @param request
+   * @return
+   */
+  private Map getInputParams(HttpServletRequest request) {
+    Map<String, String> map = new HashMap();
+    Enumeration paramNames = request.getParameterNames();
+    while (paramNames.hasMoreElements()) {
+      String paramName = (String) paramNames.nextElement();
+      String[] paramValues = request.getParameterValues(paramName);
+      if (paramValues.length == 1) {
+        String paramValue = paramValues[0];
+        if (paramValue.length() != 0) {
+          map.put(paramName, paramValue);
+        }
+      }
+    }
+    return map;
+  }
+
+  /**
+   * 获取 ip 地址
+   * @param request
+   * @return
+   */
+  public String getIpAddr(HttpServletRequest request) {
+    String ip = request.getHeader("x-forwarded-for");
+    if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
+      ip = request.getHeader("Proxy-Client-IP");
+    }
+    if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
+      ip = request.getHeader("WL-Proxy-Client-IP");
+    }
+    if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
+      ip = request.getRemoteAddr();
+    }
+    return ip;
   }
 
 }


### PR DESCRIPTION
### Scenario:
Multiple clients access the config service. When problems arise, it is impossible to locate which client and what requests were made according to the log.

### Solution:
edit 'GlobalDefaultExceptionHandler.java',it will add additional information to log when an exception occurs to an HTTP request。The additional information includes ip、url、httpInputParams ...

### Example:
HTTP eg:

> curl http://192.168.0.1:8080/notifications/v2?appId=11&cluster=default&notifications=

log out:

> 2019-02-28 17:28:45.858 ERROR 99598 --- [nio-8080-exec-1] .c.f.a.c.c.GlobalDefaultExceptionHandler : message:Invalid format of notifications: ;url:http://192.168.0.1:8080/notifications/v2,httpInputParams:{cluster=default, appId=11},ip:192.168.40.34
