### PR TITLE
Add OpenAPI to get application information

### DIFF
--- a/apollo-openapi/src/main/java/com/ctrip/framework/apollo/openapi/client/ApolloOpenApiClient.java
+++ b/apollo-openapi/src/main/java/com/ctrip/framework/apollo/openapi/client/ApolloOpenApiClient.java
@@ -6,6 +6,7 @@ import com.ctrip.framework.apollo.openapi.client.service.ItemOpenApiService;
 import com.ctrip.framework.apollo.openapi.client.service.NamespaceOpenApiService;
 import com.ctrip.framework.apollo.openapi.client.service.ReleaseOpenApiService;
 import com.ctrip.framework.apollo.openapi.dto.NamespaceReleaseDTO;
+import com.ctrip.framework.apollo.openapi.dto.OpenAppDTO;
 import com.ctrip.framework.apollo.openapi.dto.OpenAppNamespaceDTO;
 import com.ctrip.framework.apollo.openapi.dto.OpenEnvClusterDTO;
 import com.ctrip.framework.apollo.openapi.dto.OpenItemDTO;
@@ -17,11 +18,12 @@ import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import java.util.List;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.message.BasicHeader;
+
+import java.util.List;
 
 /**
  * This class contains collections of methods to access Apollo Open Api.
@@ -56,6 +58,20 @@ public class ApolloOpenApiClient {
    */
   public List<OpenEnvClusterDTO> getEnvClusterInfo(String appId) {
     return appService.getEnvClusterInfo(appId);
+  }
+
+  /**
+   * Get all App information
+   */
+  public List<OpenAppDTO> getAllApps() {
+    return appService.getAppsInfo(null);
+  }
+
+  /**
+   * Get App information by app ids
+   */
+  public List<OpenAppDTO> getAppsByIds(List<String> appIds) {
+    return appService.getAppsInfo(appIds);
   }
 
   /**

--- a/apollo-openapi/src/main/java/com/ctrip/framework/apollo/openapi/client/service/AppOpenApiService.java
+++ b/apollo-openapi/src/main/java/com/ctrip/framework/apollo/openapi/client/service/AppOpenApiService.java
@@ -1,6 +1,8 @@
 package com.ctrip.framework.apollo.openapi.client.service;
 
+import com.ctrip.framework.apollo.openapi.dto.OpenAppDTO;
 import com.ctrip.framework.apollo.openapi.dto.OpenEnvClusterDTO;
+import com.google.common.base.Joiner;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import java.lang.reflect.Type;
@@ -11,6 +13,8 @@ import org.apache.http.util.EntityUtils;
 
 public class AppOpenApiService extends AbstractOpenApiService {
   private static final Type OPEN_ENV_CLUSTER_DTO_LIST_TYPE = new TypeToken<List<OpenEnvClusterDTO>>() {
+  }.getType();
+  private static final Type OPEN_APP_DTO_LIST_TYPE = new TypeToken<List<OpenAppDTO>>() {
   }.getType();
 
   public AppOpenApiService(CloseableHttpClient client, String baseUrl, Gson gson) {
@@ -26,6 +30,21 @@ public class AppOpenApiService extends AbstractOpenApiService {
       return gson.fromJson(EntityUtils.toString(response.getEntity()), OPEN_ENV_CLUSTER_DTO_LIST_TYPE);
     } catch (Throwable ex) {
       throw new RuntimeException(String.format("Load env cluster information for appId: %s failed", appId), ex);
+    }
+  }
+
+  public List<OpenAppDTO> getAppsInfo(List<String> appIds) {
+    String path = "apps";
+
+    if (appIds != null && !appIds.isEmpty()) {
+      String param = Joiner.on(",").join(appIds);
+      path = String.format("apps?appIds=%s", escapeParam(param));
+    }
+
+    try (CloseableHttpResponse response = get(path)) {
+      return gson.fromJson(EntityUtils.toString(response.getEntity()), OPEN_APP_DTO_LIST_TYPE);
+    } catch (Throwable ex) {
+      throw new RuntimeException(String.format("Load app information for appIds: %s failed", appIds), ex);
     }
   }
 }

--- a/apollo-openapi/src/main/java/com/ctrip/framework/apollo/openapi/dto/OpenAppDTO.java
+++ b/apollo-openapi/src/main/java/com/ctrip/framework/apollo/openapi/dto/OpenAppDTO.java
@@ -1,0 +1,81 @@
+package com.ctrip.framework.apollo.openapi.dto;
+
+public class OpenAppDTO extends BaseDTO {
+
+  private String name;
+
+  private String appId;
+
+  private String orgId;
+
+  private String orgName;
+
+  private String ownerName;
+
+  private String ownerEmail;
+
+  public String getAppId() {
+    return appId;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getOrgId() {
+    return orgId;
+  }
+
+  public String getOrgName() {
+    return orgName;
+  }
+
+  public String getOwnerEmail() {
+    return ownerEmail;
+  }
+
+  public String getOwnerName() {
+    return ownerName;
+  }
+
+  public void setAppId(String appId) {
+    this.appId = appId;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public void setOrgId(String orgId) {
+    this.orgId = orgId;
+  }
+
+  public void setOrgName(String orgName) {
+    this.orgName = orgName;
+  }
+
+  public void setOwnerEmail(String ownerEmail) {
+    this.ownerEmail = ownerEmail;
+  }
+
+  public void setOwnerName(String ownerName) {
+    this.ownerName = ownerName;
+  }
+
+  @Override
+  public String toString() {
+    final StringBuilder sb = new StringBuilder("OpenAppDTO{");
+    sb.append("name='").append(name).append('\'');
+    sb.append(", appId='").append(appId).append('\'');
+    sb.append(", orgId='").append(orgId).append('\'');
+    sb.append(", orgName='").append(orgName).append('\'');
+    sb.append(", ownerName='").append(ownerName).append('\'');
+    sb.append(", ownerEmail='").append(ownerEmail).append('\'');
+    sb.append(", dataChangeCreatedBy='").append(dataChangeCreatedBy).append('\'');
+    sb.append(", dataChangeLastModifiedBy='").append(dataChangeLastModifiedBy).append('\'');
+    sb.append(", dataChangeCreatedTime=").append(dataChangeCreatedTime);
+    sb.append(", dataChangeLastModifiedTime=").append(dataChangeLastModifiedTime);
+    sb.append('}');
+    return sb.toString();
+  }
+}

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/util/OpenApiBeanUtils.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/util/OpenApiBeanUtils.java
@@ -1,20 +1,34 @@
 package com.ctrip.framework.apollo.openapi.util;
 
-import com.ctrip.framework.apollo.common.dto.*;
-import com.ctrip.framework.apollo.openapi.dto.*;
+import com.ctrip.framework.apollo.common.dto.GrayReleaseRuleDTO;
+import com.ctrip.framework.apollo.common.dto.GrayReleaseRuleItemDTO;
+import com.ctrip.framework.apollo.common.dto.ItemDTO;
+import com.ctrip.framework.apollo.common.dto.NamespaceLockDTO;
+import com.ctrip.framework.apollo.common.dto.ReleaseDTO;
+import com.ctrip.framework.apollo.common.entity.App;
+import com.ctrip.framework.apollo.common.entity.AppNamespace;
+import com.ctrip.framework.apollo.common.utils.BeanUtils;
+import com.ctrip.framework.apollo.openapi.dto.OpenAppDTO;
+import com.ctrip.framework.apollo.openapi.dto.OpenAppNamespaceDTO;
+import com.ctrip.framework.apollo.openapi.dto.OpenGrayReleaseRuleDTO;
+import com.ctrip.framework.apollo.openapi.dto.OpenGrayReleaseRuleItemDTO;
+import com.ctrip.framework.apollo.openapi.dto.OpenItemDTO;
+import com.ctrip.framework.apollo.openapi.dto.OpenNamespaceDTO;
+import com.ctrip.framework.apollo.openapi.dto.OpenNamespaceLockDTO;
+import com.ctrip.framework.apollo.openapi.dto.OpenReleaseDTO;
+import com.ctrip.framework.apollo.portal.entity.bo.ItemBO;
+import com.ctrip.framework.apollo.portal.entity.bo.NamespaceBO;
 import com.google.common.base.Preconditions;
 import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
-
-import com.ctrip.framework.apollo.common.entity.AppNamespace;
-import com.ctrip.framework.apollo.common.utils.BeanUtils;
-import com.ctrip.framework.apollo.portal.entity.bo.ItemBO;
-import com.ctrip.framework.apollo.portal.entity.bo.NamespaceBO;
-
 import org.springframework.util.CollectionUtils;
 
 import java.lang.reflect.Type;
-import java.util.*;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class OpenApiBeanUtils {
@@ -134,4 +148,18 @@ public class OpenApiBeanUtils {
     return grayReleaseRuleDTO;
   }
 
+  public static List<OpenAppDTO> transformFromApps(final List<App> apps) {
+    if (CollectionUtils.isEmpty(apps)) {
+      return Collections.emptyList();
+    }
+    return apps.stream()
+        .map(OpenApiBeanUtils::transformFromApp)
+        .collect(Collectors.toList());
+  }
+
+  public static OpenAppDTO transformFromApp(final App app) {
+    Preconditions.checkArgument(app != null);
+
+    return BeanUtils.transform(OpenAppDTO.class, app);
+  }
 }

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/v1/controller/AppController.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/v1/controller/AppController.java
@@ -1,16 +1,20 @@
 package com.ctrip.framework.apollo.openapi.v1.controller;
 
 import com.ctrip.framework.apollo.common.dto.ClusterDTO;
+import com.ctrip.framework.apollo.common.entity.App;
 import com.ctrip.framework.apollo.common.utils.BeanUtils;
 import com.ctrip.framework.apollo.core.enums.Env;
+import com.ctrip.framework.apollo.openapi.dto.OpenAppDTO;
 import com.ctrip.framework.apollo.openapi.dto.OpenEnvClusterDTO;
+import com.ctrip.framework.apollo.openapi.util.OpenApiBeanUtils;
 import com.ctrip.framework.apollo.portal.component.PortalSettings;
+import com.ctrip.framework.apollo.portal.service.AppService;
 import com.ctrip.framework.apollo.portal.service.ClusterService;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import com.google.common.collect.Sets;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.*;
 
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -20,10 +24,14 @@ public class AppController {
 
   private final PortalSettings portalSettings;
   private final ClusterService clusterService;
+  private final AppService appService;
 
-  public AppController(final PortalSettings portalSettings, final ClusterService clusterService) {
+  public AppController(final PortalSettings portalSettings,
+                       final ClusterService clusterService,
+                       final AppService appService) {
     this.portalSettings = portalSettings;
     this.clusterService = clusterService;
+    this.appService = appService;
   }
 
   @GetMapping(value = "/apps/{appId}/envclusters")
@@ -46,4 +54,14 @@ public class AppController {
 
   }
 
+  @GetMapping("/apps")
+  public List<OpenAppDTO> findApps(@RequestParam(value = "appIds", required = false) String appIds) {
+    final List<App> apps = new ArrayList<>();
+    if (StringUtils.isEmpty(appIds)) {
+      apps.addAll(appService.findAll());
+    } else {
+      apps.addAll(appService.findByAppIds(Sets.newHashSet(appIds.split(","))));
+    }
+    return OpenApiBeanUtils.transformFromApps(apps);
+  }
 }


### PR DESCRIPTION
This patch exposes a new Open API (/apps) to allow third-party client to get application information, as stated in issue #1648 