### PR TITLE
修改了基于docker部署的:打包类型以及dockerfilez中解压方式

### DIFF
--- a/apollo-adminservice/src/assembly/assembly-descriptor.xml
+++ b/apollo-adminservice/src/assembly/assembly-descriptor.xml
@@ -4,7 +4,7 @@
 	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd">
 	<id>apollo-assembly</id>
 	<formats>
-		<format>zip</format>
+		<format>tar.gz</format>
 	</formats>
 	<includeBaseDirectory>false</includeBaseDirectory>
 	<fileSets>

--- a/apollo-adminservice/src/main/docker/Dockerfile
+++ b/apollo-adminservice/src/main/docker/Dockerfile
@@ -8,17 +8,13 @@ MAINTAINER ameizi <sxyx2008@163.com>
 
 ENV VERSION 1.4.0-SNAPSHOT
 
-RUN echo "http://mirrors.aliyun.com/alpine/v3.8/main" > /etc/apk/repositories \
-    && echo "http://mirrors.aliyun.com/alpine/v3.8/community" >> /etc/apk/repositories \
-    && apk update upgrade \
-    && apk add --no-cache procps unzip curl bash tzdata \
-    && ln -sf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime \
+RUN ln -sf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime \
     && echo "Asia/Shanghai" > /etc/timezone
 
-ADD apollo-adminservice-${VERSION}-github.zip /apollo-adminservice/apollo-adminservice-${VERSION}-github.zip
+ADD apollo-adminservice-${VERSION}-github.tar.gz /apollo-adminservice/apollo-adminservice-${VERSION}-github.tar.gz
 
-RUN unzip /apollo-adminservice/apollo-adminservice-${VERSION}-github.zip -d /apollo-adminservice \
-    && rm -rf /apollo-adminservice/apollo-adminservice-${VERSION}-github.zip \
+RUN tar -zxvf /apollo-adminservice/apollo-adminservice-${VERSION}-github.tar.gz -C /apollo-adminservice \
+    && rm -rf /apollo-adminservice/apollo-adminservice-${VERSION}-github.tar.gz \
     && sed -i '$d' /apollo-adminservice/scripts/startup.sh \
     && echo "tail -f /dev/null" >> /apollo-adminservice/scripts/startup.sh
 

--- a/apollo-configservice/src/assembly/assembly-descriptor.xml
+++ b/apollo-configservice/src/assembly/assembly-descriptor.xml
@@ -4,7 +4,7 @@
 	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd">
 	<id>apollo-assembly</id>
 	<formats>
-		<format>zip</format>
+		<format>tar.gz</format>
 	</formats>
 	<includeBaseDirectory>false</includeBaseDirectory>
 	<fileSets>

--- a/apollo-configservice/src/main/docker/Dockerfile
+++ b/apollo-configservice/src/main/docker/Dockerfile
@@ -8,17 +8,13 @@ MAINTAINER ameizi <sxyx2008@163.com>
 
 ENV VERSION 1.4.0-SNAPSHOT
 
-RUN echo "http://mirrors.aliyun.com/alpine/v3.8/main" > /etc/apk/repositories \
-    && echo "http://mirrors.aliyun.com/alpine/v3.8/community" >> /etc/apk/repositories \
-    && apk update upgrade \
-    && apk add --no-cache procps unzip curl bash tzdata \
-    && ln -sf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime \
+RUN ln -sf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime \
     && echo "Asia/Shanghai" > /etc/timezone
 
-ADD apollo-configservice-${VERSION}-github.zip /apollo-configservice/apollo-configservice-${VERSION}-github.zip
+ADD apollo-configservice-${VERSION}-github.tar.gz /apollo-configservice/apollo-configservice-${VERSION}-github.tar.gz
 
-RUN unzip /apollo-configservice/apollo-configservice-${VERSION}-github.zip -d /apollo-configservice \
-    && rm -rf /apollo-configservice/apollo-configservice-${VERSION}-github.zip \
+RUN tar -zxvf /apollo-configservice/apollo-configservice-${VERSION}-github.tar.gz -C /apollo-configservice \
+    && rm -rf /apollo-configservice/apollo-configservice-${VERSION}-github.tar.gz \
     && sed -i '$d' /apollo-configservice/scripts/startup.sh \
     && echo "tail -f /dev/null" >> /apollo-configservice/scripts/startup.sh
 

--- a/apollo-portal/src/assembly/assembly-descriptor.xml
+++ b/apollo-portal/src/assembly/assembly-descriptor.xml
@@ -4,7 +4,7 @@
 	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd">
 	<id>apollo-assembly</id>
 	<formats>
-		<format>zip</format>
+		<format>tar.gz</format>
 	</formats>
 	<includeBaseDirectory>false</includeBaseDirectory>
 	<fileSets>

--- a/apollo-portal/src/main/docker/Dockerfile
+++ b/apollo-portal/src/main/docker/Dockerfile
@@ -8,17 +8,13 @@ MAINTAINER ameizi <sxyx2008@163.com>
 
 ENV VERSION 1.4.0-SNAPSHOT
 
-RUN echo "http://mirrors.aliyun.com/alpine/v3.8/main" > /etc/apk/repositories \
-    && echo "http://mirrors.aliyun.com/alpine/v3.8/community" >> /etc/apk/repositories \
-    && apk update upgrade \
-    && apk add --no-cache procps unzip curl bash tzdata \
-    && ln -sf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime \
+RUN ln -sf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime \
     && echo "Asia/Shanghai" > /etc/timezone
 
-ADD apollo-portal-${VERSION}-github.zip /apollo-portal/apollo-portal-${VERSION}-github.zip
+ADD apollo-portal-${VERSION}-github.tar.gz /apollo-portal/apollo-portal-${VERSION}-github.tar.gz
 
-RUN unzip /apollo-portal/apollo-portal-${VERSION}-github.zip -d /apollo-portal \
-    && rm -rf /apollo-portal/apollo-portal-${VERSION}-github.zip \
+RUN tar -zxvf /apollo-portal/apollo-portal-${VERSION}-github.tar.gz -C /apollo-portal \
+    && rm -rf /apollo-portal/apollo-portal-${VERSION}-github.tar.gz \
     && sed -i '$d' /apollo-portal/scripts/startup.sh \
     && echo "tail -f /dev/null" >> /apollo-portal/scripts/startup.sh
 


### PR DESCRIPTION
本人在基于docker部署服务的过程中，在docker服务器上解压zip文件以及apt方式安装unzip都无法成功，考虑到还有其他人也可能会遇到同样的问题，所以更改了项目的打包方式为tar.gz，dockerfile的解压方式也更改为了tar的方式，以期望能够跳过apt安装软件的过程。