### PR TITLE
xml定义的bean中scope=prototype时的热更新问题

### DIFF
--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/annotation/SpringValueProcessor.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/annotation/SpringValueProcessor.java
@@ -1,20 +1,11 @@
 package com.ctrip.framework.apollo.spring.annotation;
 
 import com.ctrip.framework.apollo.build.ApolloInjector;
-import com.ctrip.framework.apollo.spring.property.PlaceholderHelper;
-import com.ctrip.framework.apollo.spring.property.SpringValue;
-import com.ctrip.framework.apollo.spring.property.SpringValueDefinition;
-import com.ctrip.framework.apollo.spring.property.SpringValueDefinitionProcessor;
-import com.ctrip.framework.apollo.spring.property.SpringValueRegistry;
+import com.ctrip.framework.apollo.spring.property.*;
 import com.ctrip.framework.apollo.spring.util.SpringInjector;
 import com.ctrip.framework.apollo.util.ConfigUtil;
 import com.google.common.collect.LinkedListMultimap;
 import com.google.common.collect.Multimap;
-import java.beans.PropertyDescriptor;
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.util.Collection;
-import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeanUtils;
@@ -26,6 +17,12 @@ import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.context.annotation.Bean;
+
+import java.beans.PropertyDescriptor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Collection;
+import java.util.Set;
 
 /**
  * Spring value processor of field or method which has @Value and xml config placeholders.
@@ -148,7 +145,7 @@ public class SpringValueProcessor extends ApolloProcessor implements BeanFactory
     }
 
     // clear
-    beanName2SpringValueDefinitions.removeAll(beanName);
+    //beanName2SpringValueDefinitions.removeAll(beanName);
   }
 
   @Override

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/property/ScopeBeanPostProcessor.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/property/ScopeBeanPostProcessor.java
@@ -1,0 +1,129 @@
+package com.ctrip.framework.apollo.spring.property;
+
+import com.ctrip.framework.apollo.spring.util.SpringInjector;
+import com.google.common.collect.Multimap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.*;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.beans.factory.config.InstantiationAwareBeanPostProcessorAdapter;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.context.EnvironmentAware;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.PropertySourcesPropertyResolver;
+
+import java.beans.PropertyDescriptor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Collection;
+
+public class ScopeBeanPostProcessor extends InstantiationAwareBeanPostProcessorAdapter implements EnvironmentAware, BeanFactoryAware {
+    private ConfigurableEnvironment environment;
+    private BeanFactory beanFactory;
+    private PropertySourcesPropertyResolver propertySourcesPropertyResolver;
+    private final PlaceholderHelper placeholderHelper;
+    private TypeConverter typeConverter;
+    private static final Logger logger = LoggerFactory.getLogger(ScopeBeanPostProcessor.class);
+
+
+    public ScopeBeanPostProcessor() {
+        this.placeholderHelper = SpringInjector.getInstance(PlaceholderHelper.class);
+        ConfigurableBeanFactory configurableBeanFactory = (ConfigurableBeanFactory) this.beanFactory;
+
+    }
+
+
+    @Override
+    public PropertyValues postProcessPropertyValues(PropertyValues pvs, PropertyDescriptor[] pds, Object bean, String beanName) throws BeansException {
+        Multimap<String, SpringValueDefinition> beanName2SpringValueDefinitions = null;
+        if (beanFactory instanceof BeanDefinitionRegistry) {
+            beanName2SpringValueDefinitions = SpringValueDefinitionProcessor
+                    .getBeanName2SpringValueDefinitions((BeanDefinitionRegistry) beanFactory);
+        }
+
+        if (propertySourcesPropertyResolver == null) {
+            propertySourcesPropertyResolver = new PropertySourcesPropertyResolver(environment.getPropertySources());
+        }
+
+        if (typeConverter == null) {
+            ConfigurableBeanFactory configurableBeanFactory = (ConfigurableBeanFactory) beanFactory;
+            this.typeConverter = configurableBeanFactory.getTypeConverter();
+
+        }
+
+
+        Collection<SpringValueDefinition> propertySpringValues = beanName2SpringValueDefinitions
+                .get(beanName);
+        if (propertySpringValues == null || propertySpringValues.isEmpty()) {
+            //不进行处理
+            return super.postProcessPropertyValues(pvs, pds, bean, beanName);
+        }
+
+        for (PropertyValue propertyValue : pvs.getPropertyValues()) {
+            //获取 placeholder
+            String placeholder = null;
+            for (SpringValueDefinition springValueDefinition : propertySpringValues) {
+                if (springValueDefinition.getPropertyName().equals(propertyValue.getName())) {
+                    placeholder = springValueDefinition.getPlaceholder();
+                    break;
+                }
+            }
+            PropertyDescriptor pd = BeanUtils
+                    .getPropertyDescriptor(bean.getClass(), propertyValue.getName());
+            Method method = pd.getWriteMethod();
+            if (method == null) {
+                continue;
+            }
+            SpringValue springValue = new SpringValue(null, placeholder,
+                    bean, beanName, method, false);
+            Object resolverValue = resolvePropertyValue(springValue);
+
+            propertyValue.setConvertedValue(resolverValue);
+
+            propertyValue.getConvertedValue().getClass();
+        }
+
+        return pvs;
+    }
+
+    private boolean testTypeConverterHasConvertIfNecessaryWithFieldParameter() {
+        try {
+            TypeConverter.class.getMethod("convertIfNecessary", Object.class, Class.class, Field.class);
+        } catch (Throwable ex) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private Object resolvePropertyValue(SpringValue springValue) {
+        // value will never be null, as @Value and @ApolloJsonValue will not allow that
+        ConfigurableBeanFactory configurableBeanFactory = (ConfigurableBeanFactory) beanFactory;
+        Object value = placeholderHelper
+                .resolvePropertyValue(configurableBeanFactory, springValue.getBeanName(), springValue.getPlaceholder());
+
+
+        value = this.typeConverter.convertIfNecessary(value, springValue.getTargetType(),
+                springValue.getMethodParameter());
+
+
+        return value;
+    }
+
+
+    @Override
+    public void setEnvironment(Environment environment) {
+        this.environment = (ConfigurableEnvironment) environment;
+    }
+
+    @Override
+    public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
+        this.beanFactory = beanFactory;
+    }
+
+
+}
+

--- a/apollo-demo/src/main/java/com/ctrip/framework/apollo/demo/spring/common/bean/AnnotatedBean.java
+++ b/apollo-demo/src/main/java/com/ctrip/framework/apollo/demo/spring/common/bean/AnnotatedBean.java
@@ -1,21 +1,25 @@
 package com.ctrip.framework.apollo.demo.spring.common.bean;
 
 import com.ctrip.framework.apollo.spring.annotation.ApolloJsonValue;
-import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
 
 /**
  * @author Jason Song(song_s@ctrip.com)
  */
 @Component("annotatedBean")
+@Scope("prototype")
 public class AnnotatedBean {
   private static final Logger logger = LoggerFactory.getLogger(AnnotatedBean.class);
 
   private int timeout;
   private int batch;
+  private String databaseUrl;
   private List<JsonBean> jsonBeans;
 
   /**
@@ -38,6 +42,12 @@ public class AnnotatedBean {
     this.timeout = timeout;
   }
 
+  @Value("${database.url:empty}")
+  public void setDatabaseUrl(String databaseUrl) {
+    logger.info("updating databaseUrl, old value: {}, new value: {}", this.databaseUrl, databaseUrl);
+    this.databaseUrl = databaseUrl;
+  }
+
   /**
    * ApolloJsonValue annotated on methods example, the default value is specified as empty list - []
    * <br />
@@ -51,7 +61,7 @@ public class AnnotatedBean {
 
   @Override
   public String toString() {
-    return String.format("[AnnotatedBean] timeout: %d, batch: %d, jsonBeans: %s", timeout, batch, jsonBeans);
+    return String.format("[AnnotatedBean] timeout: %d, batch: %d, jsonBeans: %s, databaseUrl: %s", timeout, batch, jsonBeans, databaseUrl);
   }
 
   private static class JsonBean{

--- a/apollo-demo/src/main/java/com/ctrip/framework/apollo/demo/spring/javaConfigDemo/AnnotationApplication.java
+++ b/apollo-demo/src/main/java/com/ctrip/framework/apollo/demo/spring/javaConfigDemo/AnnotationApplication.java
@@ -3,11 +3,12 @@ package com.ctrip.framework.apollo.demo.spring.javaConfigDemo;
 import com.ctrip.framework.apollo.demo.spring.common.bean.AnnotatedBean;
 import com.google.common.base.Charsets;
 import com.google.common.base.Strings;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import org.springframework.context.ApplicationContext;
-import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
 
 /**
@@ -26,7 +27,13 @@ public class AnnotationApplication {
         System.exit(0);
       }
 
-      System.out.println(annotatedBean.toString());
+      System.out.println("【init】>> hashCode:"+ annotatedBean.hashCode()+ annotatedBean.toString());
+
+      if("new".equalsIgnoreCase(input)) {
+        AnnotatedBean annotatedBeanNew = context.getBean(AnnotatedBean.class);
+        System.out.println("【new】 >> hashCode:"+ annotatedBeanNew.hashCode() + annotatedBeanNew.toString());
+      }
+
     }
   }
 }

--- a/apollo-demo/src/main/java/com/ctrip/framework/apollo/demo/spring/xmlConfigDemo/XmlApplication.java
+++ b/apollo-demo/src/main/java/com/ctrip/framework/apollo/demo/spring/xmlConfigDemo/XmlApplication.java
@@ -1,15 +1,14 @@
 package com.ctrip.framework.apollo.demo.spring.xmlConfigDemo;
 
+import com.ctrip.framework.apollo.demo.spring.xmlConfigDemo.bean.XmlBean;
+import com.google.common.base.Charsets;
 import com.google.common.base.Strings;
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
-
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
-import com.ctrip.framework.apollo.demo.spring.xmlConfigDemo.bean.XmlBean;
-import com.google.common.base.Charsets;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
 
 /**
  * @author Jason Song(song_s@ctrip.com)
@@ -18,7 +17,7 @@ public class XmlApplication {
   public static void main(String[] args) throws IOException {
     ApplicationContext context = new ClassPathXmlApplicationContext("spring.xml");
     XmlBean xmlBean = context.getBean(XmlBean.class);
-
+    XmlBean xmlBeanNew = null;
     System.out.println("XmlApplication Demo. Input any key except quit to print the values. Input quit to exit.");
     while (true) {
       System.out.print("> ");
@@ -27,7 +26,14 @@ public class XmlApplication {
         System.exit(0);
       }
 
-      System.out.println(xmlBean.toString());
+      System.out.println("【init】>> xmlBean.hashCode:"+ xmlBean.hashCode()+ xmlBean.toString());
+
+      if("new".equalsIgnoreCase(input)) {
+        xmlBeanNew = context.getBean(XmlBean.class);
+        System.out.println("【new】 >> xmlBeanNew.hashCode:"+ xmlBeanNew.hashCode() + xmlBeanNew.toString());
+      } else if("sec".equalsIgnoreCase(input)) {
+        System.out.println("【sec】 >> xmlBeanNew.hashCode:"+ xmlBeanNew.hashCode() + xmlBeanNew.toString());
+      }
     }
   }
 }

--- a/apollo-demo/src/main/resources/spring.xml
+++ b/apollo-demo/src/main/resources/spring.xml
@@ -9,10 +9,10 @@
     <apollo:config order="10"/>
     <apollo:config namespaces="TEST1.apollo,application.yaml" order="11"/>
 
-    <bean class="com.ctrip.framework.apollo.demo.spring.xmlConfigDemo.bean.XmlBean">
+    <bean class="com.ctrip.framework.apollo.demo.spring.xmlConfigDemo.bean.XmlBean" scope="prototype">
         <property name="timeout" value="${timeout:200}"/>
         <property name="batch" value="${batch:100}"/>
     </bean>
-
+    <bean class="com.ctrip.framework.apollo.spring.property.ScopeBeanPostProcessor"></bean>
     <context:annotation-config />
 </beans>


### PR DESCRIPTION
在选用apollo的过程中发现，xml中定义的beans中，如果配置scope=prototype，则更新配置发布后，新实例化出来的bean中还是取到了旧的配置，发现是SpringValueProcessor中把把之前的注册信息给remove掉了，然后增加后处理器ScopeBeanPostProcessor.java