### PR TITLE
实现：通过注解对配置类的更新进行控制

### DIFF
--- a/apollo-client-extension/apollo-client-springboot-extension/pom.xml
+++ b/apollo-client-extension/apollo-client-springboot-extension/pom.xml
@@ -1,0 +1,42 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.ctrip.framework.apollo</groupId>
+    <artifactId>apollo-client-extension</artifactId>
+    <version>1.4.0</version>
+  </parent>
+  <artifactId>apollo-client-springboot-extension</artifactId>
+  <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>1.5.16.RELEASE</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>com.ctrip.framework.apollo</groupId>
+            <artifactId>apollo-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <!-- optional spring boot dependency -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+</project>

--- a/apollo-client-extension/apollo-client-springboot-extension/src/main/java/com/ctrip/framework/apollo/spring/boot/extension/ApolloRefreshConfigurationConfigChangeListener.java
+++ b/apollo-client-extension/apollo-client-springboot-extension/src/main/java/com/ctrip/framework/apollo/spring/boot/extension/ApolloRefreshConfigurationConfigChangeListener.java
@@ -1,0 +1,53 @@
+package com.ctrip.framework.apollo.spring.boot.extension;
+
+import java.lang.annotation.Annotation;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.ApplicationContext;
+
+import com.ctrip.framework.apollo.ConfigChangeListener;
+import com.ctrip.framework.apollo.model.ConfigChangeEvent;
+
+/**
+ * 
+ * {@link ConfigurationProperties} Automatic update listener implementation
+ * 
+ * @author wangbo(wangle_r@163.com)
+ */
+public class ApolloRefreshConfigurationConfigChangeListener implements ConfigChangeListener {
+  private static Logger logger = LoggerFactory.getLogger(ApolloRefreshConfigurationConfigChangeListener.class);
+  private Object bean;
+  private String beanName;
+  private ApplicationContext applicationContext;
+
+  private Annotation[] annotations;
+
+  private ConfigurationProperties annotation;
+
+  private ApolloRefreshConfigurationProperties apolloRefreshConfigurationProperties;
+
+  public ApolloRefreshConfigurationConfigChangeListener(Object bean, String beanName,
+      ConfigurationProperties annotation, Annotation[] annotations, ApplicationContext applicationContext) {
+    super();
+    this.bean = bean;
+    this.beanName = beanName;
+    this.annotation = annotation;
+    this.annotations = annotations;
+    this.applicationContext = applicationContext;
+  }
+
+  @Override
+  public void onChange(ConfigChangeEvent changeEvent) {
+
+    logger.info("Apollo config changeEvent namespace: {},  {} oldValue {}", changeEvent.getNamespace(), beanName, bean);
+    if (this.apolloRefreshConfigurationProperties == null) {
+      this.apolloRefreshConfigurationProperties = (ApolloRefreshConfigurationProperties) applicationContext
+          .getBean(ApolloRefreshConfigurationProperties.class);
+    }
+    apolloRefreshConfigurationProperties.binding(bean, beanName, annotation, annotations);
+    logger.info("Apollo config changeEvent : {} newValue {}", beanName, bean);
+
+  }
+}

--- a/apollo-client-extension/apollo-client-springboot-extension/src/main/java/com/ctrip/framework/apollo/spring/boot/extension/ApolloRefreshConfigurationProperties.java
+++ b/apollo-client-extension/apollo-client-springboot-extension/src/main/java/com/ctrip/framework/apollo/spring/boot/extension/ApolloRefreshConfigurationProperties.java
@@ -1,0 +1,453 @@
+package com.ctrip.framework.apollo.spring.boot.extension;
+
+import java.lang.annotation.Annotation;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Properties;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.ConfigurationBeanFactoryMetaData;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConfigurationPropertiesBinding;
+import org.springframework.boot.context.properties.ConfigurationPropertiesBindingPostProcessor;
+import org.springframework.boot.validation.MessageInterpolatorFactory;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.EnvironmentAware;
+import org.springframework.core.annotation.AnnotatedElementUtils;
+import org.springframework.core.convert.ConversionService;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.core.convert.converter.GenericConverter;
+import org.springframework.core.convert.support.DefaultConversionService;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.MutablePropertySources;
+import org.springframework.core.env.PropertiesPropertySource;
+import org.springframework.core.env.PropertySource;
+import org.springframework.core.env.PropertySources;
+import org.springframework.core.env.StandardEnvironment;
+import org.springframework.util.Assert;
+import org.springframework.util.ClassUtils;
+import org.springframework.util.StringUtils;
+import org.springframework.validation.Errors;
+import org.springframework.validation.Validator;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+
+import com.ctrip.framework.apollo.spring.annotation.AutoRefresh;
+import com.ctrip.framework.apollo.spring.annotation.RefreshEnabled;
+import com.ctrip.framework.apollo.spring.boot.AbstractRefreshConfigurationProperties;
+import com.ctrip.framework.apollo.spring.boot.BeanFactoryMetadata;
+import com.ctrip.framework.apollo.spring.util.ApolloRefreshUtil;
+
+/**
+ * {@link ConfigurationProperties} The specific implementation of automatic
+ * update update implementation
+ * 
+ * @author wangbo(wangle_r@163.com)
+ */
+public class ApolloRefreshConfigurationProperties extends AbstractRefreshConfigurationProperties
+    implements BeanFactoryAware, InitializingBean, ApplicationContextAware, EnvironmentAware {
+
+  /**
+   * The bean name of the configuration properties validator.
+   */
+  public static final String VALIDATOR_BEAN_NAME = "configurationPropertiesValidator";
+
+  private static final String[] VALIDATOR_CLASSES = { "javax.validation.Validator", "javax.validation.ValidatorFactory",
+      "javax.validation.bootstrap.GenericBootstrap" };
+
+  private Validator validator;
+
+  private volatile Validator localValidator;
+
+  private ConversionService conversionService;
+
+  private DefaultConversionService defaultConversionService;
+
+  private BeanFactory beanFactory;
+
+  private ApplicationContext applicationContext;
+
+  private List<Converter<?, ?>> converters = Collections.emptyList();
+
+  private List<GenericConverter> genericConverters = Collections.emptyList();
+
+  private BeanFactoryMetadata beanFactoryMetadata;
+
+  private Environment environment;
+
+  /**
+   * The bean name that this post-processor is registered with.
+   */
+  public static final String BEAN_NAME = ApolloRefreshConfigurationProperties.class.getName();
+
+  /**
+   * A list of custom converters (in addition to the defaults) to use when
+   * converting properties for binding.
+   * 
+   * @param converters the converters to set
+   */
+  @Autowired(required = false)
+  @ConfigurationPropertiesBinding
+  public void setConverters(List<Converter<?, ?>> converters) {
+    this.converters = converters;
+  }
+
+  /**
+   * A list of custom converters (in addition to the defaults) to use when
+   * converting properties for binding.
+   * 
+   * @param converters the converters to set
+   */
+  @Autowired(required = false)
+  @ConfigurationPropertiesBinding
+  public void setGenericConverters(List<GenericConverter> converters) {
+    this.genericConverters = converters;
+  }
+
+  /**
+   * Set the bean validator used to validate property fields.
+   * 
+   * @param validator the validator
+   */
+  public void setValidator(Validator validator) {
+    this.validator = validator;
+  }
+
+  /**
+   * Set the conversion service used to convert property values.
+   * 
+   * @param conversionService the conversion service
+   */
+  public void setConversionService(ConversionService conversionService) {
+    this.conversionService = conversionService;
+  }
+
+  @Override
+  public void setApplicationContext(ApplicationContext applicationContext) {
+    this.applicationContext = applicationContext;
+  }
+
+  @Override
+  public void afterPropertiesSet() throws Exception {
+    if (this.validator == null) {
+      this.validator = getOptionalBean(VALIDATOR_BEAN_NAME, Validator.class);
+    }
+    if (this.conversionService == null) {
+      this.conversionService = getOptionalBean(ConfigurableApplicationContext.CONVERSION_SERVICE_BEAN_NAME,
+          ConversionService.class);
+    }
+    ConfigurationBeanFactoryMetaData beans = (ConfigurationBeanFactoryMetaData) applicationContext
+        .getBean(ApolloRefreshConfigurationPropertiesProcessorRegistry.METADATA_BEAN_NAME);
+
+    this.beanFactoryMetadata = new ApolloSpringBeanFactoryMetadata(beans);
+  }
+
+  @Override
+  protected ApplicationContext getApplicationContext() {
+    return this.applicationContext;
+  }
+
+  @Override
+  public void setEnvironment(Environment environment) {
+    this.environment = environment;
+    
+  }
+
+  @Override
+  public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
+    this.beanFactory = beanFactory;
+  }
+
+
+  @Override
+  public void refreshBinding(Object bean, String beanName, Properties properties) {
+    Object target = bean;
+    if (bean instanceof String) {
+      target = this.applicationContext.getBean(beanName);
+    }
+    Class<?> clazz = target.getClass();
+    ConfigurationProperties annotation = ApolloRefreshUtil.findConfigurationPropertiesAnnotation(clazz, beanName,
+        this.beanFactoryMetadata);
+    if (annotation != null) {
+      binding(target, beanName, annotation,
+          ApolloRefreshUtil.findAutoRefreshAnnotation(clazz, beanName, this.beanFactoryMetadata),
+          ApolloRefreshUtil.findRefreshEnabledAnnotation(clazz, beanName, this.beanFactoryMetadata), properties);
+    }
+
+  }
+
+  void binding(Object bean, String beanName, ConfigurationProperties annotation, AutoRefresh autoRefresh,
+      RefreshEnabled refreshEnabled, Properties properties) {
+    if (annotation == null) {
+      return;
+    }
+
+    List<Annotation> annotations = new LinkedList<Annotation>();
+    annotations.add(annotation);
+    if (refreshEnabled != null) {
+      annotations.add(refreshEnabled);
+    }
+    if (autoRefresh != null) {
+      annotations.add(autoRefresh);
+    }
+    binding(bean, beanName, annotation, annotations.toArray(new Annotation[annotations.size()]), properties);
+
+  }
+  
+  void binding(Object bean, String beanName, ConfigurationProperties annotation, Annotation[] annotations) {
+    if (annotation == null) {
+      return;
+    }
+    binding(bean, beanName, annotation, annotations, null);
+
+  }
+
+  @SuppressWarnings("deprecation")
+  void binding(Object bean, String beanName, ConfigurationProperties annotation,
+      Annotation[] annotations, Properties properties) {
+    Object target = bean;
+    ApolloRefreshPropertiesConfigurationFactory<Object> factory = new ApolloRefreshPropertiesConfigurationFactory<Object>(target);
+
+    factory.setPropertySources(this.deducePropertySources(properties));
+    factory.setApplicationContext(this.applicationContext);
+    factory.setValidator(determineValidator(bean));
+    // If no explicit conversion service is provided we add one so that (at least)
+    // comma-separated arrays of convertibles can be bound automatically
+    factory
+        .setConversionService(this.conversionService != null ? this.conversionService : getDefaultConversionService());
+    factory.setIgnoreInvalidFields(annotation.ignoreInvalidFields());
+    factory.setIgnoreUnknownFields(annotation.ignoreUnknownFields());
+    factory.setExceptionIfInvalid(annotation.exceptionIfInvalid());
+    factory.setIgnoreNestedProperties(annotation.ignoreNestedProperties());
+    factory.setAnnotations(annotations);
+    if (StringUtils.hasLength(annotation.prefix())) {
+      factory.setTargetName(annotation.prefix());
+    }
+    try {
+      factory.bindPropertiesToTarget();
+    } catch (Exception ex) {
+      String targetClass = ClassUtils.getShortName(bean.getClass());
+      throw new BeanCreationException(beanName,
+          "Could not bind properties to " + targetClass + " (" + getAnnotationDetails(annotation) + ")", ex);
+    }
+  }
+
+  private <T> T getOptionalBean(String name, Class<T> type) {
+    try {
+      return this.beanFactory.getBean(name, type);
+    } catch (NoSuchBeanDefinitionException ex) {
+      return null;
+    }
+  }
+
+  private StandardEnvironment getPropertiesEnvironment(Properties properties) {
+    StandardEnvironment environment = new StandardEnvironment();
+    environment.getPropertySources().addFirst(new PropertiesPropertySource("APOLLO_UPDATE_PROPERTIES", properties));
+    return environment;
+  }
+
+  private PropertySources deducePropertySources(Properties properties) {
+    if (properties != null) {
+      return ((ConfigurableEnvironment) getPropertiesEnvironment(properties)).getPropertySources();
+    }
+
+    if (this.environment instanceof ConfigurableEnvironment) {
+      MutablePropertySources propertySources = ((ConfigurableEnvironment) this.environment).getPropertySources();
+      return new FlatPropertySources(propertySources);
+    }
+
+    return new MutablePropertySources();
+  }
+
+  private String getAnnotationDetails(ConfigurationProperties annotation) {
+    if (annotation == null) {
+      return "";
+    }
+    StringBuilder details = new StringBuilder();
+    details.append("prefix=").append(annotation.prefix());
+    details.append(", ignoreInvalidFields=").append(annotation.ignoreInvalidFields());
+    details.append(", ignoreUnknownFields=").append(annotation.ignoreUnknownFields());
+    details.append(", ignoreNestedProperties=").append(annotation.ignoreNestedProperties());
+    return details.toString();
+  }
+
+  private Validator determineValidator(Object bean) {
+    Validator validator = getValidator();
+    boolean supportsBean = (validator != null && validator.supports(bean.getClass()));
+    if (ClassUtils.isAssignable(Validator.class, bean.getClass())) {
+      if (supportsBean) {
+        return new ChainingValidator(validator, (Validator) bean);
+      }
+      return (Validator) bean;
+    }
+    return (supportsBean ? validator : null);
+  }
+
+  private Validator getValidator() {
+    if (this.validator != null) {
+      return this.validator;
+    }
+    if (this.localValidator == null && isJsr303Present()) {
+      this.localValidator = new ValidatedLocalValidatorFactoryBean(this.applicationContext);
+    }
+    return this.localValidator;
+  }
+
+  private boolean isJsr303Present() {
+    for (String validatorClass : VALIDATOR_CLASSES) {
+      if (!ClassUtils.isPresent(validatorClass, this.applicationContext.getClassLoader())) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private ConversionService getDefaultConversionService() {
+    if (this.defaultConversionService == null) {
+      DefaultConversionService conversionService = new DefaultConversionService();
+      this.applicationContext.getAutowireCapableBeanFactory().autowireBean(this);
+      for (Converter<?, ?> converter : this.converters) {
+        conversionService.addConverter(converter);
+      }
+      for (GenericConverter genericConverter : this.genericConverters) {
+        conversionService.addConverter(genericConverter);
+      }
+      this.defaultConversionService = conversionService;
+    }
+
+    return this.defaultConversionService;
+  }
+
+  /**
+   * {@link LocalValidatorFactoryBean} supports classes annotated with
+   * {@link Validated @Validated}.
+   */
+  private static class ValidatedLocalValidatorFactoryBean extends LocalValidatorFactoryBean {
+
+    private static final String HAS_ORG_SPRINGFRAMEWORK_BOOT = "org.springframework.boot";
+    private static final Log logger = LogFactory.getLog(ConfigurationPropertiesBindingPostProcessor.class);
+
+    ValidatedLocalValidatorFactoryBean(ApplicationContext applicationContext) {
+      setApplicationContext(applicationContext);
+      setMessageInterpolator(new MessageInterpolatorFactory().getObject());
+      afterPropertiesSet();
+    }
+
+    @Override
+    public boolean supports(Class<?> type) {
+      if (!super.supports(type)) {
+        return false;
+      }
+      if (AnnotatedElementUtils.hasAnnotation(type, Validated.class)) {
+        return true;
+      }
+      if (type.getPackage() != null && type.getPackage().getName().startsWith(HAS_ORG_SPRINGFRAMEWORK_BOOT)) {
+        return false;
+      }
+      if (getConstraintsForClass(type).isBeanConstrained()) {
+        logger.warn("The @ConfigurationProperties bean " + type
+            + " contains validation constraints but had not been annotated " + "with @Validated.");
+      }
+      return true;
+    }
+
+  }
+
+  /**
+   * {@link Validator} implementation that wraps {@link Validator} instances and
+   * chains their execution.
+   */
+  private static class ChainingValidator implements Validator {
+
+    private Validator[] validators;
+
+    ChainingValidator(Validator... validators) {
+      Assert.notNull(validators, "Validators must not be null");
+      this.validators = validators;
+    }
+
+    @Override
+    public boolean supports(Class<?> clazz) {
+      for (Validator validator : this.validators) {
+        if (validator.supports(clazz)) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    @Override
+    public void validate(Object target, Errors errors) {
+      for (Validator validator : this.validators) {
+        if (validator.supports(target.getClass())) {
+          validator.validate(target, errors);
+        }
+      }
+    }
+
+  }
+
+  /**
+   * Convenience class to flatten out a tree of property sources without losing
+   * the reference to the backing data (which can therefore be updated in the
+   * background).
+   */
+  private static class FlatPropertySources implements PropertySources {
+
+    private PropertySources propertySources;
+
+    FlatPropertySources(PropertySources propertySources) {
+      this.propertySources = propertySources;
+    }
+
+    @Override
+    public Iterator<PropertySource<?>> iterator() {
+      MutablePropertySources result = getFlattened();
+      return result.iterator();
+    }
+
+    @Override
+    public boolean contains(String name) {
+      return get(name) != null;
+    }
+
+    @Override
+    public PropertySource<?> get(String name) {
+      return getFlattened().get(name);
+    }
+
+    private MutablePropertySources getFlattened() {
+      MutablePropertySources result = new MutablePropertySources();
+      for (PropertySource<?> propertySource : this.propertySources) {
+        flattenPropertySources(propertySource, result);
+      }
+      return result;
+    }
+
+    private void flattenPropertySources(PropertySource<?> propertySource, MutablePropertySources result) {
+      Object source = propertySource.getSource();
+      if (source instanceof ConfigurableEnvironment) {
+        ConfigurableEnvironment environment = (ConfigurableEnvironment) source;
+        for (PropertySource<?> childSource : environment.getPropertySources()) {
+          flattenPropertySources(childSource, result);
+        }
+      } else {
+        result.addLast(propertySource);
+      }
+    }
+
+  }
+}

--- a/apollo-client-extension/apollo-client-springboot-extension/src/main/java/com/ctrip/framework/apollo/spring/boot/extension/ApolloRefreshConfigurationPropertiesProcessor.java
+++ b/apollo-client-extension/apollo-client-springboot-extension/src/main/java/com/ctrip/framework/apollo/spring/boot/extension/ApolloRefreshConfigurationPropertiesProcessor.java
@@ -1,0 +1,312 @@
+package com.ctrip.framework.apollo.spring.boot.extension;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+
+import com.ctrip.framework.apollo.Config;
+import com.ctrip.framework.apollo.ConfigChangeListener;
+import com.ctrip.framework.apollo.ConfigService;
+import com.ctrip.framework.apollo.build.ApolloInjector;
+import com.ctrip.framework.apollo.core.ConfigConsts;
+import com.ctrip.framework.apollo.spring.annotation.ApolloProcessor;
+import com.ctrip.framework.apollo.spring.annotation.AutoRefresh;
+import com.ctrip.framework.apollo.spring.annotation.RefreshEnabled;
+import com.ctrip.framework.apollo.spring.boot.BeanFactoryMetadata;
+import com.ctrip.framework.apollo.spring.config.PropertySourcesConstants;
+import com.ctrip.framework.apollo.spring.util.ApolloRefreshUtil;
+import com.ctrip.framework.apollo.util.ConfigUtil;
+import com.google.common.base.Strings;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.boot.context.properties.ConfigurationBeanFactoryMetaData;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.context.EnvironmentAware;
+import org.springframework.core.env.Environment;
+import org.springframework.util.ClassUtils;
+
+/**
+ * The automatic refresh of SpringBoot ConfigurationProperties is implemented
+ * 
+ * @author wangbo(wangle_r@163.com)
+ */
+public class ApolloRefreshConfigurationPropertiesProcessor extends ApolloProcessor
+    implements ApplicationContextAware, EnvironmentAware, InitializingBean {
+
+  private ConfigUtil                 configUtil;
+
+  private ConfigurationBeanFactoryMetaData beans                             = new ConfigurationBeanFactoryMetaData();
+  
+  private BeanFactoryMetadata beanFactoryMetadata;
+
+  private Environment                      environment;
+
+  private ApplicationContext               applicationContext;
+
+  private String[]                         namespaces;
+
+  private final Set<Object>                registryListeners                 = new HashSet<>();
+
+  private boolean                          autoUpdateConfigurationProperties = false;
+
+  private String[]                         autoUpdateConfigurationPropertiesBasePackages;
+
+  /**
+   * The bean name that this post-processor is registered with.
+   */
+  public static final String BEAN_NAME = ApolloRefreshConfigurationPropertiesProcessor.class.getName();
+  
+  public ApolloRefreshConfigurationPropertiesProcessor() {
+  }
+
+  /**
+   * Set the bean meta-data store.
+   * 
+   * @param beans the bean meta data store
+   */
+  public void setBeanMetaDataStore(ConfigurationBeanFactoryMetaData beans) {
+    this.beans = beans;
+  }
+
+  @Override
+  public Object postProcessBeforeInitialization(Object bean, String beanName) throws BeansException {
+    /**
+     * The Listener is registered when Apollo automatic update is enabled
+     */
+    if (configUtil.isAutoUpdateInjectedSpringPropertiesEnabled() && !registryListeners.contains(bean)) {
+      registryListener(bean, beanName);
+    }
+    return bean;
+  }
+
+  /**
+   * registry Listener
+   * 
+   * @param bean
+   * @param beanName
+   */
+  private void registryListener(Object bean, String beanName) {
+    Class<?> clazz = bean.getClass();
+    ConfigurationProperties annotation = ApolloRefreshUtil.findConfigurationPropertiesAnnotation(clazz, beanName, this.beanFactoryMetadata);
+    if (annotation != null) {
+      RefreshEnabled refreshEnabled = ApolloRefreshUtil.findRefreshEnabledAnnotation(clazz, beanName, this.beanFactoryMetadata);
+      AutoRefresh autoRefresh = ApolloRefreshUtil.findAutoRefreshAnnotation(bean.getClass(), beanName, this.beanFactoryMetadata);
+      boolean enabled = false;
+      if (refreshEnabled != null || autoRefresh != null) {
+        enabled = true;
+      } else if (ApolloRefreshUtil.findRefreshDisabledAnnotation(clazz, beanName, this.beanFactoryMetadata) != null) {
+        enabled = false;
+      } else {
+        enabled = isAutoUpdateConfigurationPropertiesEnabled(clazz, beanName);
+      }
+  
+      if (enabled) {
+        
+        registryListener(bean, beanName, annotation, refreshEnabled, autoRefresh);
+      }
+    }
+  }
+
+  private void registryListener(Object bean, String beanName, ConfigurationProperties annotation,
+                                RefreshEnabled refreshEnabled, AutoRefresh autoRefresh) {
+    //Record registration
+    registryListeners.add(bean);
+    //Handle listener parameters
+    Set<String> interestedKeyPrefixes = new LinkedHashSet<>();
+    Set<String> interestedKeys = new LinkedHashSet<>();
+    interestedKeyPrefixes.add(annotation.prefix());
+    String[] targetnamespaces = getNamespaces();
+    if (refreshEnabled != null) {
+      for (String interestedKeyPrefixe : refreshEnabled.interestedKeyPrefixes()) {
+        interestedKeyPrefixes.add(interestedKeyPrefixe);
+      }
+
+      for (String interestedKey : refreshEnabled.interestedKeys()) {
+        interestedKeys.add(interestedKey);
+      }
+      targetnamespaces = refreshEnabled.namespaces();
+      if (targetnamespaces.length == 0) {
+        targetnamespaces = getNamespaces();
+      }
+    } else {
+      /*
+       * In springboot @configurationproperties, get the parameters
+       * in @autorefresh if @autorefresh exists
+       */
+      autoRefresh = ApolloRefreshUtil.findAutoRefreshAnnotation(bean.getClass(), beanName, this.beanFactoryMetadata);
+      if (autoRefresh != null) {
+        for (String interestedKeyPrefixe : autoRefresh.interestedKeyPrefixes()) {
+          interestedKeyPrefixes.add(interestedKeyPrefixe);
+        }
+
+        for (String interestedKey : autoRefresh.interestedKeys()) {
+          interestedKeys.add(interestedKey);
+        }
+        targetnamespaces = autoRefresh.namespaces();
+        if (targetnamespaces.length == 0) {
+          targetnamespaces = getNamespaces();
+        }
+      }
+    }
+    List<Annotation> annotations = new LinkedList<Annotation>();
+    annotations.add(annotation);
+    if(refreshEnabled != null) {
+      annotations.add(refreshEnabled);
+    }
+    if(autoRefresh != null) {
+      annotations.add(autoRefresh);
+    }
+    //registry Listener
+    ConfigChangeListener configChangeListener = new ApolloRefreshConfigurationConfigChangeListener(bean, beanName,
+        annotation, annotations.toArray(new Annotation[annotations.size()]), applicationContext);
+    for (String namespace : targetnamespaces) {
+      Config config = ConfigService.getConfig(namespace);
+      config.addChangeListener(configChangeListener, interestedKeys, interestedKeyPrefixes);
+    }
+  }
+
+  /**
+   * Determines whether the automatic update configuration is enabled
+   * 
+   * @param clazz
+   * @param beanName
+   * @return
+   */
+  private boolean isAutoUpdateConfigurationPropertiesEnabled(Class<?> clazz, String beanName) {
+    boolean enabled = isAutoUpdateConfigurationPropertiesEnabled();
+    if (enabled) {
+      String packageName = ClassUtils.getPackageName(clazz);
+      enabled = isAutoUpdateConfigurationPropertiesBasePackages(packageName);
+      if (!enabled) {
+        String qualifiedName = packageName + "." + ClassUtils.getShortName(clazz);
+        enabled = isAutoUpdateConfigurationPropertiesBasePackages(qualifiedName);
+      }
+    }
+    return enabled;
+  }
+
+  @Override
+  public void setEnvironment(Environment environment) {
+    this.environment = environment;
+    this.initialize();
+  }
+
+  private void initAutoUpdateConfigurationProperties(Environment environment) {
+    autoUpdateConfigurationPropertiesBasePackages = new String[]{};
+    /**
+     * Deal with whether to enable AutoUpdateConfigurationProperties
+     */
+    String value = environment.getProperty(PropertySourcesConstants.APOLLO_AUTO_REFRESH_CONFIGURATION_PROPERTIE);
+    if (Strings.isNullOrEmpty(value)) {
+      autoUpdateConfigurationProperties = false;
+    } else if ("true".equalsIgnoreCase(value)) {
+      autoUpdateConfigurationProperties = true;
+    } else if (!Strings.isNullOrEmpty(value) && !"false".equalsIgnoreCase(value)) {
+      /**
+       * When an unpassed value is not false, the passed package or class name
+       * is indicated
+       */
+      autoUpdateConfigurationProperties = true;
+      autoUpdateConfigurationPropertiesBasePackages = value.split(",");
+      for (int i = 0; i < autoUpdateConfigurationPropertiesBasePackages.length; i++) {
+        autoUpdateConfigurationPropertiesBasePackages[i] = autoUpdateConfigurationPropertiesBasePackages[i].trim();
+      }
+    } else {
+      autoUpdateConfigurationProperties = false;
+    }
+  }
+
+  private void initNamespaces() {
+    String namespaceStr = environment.getProperty(PropertySourcesConstants.APOLLO_BOOTSTRAP_NAMESPACES);
+    if (Strings.isNullOrEmpty(namespaceStr)) {
+      namespaceStr = ConfigConsts.NAMESPACE_APPLICATION;
+    }
+    if (!Strings.isNullOrEmpty(namespaceStr)) {
+      namespaces = namespaceStr.split(",");
+    }
+  }
+
+  public String[] getNamespaces() {
+    return namespaces;
+  }
+
+  @Override
+  protected void processField(Object bean, String beanName, Field field) {
+
+  }
+
+  @Override
+  protected void processMethod(Object bean, String beanName, Method method) {
+
+  }
+
+  @Override
+  public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+    this.applicationContext = applicationContext;
+
+  }
+
+  /**
+   * Determines whether springboot ConfigurationProperties is enabled to
+   * automatically update the property values
+   * 
+   * @return
+   */
+  private boolean isAutoUpdateConfigurationPropertiesEnabled() {
+    return autoUpdateConfigurationProperties;
+  }
+
+  /**
+   * Determines whether the specified package (packageName) contains the
+   * specified BasePackages
+   * 
+   * @param packageName
+   * @return
+   */
+  private boolean isAutoUpdateConfigurationPropertiesBasePackages(String packageName) {
+    if (autoUpdateConfigurationPropertiesBasePackages == null) {
+      initAutoUpdateConfigurationProperties(environment);
+    }
+    if (autoUpdateConfigurationPropertiesBasePackages.length > 0) {
+      for (String string : autoUpdateConfigurationPropertiesBasePackages) {
+        if (string.equals(packageName)) {
+          return true;
+        }
+        //Is it subpackage
+        if (packageName.startsWith(string)) {
+          return true;
+        }
+      }
+      return false;
+    } else {
+      //Returns true if no package is configured
+      return true;
+    }
+  }
+  
+  private void initialize() {
+    if (namespaces == null) {
+      this.initNamespaces();
+    }
+    
+    if (autoUpdateConfigurationPropertiesBasePackages == null) {
+      this.initAutoUpdateConfigurationProperties(environment);
+    }
+  }
+
+  @Override
+  public void afterPropertiesSet() throws Exception {
+    this.beans = (ConfigurationBeanFactoryMetaData) applicationContext.getBean(ApolloRefreshConfigurationPropertiesProcessorRegistry.METADATA_BEAN_NAME);
+    this.beanFactoryMetadata = new ApolloSpringBeanFactoryMetadata(this.beans);
+    this.initialize();
+    this.configUtil = ApolloInjector.getInstance(ConfigUtil.class);
+  }
+}

--- a/apollo-client-extension/apollo-client-springboot-extension/src/main/java/com/ctrip/framework/apollo/spring/boot/extension/ApolloRefreshConfigurationPropertiesProcessorRegistry.java
+++ b/apollo-client-extension/apollo-client-springboot-extension/src/main/java/com/ctrip/framework/apollo/spring/boot/extension/ApolloRefreshConfigurationPropertiesProcessorRegistry.java
@@ -1,0 +1,51 @@
+package com.ctrip.framework.apollo.spring.boot.extension;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProcessor;
+import org.springframework.boot.context.properties.ConfigurationBeanFactoryMetaData;
+import org.springframework.core.Ordered;
+import org.springframework.core.PriorityOrdered;
+
+/**
+ * registry {@link ApolloRefreshConfigurationPropertiesProcessor},
+ * {@link ApolloRefreshConfigurationProperties}
+ * 
+ * @author wangbo(wangle_r@163.com)
+ */
+public class ApolloRefreshConfigurationPropertiesProcessorRegistry
+    implements BeanFactoryPostProcessor, PriorityOrdered, BeanDefinitionRegistryPostProcessor {
+
+  private int                 order                              = Ordered.HIGHEST_PRECEDENCE + 1;
+
+  public static final String METADATA_BEAN_NAME                 =  ConfigurationBeanFactoryMetaData.class.getName();
+
+  @Override
+  public void postProcessBeanDefinitionRegistry(BeanDefinitionRegistry registry) throws BeansException {
+      registry(registry, METADATA_BEAN_NAME, ConfigurationBeanFactoryMetaData.class);
+      registry(registry, ApolloRefreshConfigurationProperties.BEAN_NAME, ApolloRefreshConfigurationProperties.class);
+      registry(registry, ApolloRefreshConfigurationPropertiesProcessor.BEAN_NAME, ApolloRefreshConfigurationPropertiesProcessor.class);
+  }
+
+  private void registry(BeanDefinitionRegistry registry, String beanName, Class<?> clas) {
+    if (!registry.containsBeanDefinition(beanName)) {
+      BeanDefinitionBuilder bean = BeanDefinitionBuilder.genericBeanDefinition(clas);
+      registry.registerBeanDefinition(beanName, bean.getBeanDefinition());
+
+    }
+  }
+
+  @Override
+  public int getOrder() {
+    return order;
+  }
+
+  @Override
+  public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {
+
+  }
+
+}

--- a/apollo-client-extension/apollo-client-springboot-extension/src/main/java/com/ctrip/framework/apollo/spring/boot/extension/ApolloRefreshConfigurationPropertiesProcessorRegistry.java
+++ b/apollo-client-extension/apollo-client-springboot-extension/src/main/java/com/ctrip/framework/apollo/spring/boot/extension/ApolloRefreshConfigurationPropertiesProcessorRegistry.java
@@ -1,7 +1,6 @@
 package com.ctrip.framework.apollo.spring.boot.extension;
 
 import org.springframework.beans.BeansException;
-import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
@@ -17,7 +16,7 @@ import org.springframework.core.PriorityOrdered;
  * @author wangbo(wangle_r@163.com)
  */
 public class ApolloRefreshConfigurationPropertiesProcessorRegistry
-    implements BeanFactoryPostProcessor, PriorityOrdered, BeanDefinitionRegistryPostProcessor {
+    implements PriorityOrdered, BeanDefinitionRegistryPostProcessor {
 
   private int                 order                              = Ordered.HIGHEST_PRECEDENCE + 1;
 

--- a/apollo-client-extension/apollo-client-springboot-extension/src/main/java/com/ctrip/framework/apollo/spring/boot/extension/ApolloRefreshExtensionAutoConfiguration.java
+++ b/apollo-client-extension/apollo-client-springboot-extension/src/main/java/com/ctrip/framework/apollo/spring/boot/extension/ApolloRefreshExtensionAutoConfiguration.java
@@ -1,0 +1,25 @@
+package com.ctrip.framework.apollo.spring.boot.extension;
+
+import com.ctrip.framework.apollo.spring.boot.ApolloAutoConfiguration;
+import com.ctrip.framework.apollo.spring.config.ConfigPropertySourcesProcessor;
+import com.ctrip.framework.apollo.spring.config.PropertySourcesConstants;
+
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+/**
+ * @author wangbo(wangle_r@163.com)
+ */
+@Configuration
+@ConditionalOnProperty(PropertySourcesConstants.APOLLO_BOOTSTRAP_ENABLED)
+@AutoConfigureAfter(ApolloAutoConfiguration.class)
+public class ApolloRefreshExtensionAutoConfiguration {
+
+  @Bean
+  @ConditionalOnBean(ConfigPropertySourcesProcessor.class)
+  public ApolloRefreshConfigurationPropertiesProcessorRegistry apolloRefreshConfigurationPropertiesProcessorRegistry() {
+    return new ApolloRefreshConfigurationPropertiesProcessorRegistry();
+  }
+}

--- a/apollo-client-extension/apollo-client-springboot-extension/src/main/java/com/ctrip/framework/apollo/spring/boot/extension/ApolloRefreshPropertiesConfigurationFactory.java
+++ b/apollo-client-extension/apollo-client-springboot-extension/src/main/java/com/ctrip/framework/apollo/spring/boot/extension/ApolloRefreshPropertiesConfigurationFactory.java
@@ -1,0 +1,403 @@
+package com.ctrip.framework.apollo.spring.boot.extension;
+
+import java.beans.PropertyDescriptor;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.BeanUtils;
+import org.springframework.beans.PropertyValues;
+import org.springframework.beans.support.ResourceEditorRegistrar;
+import org.springframework.boot.bind.ApolloExtensionPropertyNamePatternsMatcher;
+import org.springframework.boot.bind.ApolloExtensionPropertySourcesPropertyValues;
+import org.springframework.boot.bind.RelaxedDataBinder;
+import org.springframework.boot.bind.RelaxedNames;
+import org.springframework.boot.bind.apolloextension.ApolloPropertyNamePatternsMatcher;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.core.convert.ConversionService;
+import org.springframework.core.env.PropertySources;
+import org.springframework.util.Assert;
+import org.springframework.util.ReflectionUtils;
+import org.springframework.util.StringUtils;
+import org.springframework.validation.BindException;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.DataBinder;
+import org.springframework.validation.ObjectError;
+import org.springframework.validation.Validator;
+
+import com.ctrip.framework.apollo.build.ApolloInjector;
+import com.ctrip.framework.apollo.spring.annotation.AutoRefresh;
+import com.ctrip.framework.apollo.spring.annotation.RefreshEnabled;
+import com.ctrip.framework.apollo.spring.annotation.RefreshField;
+import com.ctrip.framework.apollo.util.ConfigUtil;
+
+/**
+ * @author wangbo(wangle_r@163.com)
+ */
+class ApolloRefreshPropertiesConfigurationFactory<T> {
+
+  private static final char[] EXACT_DELIMITERS = { '_', '.', '[' };
+
+  private static final char[] TARGET_NAME_DELIMITERS = { '_', '.' };
+
+  private static Logger logger = LoggerFactory.getLogger(ApolloRefreshPropertiesConfigurationFactory.class);
+
+  private boolean ignoreUnknownFields = true;
+
+  private boolean ignoreInvalidFields;
+
+  private boolean exceptionIfInvalid = true;
+
+  private PropertySources propertySources;
+
+  private final T target;
+
+  private Validator validator;
+
+  private ApplicationContext applicationContext;
+
+  private boolean ignoreNestedProperties = false;
+
+  private String targetName;
+
+  private ConversionService conversionService;
+
+  private boolean resolvePlaceholders = true;
+
+  private Annotation[] annotations;
+
+  /**
+   * Create a new {@link ApolloRefreshPropertiesConfigurationFactory} instance.
+   * 
+   * @param target the target object to bind too
+   * @see #PropertiesConfigurationFactory(Class)
+   */
+  public ApolloRefreshPropertiesConfigurationFactory(T target) {
+    Assert.notNull(target, "target must not be null");
+    this.target = target;
+  }
+
+  /**
+   * Create a new {@link ApolloRefreshPropertiesConfigurationFactory} instance.
+   * 
+   * @param type the target type
+   * @see #PropertiesConfigurationFactory(Class)
+   */
+  @SuppressWarnings("unchecked")
+  public ApolloRefreshPropertiesConfigurationFactory(Class<?> type) {
+    Assert.notNull(type, "type must not be null");
+    this.target = (T) BeanUtils.instantiate(type);
+  }
+
+  /**
+   * Flag to disable binding of nested properties (i.e. those with period
+   * separators in their paths). Can be useful to disable this if the name prefix
+   * is empty and you don't want to ignore unknown fields.
+   * 
+   * @param ignoreNestedProperties the flag to set (default false)
+   */
+  public void setIgnoreNestedProperties(boolean ignoreNestedProperties) {
+    this.ignoreNestedProperties = ignoreNestedProperties;
+  }
+
+  /**
+   * Set whether to ignore unknown fields, that is, whether to ignore bind
+   * parameters that do not have corresponding fields in the target object.
+   * <p>
+   * Default is "true". Turn this off to enforce that all bind parameters must
+   * have a matching field in the target object.
+   * 
+   * @param ignoreUnknownFields if unknown fields should be ignored
+   */
+  public void setIgnoreUnknownFields(boolean ignoreUnknownFields) {
+    this.ignoreUnknownFields = ignoreUnknownFields;
+  }
+
+  /**
+   * Set whether to ignore invalid fields, that is, whether to ignore bind
+   * parameters that have corresponding fields in the target object which are not
+   * accessible (for example because of null values in the nested path).
+   * <p>
+   * Default is "false". Turn this on to ignore bind parameters for nested objects
+   * in non-existing parts of the target object graph.
+   * 
+   * @param ignoreInvalidFields if invalid fields should be ignored
+   */
+  public void setIgnoreInvalidFields(boolean ignoreInvalidFields) {
+    this.ignoreInvalidFields = ignoreInvalidFields;
+  }
+
+  /**
+   * Set the target name.
+   * 
+   * @param targetName the target name
+   */
+  public void setTargetName(String targetName) {
+    this.targetName = targetName;
+  }
+
+  public void setApplicationContext(ApplicationContext applicationContext) {
+    this.applicationContext = applicationContext;
+  }
+
+  /**
+   * Set the property sources.
+   * 
+   * @param propertySources the property sources
+   */
+  public void setPropertySources(PropertySources propertySources) {
+    this.propertySources = propertySources;
+  }
+
+  /**
+   * Set the conversion service.
+   * 
+   * @param conversionService the conversion service
+   */
+  public void setConversionService(ConversionService conversionService) {
+    this.conversionService = conversionService;
+  }
+
+  /**
+   * Set the validator.
+   * 
+   * @param validator the validator
+   */
+  public void setValidator(Validator validator) {
+    this.validator = validator;
+  }
+
+  /**
+   * Set a flag to indicate that an exception should be raised if a Validator is
+   * available and validation fails.
+   * 
+   * @param exceptionIfInvalid the flag to set
+   * @deprecated as of 1.5, do not specify a {@link Validator} if validation
+   *             should not occur
+   */
+  @Deprecated
+  public void setExceptionIfInvalid(boolean exceptionIfInvalid) {
+    this.exceptionIfInvalid = exceptionIfInvalid;
+  }
+
+  /**
+   * Flag to indicate that placeholders should be replaced during binding. Default
+   * is true.
+   * 
+   * @param resolvePlaceholders flag value
+   */
+  public void setResolvePlaceholders(boolean resolvePlaceholders) {
+    this.resolvePlaceholders = resolvePlaceholders;
+  }
+
+  public void bindPropertiesToTarget() throws BindException {
+    Assert.state(this.propertySources != null, "PropertySources should not be null");
+    try {
+      if (logger.isTraceEnabled()) {
+        logger.trace("Property Sources: " + this.propertySources);
+
+      }
+      doBindPropertiesToTarget();
+    } catch (BindException ex) {
+      if (this.exceptionIfInvalid) {
+        throw ex;
+      }
+      ApolloRefreshPropertiesConfigurationFactory.logger
+          .error("Failed to load Properties validation bean. " + "Your Properties may be invalid.", ex);
+    }
+  }
+
+  private void doBindPropertiesToTarget() throws BindException {
+    ConfigUtil configUtil = ApolloInjector.getInstance(ConfigUtil.class);
+    if (configUtil.isAutoUpdateInjectedSpringPropertiesEnabled()) {
+      RelaxedDataBinder dataBinder = (this.targetName != null ? new RelaxedDataBinder(this.target, this.targetName)
+          : new RelaxedDataBinder(this.target));
+      if (this.validator != null && this.validator.supports(dataBinder.getTarget().getClass())) {
+        dataBinder.setValidator(this.validator);
+      }
+      if (this.conversionService != null) {
+        dataBinder.setConversionService(this.conversionService);
+      }
+      dataBinder.setAutoGrowCollectionLimit(Integer.MAX_VALUE);
+      dataBinder.setIgnoreNestedProperties(this.ignoreNestedProperties);
+      dataBinder.setIgnoreInvalidFields(this.ignoreInvalidFields);
+      dataBinder.setIgnoreUnknownFields(this.ignoreUnknownFields);
+      customizeBinder(dataBinder);
+      if (this.applicationContext != null) {
+        ResourceEditorRegistrar resourceEditorRegistrar = new ResourceEditorRegistrar(this.applicationContext,
+            this.applicationContext.getEnvironment());
+        resourceEditorRegistrar.registerCustomEditors(dataBinder);
+      }
+      Iterable<String> relaxedTargetNames = getRelaxedTargetNames();
+      Set<String> names = getNames(relaxedTargetNames);
+      if (!names.isEmpty()) {
+        PropertyValues propertyValues = getPropertySourcesPropertyValues(names, relaxedTargetNames);
+        dataBinder.bind(propertyValues);
+        if (this.validator != null) {
+          dataBinder.validate();
+        }
+        checkForBindingErrors(dataBinder);
+      }
+    }
+  }
+
+  private Iterable<String> getRelaxedTargetNames() {
+    return (this.target != null && StringUtils.hasLength(this.targetName) ? new RelaxedNames(this.targetName) : null);
+  }
+
+  private Set<String> getNames(Iterable<String> prefixes) {
+    Set<String> names = new LinkedHashSet<String>();
+    if (this.target != null) {
+      Map<String, Field> allField = findAllField(this.target.getClass());
+      PropertyDescriptor[] descriptors = BeanUtils.getPropertyDescriptors(this.target.getClass());
+      for (PropertyDescriptor descriptor : descriptors) {
+        String name = descriptor.getName();
+        if (!"class".equals(name)) {
+          /*
+           * Determines whether to run the update field value
+           */
+          boolean isRefresh = hasRefresh(descriptor, allField);
+          if (isRefresh) {
+            RelaxedNames relaxedNames = RelaxedNames.forCamelCase(name);
+            if (prefixes == null) {
+              for (String relaxedName : relaxedNames) {
+                names.add(relaxedName);
+              }
+            } else {
+              for (String prefix : prefixes) {
+                for (String relaxedName : relaxedNames) {
+                  names.add(prefix + "." + relaxedName);
+                  names.add(prefix + "_" + relaxedName);
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    return names;
+  }
+
+  private boolean hasRefresh(PropertyDescriptor descriptor, Map<String, Field> allField) {
+    /*
+     * @RefreshEnabled has the highest priority
+     */
+    if (this.getAnnotation(RefreshEnabled.class) != null) {
+      return true;
+    }
+
+    Field field = allField.get(descriptor.getName());
+    if (field != null) {
+      RefreshField annotation = AnnotationUtils.findAnnotation(field, RefreshField.class);
+      if (annotation != null) {
+        return annotation.value();
+      }
+    }
+    /*
+     * Determine if @RefreshField exists, and enable automatic updates
+     */
+    if(descriptor.getWriteMethod() != null) {
+      RefreshField annotation = AnnotationUtils.findAnnotation(descriptor.getWriteMethod(), RefreshField.class);
+      if (annotation != null) {
+        return annotation.value();
+      }
+    }
+    /*
+     * If @Refreshfield does not exist, determine if @Autorefresh does
+     */
+    AutoRefresh autoRefresh = this.getAnnotation(AutoRefresh.class);
+    if (autoRefresh != null) {
+      return autoRefresh.value();
+    }
+
+    /*
+     * The default enable automatic updates
+     */
+    return true;
+  }
+
+  private Map<String, Field> findAllField(Class<?> clazz) {
+    final Map<String, Field> res = new HashMap<>();
+    ReflectionUtils.doWithFields(clazz, new ReflectionUtils.FieldCallback() {
+      @Override
+      public void doWith(Field field) throws IllegalArgumentException, IllegalAccessException {
+        res.put(field.getName(), field);
+      }
+    });
+    return res;
+  }
+
+  @SuppressWarnings("unchecked")
+  private <A extends Annotation> A getAnnotation(Class<A> type) {
+    for (Annotation annotation : this.annotations) {
+      if (type.isInstance(annotation)) {
+        return (A) annotation;
+      }
+    }
+    return null;
+  }
+
+  private PropertyValues getPropertySourcesPropertyValues(Set<String> names, Iterable<String> relaxedTargetNames) {
+    ApolloExtensionPropertyNamePatternsMatcher includes = getPropertyNamePatternsMatcher(names, relaxedTargetNames);
+    return new ApolloExtensionPropertySourcesPropertyValues(this.propertySources, names, includes,
+        this.resolvePlaceholders);
+  }
+
+  private ApolloExtensionPropertyNamePatternsMatcher getPropertyNamePatternsMatcher(Set<String> names,
+      Iterable<String> relaxedTargetNames) {
+    if (this.ignoreUnknownFields && !isMapTarget()) {
+      // Since unknown fields are ignored we can filter them out early to save
+      // unnecessary calls to the PropertySource.
+      return new ApolloPropertyNamePatternsMatcher(EXACT_DELIMITERS, true, names);
+    }
+    if (relaxedTargetNames != null) {
+      // We can filter properties to those starting with the target name, but
+      // we can't do a complete filter since we need to trigger the
+      // unknown fields check
+      Set<String> relaxedNames = new HashSet<String>();
+      for (String relaxedTargetName : relaxedTargetNames) {
+        relaxedNames.add(relaxedTargetName);
+      }
+      return new ApolloPropertyNamePatternsMatcher(TARGET_NAME_DELIMITERS, true, relaxedNames);
+    }
+    // Not ideal, we basically can't filter anything
+    return ApolloPropertyNamePatternsMatcher.ALL;
+  }
+
+  private boolean isMapTarget() {
+    return this.target != null && Map.class.isAssignableFrom(this.target.getClass());
+  }
+
+  private void checkForBindingErrors(RelaxedDataBinder dataBinder) throws BindException {
+    BindingResult errors = dataBinder.getBindingResult();
+    if (errors.hasErrors()) {
+      logger.error("Properties configuration failed validation");
+      for (ObjectError error : errors.getAllErrors()) {
+        logger.error("{}", error);
+      }
+      if (this.exceptionIfInvalid) {
+        throw new BindException(errors);
+      }
+    }
+  }
+
+  /**
+   * Customize the data binder.
+   * 
+   * @param dataBinder the data binder that will be used to bind and validate
+   */
+  protected void customizeBinder(DataBinder dataBinder) {
+  }
+
+  public void setAnnotations(Annotation[] annotations) {
+    this.annotations = annotations;
+  }
+
+}

--- a/apollo-client-extension/apollo-client-springboot-extension/src/main/java/com/ctrip/framework/apollo/spring/boot/extension/ApolloSpringBeanFactoryMetadata.java
+++ b/apollo-client-extension/apollo-client-springboot-extension/src/main/java/com/ctrip/framework/apollo/spring/boot/extension/ApolloSpringBeanFactoryMetadata.java
@@ -1,0 +1,30 @@
+package com.ctrip.framework.apollo.spring.boot.extension;
+
+import java.lang.annotation.Annotation;
+
+import com.ctrip.framework.apollo.spring.boot.BeanFactoryMetadata;
+
+import org.springframework.boot.context.properties.ConfigurationBeanFactoryMetaData;
+
+public class ApolloSpringBeanFactoryMetadata implements BeanFactoryMetadata {
+  private ConfigurationBeanFactoryMetaData beanFactoryMetadata;
+  
+  public ApolloSpringBeanFactoryMetadata(ConfigurationBeanFactoryMetaData beanFactoryMetadata) {
+    super();
+    this.beanFactoryMetadata = beanFactoryMetadata;
+  }
+
+  @Override
+  public <A extends Annotation> A findFactoryAnnotation(String beanName, Class<A> type) {
+    return beanFactoryMetadata.findFactoryAnnotation(beanName, type);
+  }
+
+  public ConfigurationBeanFactoryMetaData getBeanFactoryMetadata() {
+    return beanFactoryMetadata;
+  }
+
+  public void setBeanFactoryMetadata(ConfigurationBeanFactoryMetaData beanFactoryMetadata) {
+    this.beanFactoryMetadata = beanFactoryMetadata;
+  }
+
+}

--- a/apollo-client-extension/apollo-client-springboot-extension/src/main/java/org/springframework/boot/bind/ApolloExtensionPropertyNamePatternsMatcher.java
+++ b/apollo-client-extension/apollo-client-springboot-extension/src/main/java/org/springframework/boot/bind/ApolloExtensionPropertyNamePatternsMatcher.java
@@ -1,0 +1,9 @@
+package org.springframework.boot.bind;
+
+import org.springframework.boot.bind.PropertyNamePatternsMatcher;
+
+/**
+ * @author wangbo(wangle_r@163.com)
+ */
+public interface ApolloExtensionPropertyNamePatternsMatcher extends PropertyNamePatternsMatcher {
+}

--- a/apollo-client-extension/apollo-client-springboot-extension/src/main/java/org/springframework/boot/bind/ApolloExtensionPropertySourcesPropertyValues.java
+++ b/apollo-client-extension/apollo-client-springboot-extension/src/main/java/org/springframework/boot/bind/ApolloExtensionPropertySourcesPropertyValues.java
@@ -1,0 +1,18 @@
+package org.springframework.boot.bind;
+
+import java.util.Collection;
+
+import org.springframework.core.env.PropertySources;
+
+/**
+ * @author wangbo(wangle_r@163.com)
+ */
+public class ApolloExtensionPropertySourcesPropertyValues extends PropertySourcesPropertyValues {
+  public ApolloExtensionPropertySourcesPropertyValues(PropertySources propertySources,
+                                                      Collection<String> nonEnumerableFallbackNames,
+                                                      PropertyNamePatternsMatcher includes,
+                                                      boolean resolvePlaceholders) {
+    super(propertySources, nonEnumerableFallbackNames, includes, resolvePlaceholders);
+  }
+
+}

--- a/apollo-client-extension/apollo-client-springboot-extension/src/main/java/org/springframework/boot/bind/apolloextension/AllPropertyNamePatternsMatcher.java
+++ b/apollo-client-extension/apollo-client-springboot-extension/src/main/java/org/springframework/boot/bind/apolloextension/AllPropertyNamePatternsMatcher.java
@@ -1,0 +1,14 @@
+package org.springframework.boot.bind.apolloextension;
+
+import org.springframework.boot.bind.ApolloExtensionPropertyNamePatternsMatcher;
+
+/**
+ * @author wangbo(wangle_r@163.com)
+ */
+public class AllPropertyNamePatternsMatcher implements ApolloExtensionPropertyNamePatternsMatcher {
+
+  @Override
+  public boolean matches(String propertyName) {
+    return true;
+  }
+}

--- a/apollo-client-extension/apollo-client-springboot-extension/src/main/java/org/springframework/boot/bind/apolloextension/ApolloPropertyNamePatternsMatcher.java
+++ b/apollo-client-extension/apollo-client-springboot-extension/src/main/java/org/springframework/boot/bind/apolloextension/ApolloPropertyNamePatternsMatcher.java
@@ -1,0 +1,96 @@
+package org.springframework.boot.bind.apolloextension;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.springframework.boot.bind.ApolloExtensionPropertyNamePatternsMatcher;
+
+/**
+ * @author wangbo(wangle_r@163.com)
+ */
+public class ApolloPropertyNamePatternsMatcher implements ApolloExtensionPropertyNamePatternsMatcher {
+
+  public static AllPropertyNamePatternsMatcher ALL = new AllPropertyNamePatternsMatcher();
+
+  private final char[]                         delimiters;
+
+  private final boolean                        ignoreCase;
+
+  private final String[]                       names;
+
+  protected ApolloPropertyNamePatternsMatcher(char[] delimiters, String... names) {
+    this(delimiters, false, names);
+  }
+
+  protected ApolloPropertyNamePatternsMatcher(char[] delimiters, boolean ignoreCase, String... names) {
+    this(delimiters, ignoreCase, new HashSet<String>(Arrays.asList(names)));
+  }
+
+  public ApolloPropertyNamePatternsMatcher(char[] delimiters, boolean ignoreCase, Set<String> names) {
+    this.delimiters = delimiters;
+    this.ignoreCase = ignoreCase;
+    this.names = names.toArray(new String[names.size()]);
+  }
+
+  @Override
+  public boolean matches(String propertyName) {
+    char[] propertyNameChars = propertyName.toCharArray();
+    boolean[] match = new boolean[this.names.length];
+    boolean noneMatched = true;
+    for (int i = 0; i < this.names.length; i++) {
+      if (this.names[i].length() <= propertyNameChars.length) {
+        match[i] = true;
+        noneMatched = false;
+      }
+    }
+    if (noneMatched) {
+      return false;
+    }
+    for (int charIndex = 0; charIndex < propertyNameChars.length; charIndex++) {
+      for (int nameIndex = 0; nameIndex < this.names.length; nameIndex++) {
+        if (match[nameIndex]) {
+          match[nameIndex] = false;
+          if (charIndex < this.names[nameIndex].length()) {
+            if (isCharMatch(this.names[nameIndex].charAt(charIndex), propertyNameChars[charIndex])) {
+              match[nameIndex] = true;
+              noneMatched = false;
+            }
+          } else {
+            char charAfter = propertyNameChars[this.names[nameIndex].length()];
+            if (isDelimiter(charAfter)) {
+              match[nameIndex] = true;
+              noneMatched = false;
+            }
+          }
+        }
+      }
+      if (noneMatched) {
+        return false;
+      }
+    }
+    for (int i = 0; i < match.length; i++) {
+      if (match[i]) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private boolean isCharMatch(char c1, char c2) {
+    if (this.ignoreCase) {
+      return Character.toLowerCase(c1) == Character.toLowerCase(c2);
+    }
+    return c1 == c2;
+  }
+
+  private boolean isDelimiter(char c) {
+    for (char delimiter : this.delimiters) {
+      if (c == delimiter) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+}

--- a/apollo-client-extension/apollo-client-springboot-extension/src/main/resources/META-INF/spring.factories
+++ b/apollo-client-extension/apollo-client-springboot-extension/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+com.ctrip.framework.apollo.spring.boot.extension.ApolloRefreshExtensionAutoConfiguration

--- a/apollo-client-extension/apollo-client-springboot2-extension/pom.xml
+++ b/apollo-client-extension/apollo-client-springboot2-extension/pom.xml
@@ -1,0 +1,35 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.ctrip.framework.apollo</groupId>
+    <artifactId>apollo-client-extension</artifactId>
+    <version>1.4.0</version>
+  </parent>
+  <artifactId>apollo-client-springboot2-extension</artifactId>
+  <dependencies>
+    <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-autoconfigure</artifactId>
+        <optional>true</optional>
+    </dependency>
+    <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-context</artifactId>
+        <optional>true</optional>
+    </dependency>
+    <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-beans</artifactId>
+        <optional>true</optional>
+    </dependency>
+    <dependency>
+        <groupId>com.ctrip.framework.apollo</groupId>
+        <artifactId>apollo-client</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>javax.validation</groupId>
+        <artifactId>validation-api</artifactId>
+        <optional>true</optional>
+    </dependency>
+  </dependencies>
+</project>

--- a/apollo-client-extension/apollo-client-springboot2-extension/src/main/java/com/ctrip/framework/apollo/spring/boot/extension/ApolloRefreshConfigurationConfigChangeListener.java
+++ b/apollo-client-extension/apollo-client-springboot2-extension/src/main/java/com/ctrip/framework/apollo/spring/boot/extension/ApolloRefreshConfigurationConfigChangeListener.java
@@ -1,0 +1,51 @@
+package com.ctrip.framework.apollo.spring.boot.extension;
+
+import java.lang.annotation.Annotation;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.ApplicationContext;
+
+import com.ctrip.framework.apollo.ConfigChangeListener;
+import com.ctrip.framework.apollo.model.ConfigChangeEvent;
+import com.ctrip.framework.apollo.spring.boot.RefreshConfigurationProperties;
+
+/**
+ * 
+ * {@link ConfigurationProperties} Automatic update listener implementation
+ * 
+ * @author wangbo(wangle_r@163.com)
+ */
+public class ApolloRefreshConfigurationConfigChangeListener implements ConfigChangeListener {
+  private static Logger logger = LoggerFactory.getLogger(ApolloRefreshConfigurationConfigChangeListener.class);
+  private Object bean;
+  private String beanName;
+  private ConfigurationProperties annotation;
+
+  private ApplicationContext applicationContext;
+  private Annotation[] annotations;
+  private ApolloRefreshConfigurationProperties apolloRefreshConfigurationProperties;
+
+  public ApolloRefreshConfigurationConfigChangeListener(Object bean, String beanName,
+      ConfigurationProperties annotation, Annotation[] annotations, ApplicationContext applicationContext) {
+    super();
+    this.bean = bean;
+    this.beanName = beanName;
+    this.annotation = annotation;
+    this.annotations = annotations;
+    this.applicationContext = applicationContext;
+  }
+
+  @Override
+  public void onChange(ConfigChangeEvent changeEvent) {
+    if (this.apolloRefreshConfigurationProperties == null) {
+      this.apolloRefreshConfigurationProperties = (ApolloRefreshConfigurationProperties) applicationContext
+          .getBean(ApolloRefreshConfigurationProperties.class);
+    }
+    logger.info("Apollo config changeEvent namespace: {},  {} oldValue {}", changeEvent.getNamespace(), beanName, bean);
+    this.apolloRefreshConfigurationProperties.binding(bean, beanName, annotation, annotations);
+    logger.info("Apollo config changeEvent : {} newValue {}", beanName, bean);
+
+  }
+}

--- a/apollo-client-extension/apollo-client-springboot2-extension/src/main/java/com/ctrip/framework/apollo/spring/boot/extension/ApolloRefreshConfigurationProperties.java
+++ b/apollo-client-extension/apollo-client-springboot2-extension/src/main/java/com/ctrip/framework/apollo/spring/boot/extension/ApolloRefreshConfigurationProperties.java
@@ -1,0 +1,166 @@
+package com.ctrip.framework.apollo.spring.boot.extension;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Properties;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.boot.context.properties.ApolloRefreshConfigurationPropertiesBinder;
+import org.springframework.boot.context.properties.ConfigurationBeanFactoryMetadata;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.context.EnvironmentAware;
+import org.springframework.core.ResolvableType;
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.MutablePropertySources;
+import org.springframework.core.env.PropertiesPropertySource;
+import org.springframework.core.env.PropertySources;
+import org.springframework.core.env.StandardEnvironment;
+import org.springframework.validation.annotation.Validated;
+
+import com.ctrip.framework.apollo.spring.annotation.AutoRefresh;
+import com.ctrip.framework.apollo.spring.annotation.RefreshEnabled;
+import com.ctrip.framework.apollo.spring.boot.AbstractRefreshConfigurationProperties;
+import com.ctrip.framework.apollo.spring.util.ApolloRefreshUtil;
+
+/**
+ * {@link ConfigurationProperties} The specific implementation of automatic
+ * update update implementation
+ * 
+ * @author wangbo(wangle_r@163.com)
+ */
+public class ApolloRefreshConfigurationProperties extends AbstractRefreshConfigurationProperties
+    implements ApplicationContextAware, InitializingBean, EnvironmentAware {
+  /**
+   * The bean name of the configuration properties validator.
+   */
+  public static final String  VALIDATOR_BEAN_NAME = "configurationPropertiesValidator";
+  /**
+   * The bean name that this post-processor is registered with.
+   */
+  public static final String  BEAN_NAME           = ApolloRefreshConfigurationProperties.class.getName();
+
+  private ApolloSpringBeanFactoryMetadata beanFactoryMetadata;
+  
+  private ApplicationContext applicationContext;
+  
+  private ApolloRefreshConfigurationPropertiesBinder binder;
+  
+  private Environment environment;
+
+  @Override
+  public void refreshBinding(Object bean, String beanName, Properties properties) {
+    Object target = bean;
+    if(bean instanceof String) {
+      target = this.applicationContext.getBean(beanName);
+    }
+    Class<?> clazz = target.getClass();
+    ConfigurationProperties annotation = ApolloRefreshUtil.findConfigurationPropertiesAnnotation(clazz, beanName, this.beanFactoryMetadata);
+    if (annotation != null) {
+      binding(target, beanName, annotation, 
+          ApolloRefreshUtil.findAutoRefreshAnnotation(clazz, beanName, this.beanFactoryMetadata),
+          ApolloRefreshUtil.findRefreshEnabledAnnotation(clazz, beanName, this.beanFactoryMetadata),
+          properties);
+    }
+    
+  }
+
+  void binding(Object bean, String beanName, ConfigurationProperties annotation, AutoRefresh autoRefresh,
+                      RefreshEnabled refreshEnabled, Properties properties) {
+    if (annotation == null || properties.isEmpty()) {
+      return;
+    }
+
+    Validated validated = getAnnotation(bean, beanName, Validated.class);
+    
+    List<Annotation> annotations = new LinkedList<Annotation>();
+    annotations.add(annotation);
+    if(refreshEnabled != null) {
+      annotations.add(refreshEnabled);
+    }
+    if(autoRefresh != null) {
+      annotations.add(autoRefresh);
+    }
+    if(validated != null) {
+      annotations.add(validated);
+    }
+    binding(bean, beanName, properties, annotations.toArray(new Annotation[annotations.size()]));
+  }
+  
+  void binding(Object bean, String beanName, ConfigurationProperties annotation, Annotation[] annotations) {
+    ResolvableType type = getBeanType(bean, beanName);
+    Bindable<?> target = Bindable.of(type).withExistingValue(bean).withAnnotations(annotations);
+    
+    this.binder.bind(target, this.deducePropertySources(null));
+  }
+
+  void binding(Object bean, String beanName, Properties properties, Annotation[] annotations) {
+    ResolvableType type = getBeanType(bean, beanName);
+    Bindable<?> target = Bindable.of(type).withExistingValue(bean).withAnnotations(annotations);
+    
+    this.binder.bind(target, this.deducePropertySources(properties));
+  }
+
+  private PropertySources deducePropertySources(Properties properties) {
+    if(properties != null) {
+      return ((ConfigurableEnvironment) getPropertiesEnvironment(properties)).getPropertySources();
+    }
+    if (this.environment instanceof ConfigurableEnvironment) {
+      return ((ConfigurableEnvironment) this.environment).getPropertySources();
+    }
+    
+    return new MutablePropertySources();
+  }
+
+  private StandardEnvironment getPropertiesEnvironment(Properties properties) {
+    StandardEnvironment environment = new StandardEnvironment();
+    environment.getPropertySources().addFirst(new PropertiesPropertySource("APOLLO_UPDATE_PROPERTIES", properties));
+    return environment;
+  }
+
+  @Override
+  public void afterPropertiesSet() throws Exception {
+    this.beanFactoryMetadata = new ApolloSpringBeanFactoryMetadata(this.applicationContext
+        .getBean(ConfigurationBeanFactoryMetadata.BEAN_NAME, ConfigurationBeanFactoryMetadata.class));
+    this.binder = new ApolloRefreshConfigurationPropertiesBinder(applicationContext, VALIDATOR_BEAN_NAME);
+  }
+
+  @Override
+  public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+    this.applicationContext = applicationContext;
+
+  }
+  @Override
+  public ApplicationContext getApplicationContext(){
+   return this.applicationContext;
+  }
+
+  private ResolvableType getBeanType(Object bean, String beanName) {
+    Method factoryMethod = this.beanFactoryMetadata.findFactoryMethod(beanName);
+    if (factoryMethod != null) {
+      return ResolvableType.forMethodReturnType(factoryMethod);
+    }
+    return ResolvableType.forClass(bean.getClass());
+  }
+
+  private <A extends Annotation> A getAnnotation(Object bean, String beanName, Class<A> type) {
+    A annotation = this.beanFactoryMetadata.findFactoryAnnotation(beanName, type);
+    if (annotation == null) {
+      annotation = AnnotationUtils.findAnnotation(bean.getClass(), type);
+    }
+    return annotation;
+  }
+
+  @Override
+  public void setEnvironment(Environment environment) {
+    this.environment = environment;
+    
+  }
+}

--- a/apollo-client-extension/apollo-client-springboot2-extension/src/main/java/com/ctrip/framework/apollo/spring/boot/extension/ApolloRefreshConfigurationPropertiesProcessor.java
+++ b/apollo-client-extension/apollo-client-springboot2-extension/src/main/java/com/ctrip/framework/apollo/spring/boot/extension/ApolloRefreshConfigurationPropertiesProcessor.java
@@ -1,0 +1,313 @@
+package com.ctrip.framework.apollo.spring.boot.extension;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+
+import com.ctrip.framework.apollo.Config;
+import com.ctrip.framework.apollo.ConfigChangeListener;
+import com.ctrip.framework.apollo.ConfigService;
+import com.ctrip.framework.apollo.build.ApolloInjector;
+import com.ctrip.framework.apollo.core.ConfigConsts;
+import com.ctrip.framework.apollo.spring.annotation.ApolloProcessor;
+import com.ctrip.framework.apollo.spring.annotation.AutoRefresh;
+import com.ctrip.framework.apollo.spring.annotation.RefreshEnabled;
+import com.ctrip.framework.apollo.spring.boot.BeanFactoryMetadata;
+import com.ctrip.framework.apollo.spring.config.PropertySourcesConstants;
+import com.ctrip.framework.apollo.spring.util.ApolloRefreshUtil;
+import com.ctrip.framework.apollo.util.ConfigUtil;
+import com.google.common.base.Strings;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.boot.context.properties.ConfigurationBeanFactoryMetadata;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.context.EnvironmentAware;
+import org.springframework.core.env.Environment;
+import org.springframework.util.ClassUtils;
+
+/**
+ * The automatic refresh of SpringBoot ConfigurationProperties is implemented
+ * 
+ * @author wangbo(wangle_r@163.com)
+ */
+public class ApolloRefreshConfigurationPropertiesProcessor extends ApolloProcessor
+    implements ApplicationContextAware, EnvironmentAware, InitializingBean {
+
+  private ConfigUtil                 configUtil;
+
+  private BeanFactoryMetadata beanFactoryMetadata;
+
+  private Environment                      environment;
+
+  private ApplicationContext               applicationContext;
+
+  private String[]                         namespaces;
+
+  private final Set<Object>                registryListeners                 = new HashSet<>();
+
+  private boolean                          autoUpdateConfigurationProperties = false;
+
+  private String[]                         autoUpdateConfigurationPropertiesBasePackages;
+  
+  /**
+   * The bean name that this post-processor is registered with.
+   */
+  public static final String BEAN_NAME = ApolloRefreshConfigurationPropertiesProcessor.class
+      .getName();
+
+  /**
+   * The bean name of the configuration properties validator.
+   */
+  public static final String VALIDATOR_BEAN_NAME = "configurationPropertiesValidator";
+
+  public ApolloRefreshConfigurationPropertiesProcessor() {
+    
+  }
+
+  @Override
+  public Object postProcessBeforeInitialization(Object bean, String beanName) throws BeansException {
+    /**
+     * The Listener is registered when Apollo automatic update is enabled
+     */
+    if (configUtil.isAutoUpdateInjectedSpringPropertiesEnabled() && !registryListeners.contains(bean)) {
+      registryListener(bean, beanName);
+    }
+    return bean;
+  }
+
+  /**
+   * registry Listener
+   * 
+   * @param bean
+   * @param beanName
+   */
+  private void registryListener(Object bean, String beanName) {
+    Class<?> clazz = bean.getClass();
+    ConfigurationProperties annotation = ApolloRefreshUtil.findConfigurationPropertiesAnnotation(clazz, beanName, this.beanFactoryMetadata);
+    if (annotation != null) {
+      RefreshEnabled refreshEnabled = ApolloRefreshUtil.findRefreshEnabledAnnotation(clazz, beanName, this.beanFactoryMetadata);
+      AutoRefresh autoRefresh = ApolloRefreshUtil.findAutoRefreshAnnotation(bean.getClass(), beanName, this.beanFactoryMetadata);
+      boolean enabled = false;
+      if (refreshEnabled != null || autoRefresh != null) {
+        enabled = true;
+      } else if (ApolloRefreshUtil.findRefreshDisabledAnnotation(clazz, beanName, this.beanFactoryMetadata) != null) {
+        enabled = false;
+      } else {
+        enabled = isAutoUpdateConfigurationPropertiesEnabled(clazz, beanName);
+      }
+  
+      if (enabled) {
+      
+        registryListener(bean, beanName, annotation, refreshEnabled, autoRefresh);
+      }
+    }
+  }
+
+  private void registryListener(Object bean, String beanName, ConfigurationProperties annotation,
+                                RefreshEnabled refreshEnabled, AutoRefresh autoRefresh) {
+
+    //Record registration
+    registryListeners.add(bean);
+    //Handle listener parameters
+    Set<String> interestedKeyPrefixes = new LinkedHashSet<>();
+    Set<String> interestedKeys = new LinkedHashSet<>();
+    interestedKeyPrefixes.add(annotation.prefix());
+    String[] targetnamespaces = getNamespaces();
+    if (refreshEnabled != null) {
+      for (String interestedKeyPrefixe : refreshEnabled.interestedKeyPrefixes()) {
+        interestedKeyPrefixes.add(interestedKeyPrefixe);
+      }
+
+      for (String interestedKey : refreshEnabled.interestedKeys()) {
+        interestedKeys.add(interestedKey);
+      }
+      targetnamespaces = refreshEnabled.namespaces();
+      if (targetnamespaces.length == 0) {
+        targetnamespaces = getNamespaces();
+      }
+    } else {
+      /*
+       * In springboot @configurationproperties, get the parameters
+       * in @autorefresh if @autorefresh exists
+       */
+      if (autoRefresh != null) {
+        for (String interestedKeyPrefixe : autoRefresh.interestedKeyPrefixes()) {
+          interestedKeyPrefixes.add(interestedKeyPrefixe);
+        }
+
+        for (String interestedKey : autoRefresh.interestedKeys()) {
+          interestedKeys.add(interestedKey);
+        }
+        targetnamespaces = autoRefresh.namespaces();
+        if (targetnamespaces.length == 0) {
+          targetnamespaces = getNamespaces();
+        }
+      }
+    }
+    List<Annotation> annotations = new LinkedList<Annotation>();
+    annotations.add(annotation);
+    if(refreshEnabled != null) {
+      annotations.add(refreshEnabled);
+    }
+    if(autoRefresh != null) {
+      annotations.add(autoRefresh);
+    }
+    //registry Listener
+    ConfigChangeListener configChangeListener = new ApolloRefreshConfigurationConfigChangeListener(bean, beanName,
+        annotation, annotations.toArray(new Annotation[annotations.size()]), applicationContext);
+    for (String namespace : targetnamespaces) {
+      Config config = ConfigService.getConfig(namespace);
+      config.addChangeListener(configChangeListener, interestedKeys, interestedKeyPrefixes);
+    }
+  }
+
+  /**
+   * Determines whether the automatic update configuration is enabled
+   * 
+   * @param clazz
+   * @param beanName
+   * @return
+   */
+  private boolean isAutoUpdateConfigurationPropertiesEnabled(Class<?> clazz, String beanName) {
+    boolean enabled = isAutoUpdateConfigurationPropertiesEnabled();
+    if (enabled) {
+      String packageName = ClassUtils.getPackageName(clazz);
+      enabled = isAutoUpdateConfigurationPropertiesBasePackages(packageName);
+      if (!enabled) {
+        String qualifiedName = packageName + "." + ClassUtils.getShortName(clazz);
+        enabled = isAutoUpdateConfigurationPropertiesBasePackages(qualifiedName);
+      }
+    }
+    return enabled;
+  }
+
+  public String[] getNamespaces() {
+    return namespaces;
+  }
+
+  @Override
+  protected void processField(Object bean, String beanName, Field field) {
+
+  }
+
+  @Override
+  protected void processMethod(Object bean, String beanName, Method method) {
+
+  }
+
+  @Override
+  public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+    this.applicationContext = applicationContext;
+
+  }
+
+  @Override
+  public void afterPropertiesSet() throws Exception {
+    // We can't use constructor injection of the application context because
+    // it causes eager factory bean initialization
+    this.beanFactoryMetadata = new ApolloSpringBeanFactoryMetadata(this.applicationContext.getBean(
+        ConfigurationBeanFactoryMetadata.BEAN_NAME,
+        ConfigurationBeanFactoryMetadata.class));
+    
+    this.initialize();
+    
+    this.configUtil = ApolloInjector.getInstance(ConfigUtil.class);
+  }
+
+  @Override
+  public void setEnvironment(Environment environment) {
+    this.environment = environment;
+    this.initialize();
+  }
+
+  private void initialize() {
+    if (namespaces == null) {
+      initNamespaces();
+    }
+    
+    if (autoUpdateConfigurationPropertiesBasePackages == null) {
+      initAutoUpdateConfigurationProperties(environment);
+    }
+  }
+
+  private void initAutoUpdateConfigurationProperties(Environment environment) {
+    autoUpdateConfigurationPropertiesBasePackages = new String[]{};
+    /**
+     * Deal with whether to enable AutoUpdateConfigurationProperties
+     */
+    String value = environment.getProperty(PropertySourcesConstants.APOLLO_AUTO_REFRESH_CONFIGURATION_PROPERTIE);
+    if (Strings.isNullOrEmpty(value)) {
+      autoUpdateConfigurationProperties = false;
+    } else if ("true".equalsIgnoreCase(value)) {
+      autoUpdateConfigurationProperties = true;
+    } else if (!Strings.isNullOrEmpty(value) && !"false".equalsIgnoreCase(value)) {
+      /**
+       * When an unpassed value is not false, the passed package or class name
+       * is indicated
+       */
+      autoUpdateConfigurationProperties = true;
+      autoUpdateConfigurationPropertiesBasePackages = value.split(",");
+      for (int i = 0; i < autoUpdateConfigurationPropertiesBasePackages.length; i++) {
+        autoUpdateConfigurationPropertiesBasePackages[i] = autoUpdateConfigurationPropertiesBasePackages[i].trim();
+      }
+    } else {
+      autoUpdateConfigurationProperties = false;
+    }
+  }
+
+  private void initNamespaces() {
+    String namespaceStr = environment.getProperty(PropertySourcesConstants.APOLLO_BOOTSTRAP_NAMESPACES);
+    if (Strings.isNullOrEmpty(namespaceStr)) {
+      namespaceStr = ConfigConsts.NAMESPACE_APPLICATION;
+    }
+    if (!Strings.isNullOrEmpty(namespaceStr)) {
+      namespaces = namespaceStr.split(",");
+    }
+  }
+
+  /**
+   * Determines whether springboot ConfigurationProperties is enabled to
+   * automatically update the property values
+   * 
+   * @return
+   */
+  private boolean isAutoUpdateConfigurationPropertiesEnabled() {
+    return autoUpdateConfigurationProperties;
+  }
+
+  /**
+   * Determines whether the specified package (packageName) contains the
+   * specified BasePackages
+   * 
+   * @param packageName
+   * @return
+   */
+  private boolean isAutoUpdateConfigurationPropertiesBasePackages(String packageName) {
+    if (autoUpdateConfigurationPropertiesBasePackages == null) {
+      initAutoUpdateConfigurationProperties(environment);
+    }
+    if (autoUpdateConfigurationPropertiesBasePackages.length > 0) {
+      for (String string : autoUpdateConfigurationPropertiesBasePackages) {
+        if (string.equals(packageName)) {
+          return true;
+        }
+        //Is it subpackage
+        if (packageName.startsWith(string)) {
+          return true;
+        }
+      }
+      return false;
+    } else {
+      //Returns true if no package is configured
+      return true;
+    }
+  }
+}

--- a/apollo-client-extension/apollo-client-springboot2-extension/src/main/java/com/ctrip/framework/apollo/spring/boot/extension/ApolloRefreshConfigurationPropertiesProcessorRegistry.java
+++ b/apollo-client-extension/apollo-client-springboot2-extension/src/main/java/com/ctrip/framework/apollo/spring/boot/extension/ApolloRefreshConfigurationPropertiesProcessorRegistry.java
@@ -1,7 +1,6 @@
 package com.ctrip.framework.apollo.spring.boot.extension;
 
 import org.springframework.beans.BeansException;
-import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
@@ -17,7 +16,7 @@ import org.springframework.core.PriorityOrdered;
  * @author wangbo(wangle_r@163.com)
  */
 public class ApolloRefreshConfigurationPropertiesProcessorRegistry
-    implements BeanFactoryPostProcessor, PriorityOrdered, BeanDefinitionRegistryPostProcessor {
+    implements PriorityOrdered, BeanDefinitionRegistryPostProcessor {
 
   private int order = Ordered.HIGHEST_PRECEDENCE + 1;
 

--- a/apollo-client-extension/apollo-client-springboot2-extension/src/main/java/com/ctrip/framework/apollo/spring/boot/extension/ApolloRefreshConfigurationPropertiesProcessorRegistry.java
+++ b/apollo-client-extension/apollo-client-springboot2-extension/src/main/java/com/ctrip/framework/apollo/spring/boot/extension/ApolloRefreshConfigurationPropertiesProcessorRegistry.java
@@ -1,0 +1,50 @@
+package com.ctrip.framework.apollo.spring.boot.extension;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProcessor;
+import org.springframework.boot.context.properties.ConfigurationBeanFactoryMetadata;
+import org.springframework.core.Ordered;
+import org.springframework.core.PriorityOrdered;
+
+/**
+ * registry {@link ApolloRefreshConfigurationPropertiesProcessor},
+ * {@link ApolloRefreshConfigurationProperties}
+ * 
+ * @author wangbo(wangle_r@163.com)
+ */
+public class ApolloRefreshConfigurationPropertiesProcessorRegistry
+    implements BeanFactoryPostProcessor, PriorityOrdered, BeanDefinitionRegistryPostProcessor {
+
+  private int order = Ordered.HIGHEST_PRECEDENCE + 1;
+
+  @Override
+  public void postProcessBeanDefinitionRegistry(BeanDefinitionRegistry registry) throws BeansException {
+    registry(registry, ConfigurationBeanFactoryMetadata.BEAN_NAME, ConfigurationBeanFactoryMetadata.class);
+    registry(registry, ApolloRefreshConfigurationProperties.BEAN_NAME, ApolloRefreshConfigurationProperties.class);
+    registry(registry, ApolloRefreshConfigurationPropertiesProcessor.BEAN_NAME,
+        ApolloRefreshConfigurationPropertiesProcessor.class);
+  }
+
+  private void registry(BeanDefinitionRegistry registry, String beanName, Class<?> clas) {
+    if (!registry.containsBeanDefinition(beanName)) {
+      BeanDefinitionBuilder bean = BeanDefinitionBuilder.genericBeanDefinition(clas);
+      registry.registerBeanDefinition(beanName, bean.getBeanDefinition());
+    }
+
+  }
+
+  @Override
+  public int getOrder() {
+    return order;
+  }
+
+  @Override
+  public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {
+
+  }
+
+}

--- a/apollo-client-extension/apollo-client-springboot2-extension/src/main/java/com/ctrip/framework/apollo/spring/boot/extension/ApolloRefreshExtensionAutoConfiguration.java
+++ b/apollo-client-extension/apollo-client-springboot2-extension/src/main/java/com/ctrip/framework/apollo/spring/boot/extension/ApolloRefreshExtensionAutoConfiguration.java
@@ -1,0 +1,25 @@
+package com.ctrip.framework.apollo.spring.boot.extension;
+
+import com.ctrip.framework.apollo.spring.boot.ApolloAutoConfiguration;
+import com.ctrip.framework.apollo.spring.config.ConfigPropertySourcesProcessor;
+import com.ctrip.framework.apollo.spring.config.PropertySourcesConstants;
+
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+/**
+ * @author wangbo(wangle_r@163.com)
+ */
+@Configuration
+@ConditionalOnProperty(PropertySourcesConstants.APOLLO_BOOTSTRAP_ENABLED)
+@AutoConfigureAfter(ApolloAutoConfiguration.class)
+public class ApolloRefreshExtensionAutoConfiguration {
+
+  @Bean
+  @ConditionalOnBean(ConfigPropertySourcesProcessor.class)
+  public ApolloRefreshConfigurationPropertiesProcessorRegistry apolloRefreshConfigurationPropertiesProcessorRegistry() {
+    return new ApolloRefreshConfigurationPropertiesProcessorRegistry();
+  }
+}

--- a/apollo-client-extension/apollo-client-springboot2-extension/src/main/java/com/ctrip/framework/apollo/spring/boot/extension/ApolloSpringBeanFactoryMetadata.java
+++ b/apollo-client-extension/apollo-client-springboot2-extension/src/main/java/com/ctrip/framework/apollo/spring/boot/extension/ApolloSpringBeanFactoryMetadata.java
@@ -1,0 +1,41 @@
+package com.ctrip.framework.apollo.spring.boot.extension;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+
+import com.ctrip.framework.apollo.spring.boot.BeanFactoryMetadata;
+
+import org.springframework.boot.context.properties.ConfigurationBeanFactoryMetadata;
+
+/**
+ * 
+ * @author wangbo(wangle_r@163.com)
+ *
+ */
+public class ApolloSpringBeanFactoryMetadata implements BeanFactoryMetadata {
+  private ConfigurationBeanFactoryMetadata beanFactoryMetadata;
+  
+  public ApolloSpringBeanFactoryMetadata(ConfigurationBeanFactoryMetadata beanFactoryMetadata) {
+    super();
+    this.beanFactoryMetadata = beanFactoryMetadata;
+  }
+
+  @Override
+  public <A extends Annotation> A findFactoryAnnotation(String beanName, Class<A> type) {
+    return beanFactoryMetadata.findFactoryAnnotation(beanName, type);
+  }
+
+  public ConfigurationBeanFactoryMetadata getBeanFactoryMetadata() {
+    return beanFactoryMetadata;
+  }
+
+  public void setBeanFactoryMetadata(ConfigurationBeanFactoryMetadata beanFactoryMetadata) {
+    this.beanFactoryMetadata = beanFactoryMetadata;
+  }
+
+  public Method findFactoryMethod(String beanName) {
+    return beanFactoryMetadata.findFactoryMethod(beanName);
+  }
+  
+  
+}

--- a/apollo-client-extension/apollo-client-springboot2-extension/src/main/java/org/springframework/boot/context/properties/ApolloRefreshConfigurationPropertiesBinder.java
+++ b/apollo-client-extension/apollo-client-springboot2-extension/src/main/java/org/springframework/boot/context/properties/ApolloRefreshConfigurationPropertiesBinder.java
@@ -1,0 +1,182 @@
+package org.springframework.boot.context.properties;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.springframework.beans.PropertyEditorRegistry;
+import org.springframework.boot.context.properties.bind.ApolloBinder;
+import org.springframework.boot.context.properties.bind.BindHandler;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.PropertySourcesPlaceholdersResolver;
+import org.springframework.boot.context.properties.bind.handler.IgnoreErrorsBindHandler;
+import org.springframework.boot.context.properties.bind.handler.IgnoreTopLevelConverterNotFoundBindHandler;
+import org.springframework.boot.context.properties.bind.handler.NoUnboundElementsBindHandler;
+import org.springframework.boot.context.properties.bind.validation.ValidationBindHandler;
+import org.springframework.boot.context.properties.source.ConfigurationPropertySource;
+import org.springframework.boot.context.properties.source.ConfigurationPropertySources;
+import org.springframework.boot.context.properties.source.UnboundElementsSourceFilter;
+import org.springframework.boot.validation.MessageInterpolatorFactory;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.core.convert.ConversionService;
+import org.springframework.core.env.PropertySources;
+import org.springframework.util.Assert;
+import org.springframework.util.ClassUtils;
+import org.springframework.validation.Errors;
+import org.springframework.validation.Validator;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+
+/**
+ * {@link ConfigurationProperties} The specific implementation of automatic update update implementation
+ * 
+ * @author wangbo(wangle_r@163.com)
+ */
+public class ApolloRefreshConfigurationPropertiesBinder{
+
+  private static final String[] VALIDATOR_CLASSES = { "javax.validation.Validator",
+      "javax.validation.ValidatorFactory",
+      "javax.validation.bootstrap.GenericBootstrap" };
+  
+  private ApplicationContext applicationContext;
+
+  private Validator configurationPropertiesValidator;
+
+  private boolean jsr303Present;
+
+  private Validator jsr303Validator;
+  
+  private ConversionService conversionService;
+  
+  public ApolloRefreshConfigurationPropertiesBinder(ApplicationContext applicationContext, String validatorBeanName) {
+    this.applicationContext = applicationContext;
+    this.configurationPropertiesValidator = getConfigurationPropertiesValidator(validatorBeanName);
+    this.jsr303Present = isJsr303Present();
+    this.conversionService = getConversionService();
+  }
+  
+  public boolean isJsr303Present() {
+    ClassLoader classLoader = this.applicationContext.getClassLoader();
+    for (String validatorClass : VALIDATOR_CLASSES) {
+      if (!ClassUtils.isPresent(validatorClass, classLoader)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  public void bind(Bindable<?> target, PropertySources propertySources) {
+    ConfigurationProperties annotation = target
+        .getAnnotation(ConfigurationProperties.class);
+    Assert.state(annotation != null,
+        () -> "Missing @ConfigurationProperties on " + target);
+    List<Validator> validators = getValidators(target);
+    BindHandler bindHandler = getBindHandler(annotation, validators);
+    getBinder(propertySources).bind(annotation.prefix(), target, bindHandler);
+  }
+
+  
+  private Validator getConfigurationPropertiesValidator(String validatorBeanName) {
+    if (this.applicationContext.containsBean(validatorBeanName)) {
+      return this.applicationContext.getBean(validatorBeanName, Validator.class);
+    }
+    return null;
+  }
+
+  private List<Validator> getValidators(Bindable<?> target) {
+    List<Validator> validators = new ArrayList<>(3);
+    if (this.configurationPropertiesValidator != null) {
+      validators.add(this.configurationPropertiesValidator);
+    }
+    if (this.jsr303Present && target.getAnnotation(Validated.class) != null) {
+      validators.add(getJsr303Validator());
+    }
+    if (target.getValue() != null && target.getValue().get() instanceof Validator) {
+      validators.add((Validator) target.getValue().get());
+    }
+    return validators;
+  }
+
+  private Validator getJsr303Validator() {
+    if (this.jsr303Validator == null) {
+      this.jsr303Validator = new Jsr303Validator(
+          this.applicationContext);
+    }
+    return this.jsr303Validator;
+  }
+
+  private BindHandler getBindHandler(ConfigurationProperties annotation,
+      List<Validator> validators) {
+    BindHandler handler = new IgnoreTopLevelConverterNotFoundBindHandler();
+    if (annotation.ignoreInvalidFields()) {
+      handler = new IgnoreErrorsBindHandler(handler);
+    }
+    if (!annotation.ignoreUnknownFields()) {
+      UnboundElementsSourceFilter filter = new UnboundElementsSourceFilter();
+      handler = new NoUnboundElementsBindHandler(handler, filter);
+    }
+    if (!validators.isEmpty()) {
+      handler = new ValidationBindHandler(handler,
+          validators.toArray(new Validator[0]));
+    }
+    return handler;
+  }
+
+  private ApolloBinder getBinder(PropertySources propertySources) {
+      return new ApolloBinder(getConfigurationPropertySources(propertySources),
+          getPropertySourcesPlaceholdersResolver(propertySources), conversionService,
+          getPropertyEditorInitializer());
+  }
+
+  private Iterable<ConfigurationPropertySource> getConfigurationPropertySources(PropertySources propertySources) {
+    return ConfigurationPropertySources.from(propertySources);
+  }
+
+  private PropertySourcesPlaceholdersResolver getPropertySourcesPlaceholdersResolver(PropertySources propertySources) {
+    return new PropertySourcesPlaceholdersResolver(propertySources);
+  }
+
+  private ConversionService getConversionService() {
+    
+    return new ConversionServiceDeducer(this.applicationContext).getConversionService();
+  }
+
+  private Consumer<PropertyEditorRegistry> getPropertyEditorInitializer() {
+    if (this.applicationContext instanceof ConfigurableApplicationContext) {
+      return ((ConfigurableApplicationContext) this.applicationContext)
+          .getBeanFactory()::copyRegisteredEditorsTo;
+    }
+    return null;
+  }
+
+  
+  private  final class Jsr303Validator implements Validator {
+
+    private final Delegate delegate;
+
+    Jsr303Validator(ApplicationContext applicationContext) {
+      this.delegate = new Delegate(applicationContext);
+    }
+
+    @Override
+    public boolean supports(Class<?> type) {
+      return this.delegate.supports(type);
+    }
+
+    @Override
+    public void validate(Object target, Errors errors) {
+      this.delegate.validate(target, errors);
+    }
+
+  }
+  private static class Delegate extends LocalValidatorFactoryBean {
+    
+    Delegate(ApplicationContext applicationContext) {
+      setApplicationContext(applicationContext);
+      setMessageInterpolator(new MessageInterpolatorFactory().getObject());
+      afterPropertiesSet();
+    }
+    
+  }
+}

--- a/apollo-client-extension/apollo-client-springboot2-extension/src/main/java/org/springframework/boot/context/properties/bind/ApolloAggregateBinder.java
+++ b/apollo-client-extension/apollo-client-springboot2-extension/src/main/java/org/springframework/boot/context/properties/bind/ApolloAggregateBinder.java
@@ -1,0 +1,99 @@
+package org.springframework.boot.context.properties.bind;
+
+import java.util.function.Supplier;
+
+import org.springframework.boot.context.properties.bind.AggregateElementBinder;
+import org.springframework.boot.context.properties.bind.ApolloBinder.ApolloContext;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.source.ConfigurationPropertyName;
+import org.springframework.boot.context.properties.source.ConfigurationPropertySource;
+
+public abstract class ApolloAggregateBinder<T> {
+
+  private final ApolloContext context;
+
+  ApolloAggregateBinder(ApolloContext context) {
+    this.context = context;
+  }
+
+  /**
+   * Determine if recursive binding is supported.
+   * @param source the configuration property source or {@code null} for all sources.
+   * @return if recursive binding is supported
+   */
+  protected abstract boolean isAllowRecursiveBinding(
+      ConfigurationPropertySource source);
+
+  /**
+   * Perform binding for the aggregate.
+   * @param name the configuration property name to bind
+   * @param target the target to bind
+   * @param elementBinder an element binder
+   * @return the bound aggregate or null
+   */
+  @SuppressWarnings("unchecked")
+  public final Object bind(ConfigurationPropertyName name, Bindable<?> target,
+      AggregateElementBinder elementBinder) {
+    Object result = bindAggregate(name, target, elementBinder);
+    Supplier<?> value = target.getValue();
+    if (result == null || value == null) {
+      return result;
+    }
+    return merge(value, (T) result);
+  }
+
+  /**
+   * Perform the actual aggregate binding.
+   * @param name the configuration property name to bind
+   * @param target the target to bind
+   * @param elementBinder an element binder
+   * @return the bound result
+   */
+  protected abstract Object bindAggregate(ConfigurationPropertyName name,
+      Bindable<?> target, AggregateElementBinder elementBinder);
+
+  /**
+   * Merge any additional elements into the existing aggregate.
+   * @param existing the supplier for the existing value
+   * @param additional the additional elements to merge
+   * @return the merged result
+   */
+  protected abstract T merge(Supplier<?> existing, T additional);
+
+  /**
+   * Return the context being used by this binder.
+   * @return the context
+   */
+  protected final ApolloContext getContext() {
+    return this.context;
+  }
+
+  /**
+   * Internal class used to supply the aggregate and cache the value.
+   *
+   * @param <T> the aggregate type
+   */
+  protected static class ApolloAggregateSupplier<T> {
+
+    private final Supplier<T> supplier;
+
+    private T supplied;
+
+    public ApolloAggregateSupplier(Supplier<T> supplier) {
+      this.supplier = supplier;
+    }
+
+    public T get() {
+      if (this.supplied == null) {
+        this.supplied = this.supplier.get();
+      }
+      return this.supplied;
+    }
+
+    public boolean wasSupplied() {
+      return this.supplied != null;
+    }
+
+  }
+
+}

--- a/apollo-client-extension/apollo-client-springboot2-extension/src/main/java/org/springframework/boot/context/properties/bind/ApolloArrayBinder.java
+++ b/apollo-client-extension/apollo-client-springboot2-extension/src/main/java/org/springframework/boot/context/properties/bind/ApolloArrayBinder.java
@@ -1,0 +1,49 @@
+package org.springframework.boot.context.properties.bind;
+import java.lang.reflect.Array;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+
+import org.springframework.boot.context.properties.bind.AggregateBinder;
+import org.springframework.boot.context.properties.bind.AggregateElementBinder;
+import org.springframework.boot.context.properties.bind.ApolloBinder.ApolloContext;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.source.ConfigurationPropertyName;
+import org.springframework.core.ResolvableType;
+
+/**
+ * {@link AggregateBinder} for arrays.
+ *
+ * @author Phillip Webb
+ * @author Madhura Bhave
+ */
+class ApolloArrayBinder extends ApolloIndexedElementsBinder<Object> {
+
+	ApolloArrayBinder(ApolloContext context) {
+		super(context);
+	}
+
+	@Override
+	protected Object bindAggregate(ConfigurationPropertyName name, Bindable<?> target,
+			AggregateElementBinder elementBinder) {
+	  ApolloIndexedCollectionSupplier result = new ApolloIndexedCollectionSupplier(ArrayList::new);
+		ResolvableType aggregateType = target.getType();
+		ResolvableType elementType = target.getType().getComponentType();
+		bindIndexed(name, target, elementBinder, aggregateType, elementType, result);
+		if (result.wasSupplied()) {
+			List<Object> list = (List<Object>) result.get();
+			Object array = Array.newInstance(elementType.resolve(), list.size());
+			for (int i = 0; i < list.size(); i++) {
+				Array.set(array, i, list.get(i));
+			}
+			return array;
+		}
+		return null;
+	}
+
+	@Override
+	protected Object merge(Supplier<?> existing, Object additional) {
+		return additional;
+	}
+
+}

--- a/apollo-client-extension/apollo-client-springboot2-extension/src/main/java/org/springframework/boot/context/properties/bind/ApolloBinder.java
+++ b/apollo-client-extension/apollo-client-springboot2-extension/src/main/java/org/springframework/boot/context/properties/bind/ApolloBinder.java
@@ -1,0 +1,481 @@
+package org.springframework.boot.context.properties.bind;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import org.springframework.beans.PropertyEditorRegistry;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.boot.context.properties.bind.BeanPropertyBinder;
+import org.springframework.boot.context.properties.bind.BindContext;
+import org.springframework.boot.context.properties.bind.BindConverter;
+import org.springframework.boot.context.properties.bind.BindException;
+import org.springframework.boot.context.properties.bind.BindHandler;
+import org.springframework.boot.context.properties.bind.BindResult;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.PlaceholdersResolver;
+import org.springframework.boot.context.properties.bind.PropertySourcesPlaceholdersResolver;
+import org.springframework.boot.context.properties.source.ConfigurationProperty;
+import org.springframework.boot.context.properties.source.ConfigurationPropertyName;
+import org.springframework.boot.context.properties.source.ConfigurationPropertySource;
+import org.springframework.boot.context.properties.source.ConfigurationPropertySources;
+import org.springframework.boot.context.properties.source.ConfigurationPropertyState;
+import org.springframework.boot.convert.ApplicationConversionService;
+import org.springframework.core.convert.ConversionService;
+import org.springframework.core.convert.ConverterNotFoundException;
+import org.springframework.core.env.Environment;
+import org.springframework.format.support.DefaultFormattingConversionService;
+import org.springframework.util.Assert;
+import org.springframework.util.ClassUtils;
+/**
+ * 
+ * @author wangbo(wangle_r@163.com)
+ *
+ */
+public class ApolloBinder {
+
+  private static final Set<Class<?>> NON_BEAN_CLASSES = Collections
+      .unmodifiableSet(new HashSet<>(Arrays.asList(Object.class, Class.class)));
+
+  private static final List<ExtensionBinder> BEAN_BINDERS;
+
+  static {
+    List<ExtensionBinder> binders = new ArrayList<>();
+    binders.add(new ApolloJavaBeanBinder());
+    BEAN_BINDERS = Collections.unmodifiableList(binders);
+  }
+
+  private final Iterable<ConfigurationPropertySource> sources;
+
+  private final PlaceholdersResolver placeholdersResolver;
+
+  private final ConversionService conversionService;
+
+  private final Consumer<PropertyEditorRegistry> propertyEditorInitializer;
+
+  /**
+   * Create a new {@link ApolloBinder} instance for the specified sources. A
+   * {@link DefaultFormattingConversionService} will be used for all conversion.
+   * @param sources the sources used for binding
+   */
+  public ApolloBinder(ConfigurationPropertySource... sources) {
+    this(Arrays.asList(sources), null, null, null);
+  }
+
+  /**
+   * Create a new {@link ApolloBinder} instance for the specified sources. A
+   * {@link DefaultFormattingConversionService} will be used for all conversion.
+   * @param sources the sources used for binding
+   */
+  public ApolloBinder(Iterable<ConfigurationPropertySource> sources) {
+    this(sources, null, null, null);
+  }
+
+  /**
+   * Create a new {@link ApolloBinder} instance for the specified sources.
+   * @param sources the sources used for binding
+   * @param placeholdersResolver strategy to resolve any property place-holders
+   */
+  public ApolloBinder(Iterable<ConfigurationPropertySource> sources,
+      PlaceholdersResolver placeholdersResolver) {
+    this(sources, placeholdersResolver, null, null);
+  }
+
+  /**
+   * Create a new {@link ApolloBinder} instance for the specified sources.
+   * @param sources the sources used for binding
+   * @param placeholdersResolver strategy to resolve any property place-holders
+   * @param conversionService the conversion service to convert values (or {@code null}
+   * to use {@link ApplicationConversionService})
+   */
+  public ApolloBinder(Iterable<ConfigurationPropertySource> sources,
+      PlaceholdersResolver placeholdersResolver,
+      ConversionService conversionService) {
+    this(sources, placeholdersResolver, conversionService, null);
+  }
+
+  /**
+   * Create a new {@link ApolloBinder} instance for the specified sources.
+   * @param sources the sources used for binding
+   * @param placeholdersResolver strategy to resolve any property place-holders
+   * @param conversionService the conversion service to convert values (or {@code null}
+   * to use {@link ApplicationConversionService})
+   * @param propertyEditorInitializer initializer used to configure the property editors
+   * that can convert values (or {@code null} if no initialization is required). Often
+   * used to call {@link ConfigurableListableBeanFactory#copyRegisteredEditorsTo}.
+   */
+  public ApolloBinder(Iterable<ConfigurationPropertySource> sources,
+      PlaceholdersResolver placeholdersResolver,
+      ConversionService conversionService,
+      Consumer<PropertyEditorRegistry> propertyEditorInitializer) {
+    Assert.notNull(sources, "Sources must not be null");
+    this.sources = sources;
+    this.placeholdersResolver = (placeholdersResolver != null) ? placeholdersResolver
+        : PlaceholdersResolver.NONE;
+    this.conversionService = (conversionService != null) ? conversionService
+        : ApplicationConversionService.getSharedInstance();
+    this.propertyEditorInitializer = propertyEditorInitializer;
+  }
+
+  /**
+   * Bind the specified target {@link Class} using this binders
+   * {@link ConfigurationPropertySource property sources}.
+   * @param name the configuration property name to bind
+   * @param target the target class
+   * @param <T> the bound type
+   * @return the binding result (never {@code null})
+   * @see #bind(ConfigurationPropertyName, Bindable, BindHandler)
+   */
+  public <T> BindResult<T> bind(String name, Class<T> target) {
+    return bind(name, Bindable.of(target));
+  }
+
+  /**
+   * Bind the specified target {@link Bindable} using this binders
+   * {@link ConfigurationPropertySource property sources}.
+   * @param name the configuration property name to bind
+   * @param target the target bindable
+   * @param <T> the bound type
+   * @return the binding result (never {@code null})
+   * @see #bind(ConfigurationPropertyName, Bindable, BindHandler)
+   */
+  public <T> BindResult<T> bind(String name, Bindable<T> target) {
+    return bind(ConfigurationPropertyName.of(name), target, null);
+  }
+
+  /**
+   * Bind the specified target {@link Bindable} using this binders
+   * {@link ConfigurationPropertySource property sources}.
+   * @param name the configuration property name to bind
+   * @param target the target bindable
+   * @param <T> the bound type
+   * @return the binding result (never {@code null})
+   * @see #bind(ConfigurationPropertyName, Bindable, BindHandler)
+   */
+  public <T> BindResult<T> bind(ConfigurationPropertyName name, Bindable<T> target) {
+    return bind(name, target, null);
+  }
+
+  /**
+   * Bind the specified target {@link Bindable} using this binders
+   * {@link ConfigurationPropertySource property sources}.
+   * @param name the configuration property name to bind
+   * @param target the target bindable
+   * @param handler the bind handler (may be {@code null})
+   * @param <T> the bound type
+   * @return the binding result (never {@code null})
+   */
+  public <T> BindResult<T> bind(String name, Bindable<T> target, BindHandler handler) {
+    return bind(ConfigurationPropertyName.of(name), target, handler);
+  }
+
+  /**
+   * Bind the specified target {@link Bindable} using this binders
+   * {@link ConfigurationPropertySource property sources}.
+   * @param name the configuration property name to bind
+   * @param target the target bindable
+   * @param handler the bind handler (may be {@code null})
+   * @param <T> the bound type
+   * @return the binding result (never {@code null})
+   */
+  public <T> BindResult<T> bind(ConfigurationPropertyName name, Bindable<T> target,
+      BindHandler handler) {
+    Assert.notNull(name, "Name must not be null");
+    Assert.notNull(target, "Target must not be null");
+    handler = (handler != null) ? handler : BindHandler.DEFAULT;
+    ApolloContext context = new ApolloContext();
+    T bound = bind(name, target, handler, context, false);
+    return BindResult.of(bound);
+  }
+
+  protected final <T> T bind(ConfigurationPropertyName name, Bindable<T> target,
+      BindHandler handler, ApolloContext context, boolean allowRecursiveBinding) {
+    context.clearConfigurationProperty();
+    try {
+      if (!handler.onStart(name, target, context)) {
+        return null;
+      }
+      Object bound = bindObject(name, target, handler, context,
+          allowRecursiveBinding);
+      return handleBindResult(name, target, handler, context, bound);
+    }
+    catch (Exception ex) {
+      return handleBindError(name, target, handler, context, ex);
+    }
+  }
+
+  private <T> T handleBindResult(ConfigurationPropertyName name, Bindable<T> target,
+      BindHandler handler, ApolloContext context, Object result) throws Exception {
+    if (result != null) {
+      result = handler.onSuccess(name, target, context, result);
+      result = context.getConverter().convert(result, target);
+    }
+    handler.onFinish(name, target, context, result);
+    return context.getConverter().convert(result, target);
+  }
+
+  private <T> T handleBindError(ConfigurationPropertyName name, Bindable<T> target,
+      BindHandler handler, ApolloContext context, Exception error) {
+    try {
+      Object result = handler.onFailure(name, target, context, error);
+      return context.getConverter().convert(result, target);
+    }
+    catch (Exception ex) {
+      if (ex instanceof BindException) {
+        throw (BindException) ex;
+      }
+      throw new BindException(name, target, context.getConfigurationProperty(), ex);
+    }
+  }
+
+  private <T> Object bindObject(ConfigurationPropertyName name, Bindable<T> target,
+      BindHandler handler, ApolloContext context, boolean allowRecursiveBinding) {
+    ConfigurationProperty property = findProperty(name, context);
+    if (property == null && containsNoDescendantOf(context.streamSources(), name)) {
+      return null;
+    }
+    ApolloAggregateBinder<?> aggregateBinder = getAggregateBinder(target, context);
+    if (aggregateBinder != null) {
+      return bindAggregate(name, target, handler, context, aggregateBinder);
+    }
+    
+    if (property != null) {
+      try {
+        return bindProperty(target, context, property);
+      }
+      catch (ConverterNotFoundException ex) {
+        // We might still be able to bind it as a bean
+        Object bean = bindBean(name, target, handler, context,
+            allowRecursiveBinding);
+        if (bean != null) {
+          return bean;
+        }
+        throw ex;
+      }
+    }
+    return bindBean(name, target, handler, context, allowRecursiveBinding);
+  }
+
+  @SuppressWarnings("rawtypes")
+  private ApolloAggregateBinder getAggregateBinder(Bindable<?> target, ApolloContext context) {
+    Class<?> resolvedType = target.getType().resolve(Object.class);
+    if (Map.class.isAssignableFrom(resolvedType)) {
+      return new ApolloMapBinder(context);
+    }
+    if (Collection.class.isAssignableFrom(resolvedType)) {
+      return new ApolloCollectionBinder(context);
+    }
+    if (target.getType().isArray()) {
+      return new ApolloArrayBinder(context);
+    }
+    return null;
+  }
+
+  private <T> Object bindAggregate(ConfigurationPropertyName name, Bindable<T> target,
+      BindHandler handler, ApolloContext context, ApolloAggregateBinder<?> aggregateBinder) {
+    AggregateElementBinder elementBinder = (itemName, itemTarget, source) -> {
+      boolean allowRecursiveBinding = aggregateBinder
+          .isAllowRecursiveBinding(source);
+      Supplier<?> supplier = () -> bind(itemName, itemTarget, handler, context,
+          allowRecursiveBinding);
+      return context.withSource(source, supplier);
+    };
+    return context.withIncreasedDepth(
+        () -> aggregateBinder.bind(name, target, elementBinder));
+  }
+
+  private ConfigurationProperty findProperty(ConfigurationPropertyName name,
+      ApolloContext context) {
+    if (name.isEmpty()) {
+      return null;
+    }
+    return context.streamSources()
+        .map((source) -> source.getConfigurationProperty(name))
+        .filter(Objects::nonNull).findFirst().orElse(null);
+  }
+
+  private <T> Object bindProperty(Bindable<T> target, ApolloContext context,
+      ConfigurationProperty property) {
+    context.setConfigurationProperty(property);
+    Object result = property.getValue();
+    result = this.placeholdersResolver.resolvePlaceholders(result);
+    result = context.getConverter().convert(result, target);
+    return result;
+  }
+
+  private Object bindBean(ConfigurationPropertyName name, Bindable<?> target,
+      BindHandler handler, ApolloContext context, boolean allowRecursiveBinding) {
+    if (containsNoDescendantOf(context.streamSources(), name)
+        || isUnbindableBean(name, target, context)) {
+      return null;
+    }
+    BeanPropertyBinder propertyBinder = (propertyName, propertyTarget) -> bind(
+        name.append(propertyName), propertyTarget, handler, context, false);
+    Class<?> type = target.getType().resolve(Object.class);
+    if (!allowRecursiveBinding && context.hasBoundBean(type)) {
+      return null;
+    }
+    return context.withBean(type, () -> {
+      Stream<?> boundBeans = BEAN_BINDERS.stream()
+          .map((b) -> b.bind(name, target, context, propertyBinder));
+      return boundBeans.filter(Objects::nonNull).findFirst().orElse(null);
+    });
+  }
+
+  private boolean isUnbindableBean(ConfigurationPropertyName name, Bindable<?> target,
+      ApolloContext context) {
+    if (context.streamSources().anyMatch((s) -> s
+        .containsDescendantOf(name) == ConfigurationPropertyState.PRESENT)) {
+      // We know there are properties to bind so we can't bypass anything
+      return false;
+    }
+    Class<?> resolved = target.getType().resolve(Object.class);
+    if (resolved.isPrimitive() || NON_BEAN_CLASSES.contains(resolved)) {
+      return true;
+    }
+    String packageName = ClassUtils.getPackageName(resolved);
+    return packageName.startsWith("java.");
+  }
+
+  private boolean containsNoDescendantOf(Stream<ConfigurationPropertySource> sources,
+      ConfigurationPropertyName name) {
+    return sources.allMatch(
+        (s) -> s.containsDescendantOf(name) == ConfigurationPropertyState.ABSENT);
+  }
+
+  /**
+   * Create a new {@link ApolloBinder} instance from the specified environment.
+   * @param environment the environment source (must have attached
+   * {@link ConfigurationPropertySources})
+   * @return a {@link ApolloBinder} instance
+   */
+  public static ApolloBinder get(Environment environment) {
+    return new ApolloBinder(ConfigurationPropertySources.get(environment),
+        new PropertySourcesPlaceholdersResolver(environment));
+  }
+
+  /**
+   * Context used when binding and the {@link BindContext} implementation.
+   */
+  final class ApolloContext implements BindContext {
+
+    private final BindConverter converter;
+
+    private int depth;
+
+    private final List<ConfigurationPropertySource> source = Arrays
+        .asList((ConfigurationPropertySource) null);
+
+    private int sourcePushCount;
+
+    private final Deque<Class<?>> beans = new ArrayDeque<>();
+
+    private ConfigurationProperty configurationProperty;
+
+    ApolloContext() {
+      this.converter = new BindConverter(ApolloBinder.this.conversionService,
+          ApolloBinder.this.propertyEditorInitializer);
+    }
+
+    private void increaseDepth() {
+      this.depth++;
+    }
+
+    private void decreaseDepth() {
+      this.depth--;
+    }
+    private <T> T withSource(ConfigurationPropertySource source,
+        Supplier<T> supplier) {
+      if (source == null) {
+        return supplier.get();
+      }
+      this.source.set(0, source);
+      this.sourcePushCount++;
+      try {
+        return supplier.get();
+      }
+      finally {
+        this.sourcePushCount--;
+      }
+    }
+    private <T> T withBean(Class<?> bean, Supplier<T> supplier) {
+      this.beans.push(bean);
+      try {
+        return withIncreasedDepth(supplier);
+      }
+      finally {
+        this.beans.pop();
+      }
+    }
+
+    private boolean hasBoundBean(Class<?> bean) {
+      return this.beans.contains(bean);
+    }
+
+    private <T> T withIncreasedDepth(Supplier<T> supplier) {
+      increaseDepth();
+      try {
+        return supplier.get();
+      }
+      finally {
+        decreaseDepth();
+      }
+    }
+
+    private void setConfigurationProperty(
+        ConfigurationProperty configurationProperty) {
+      this.configurationProperty = configurationProperty;
+    }
+
+    private void clearConfigurationProperty() {
+      this.configurationProperty = null;
+    }
+
+    public Stream<ConfigurationPropertySource> streamSources() {
+      if (this.sourcePushCount > 0) {
+        return this.source.stream();
+      }
+      return StreamSupport.stream(ApolloBinder.this.sources.spliterator(), false);
+    }
+
+    public PlaceholdersResolver getPlaceholdersResolver() {
+      return ApolloBinder.this.placeholdersResolver;
+    }
+
+    public BindConverter getConverter() {
+      return this.converter;
+    }
+
+    @Override
+    public int getDepth() {
+      return this.depth;
+    }
+
+    @Override
+    public Iterable<ConfigurationPropertySource> getSources() {
+      if (this.sourcePushCount > 0) {
+        return this.source;
+      }
+      return ApolloBinder.this.sources;
+    }
+
+    @Override
+    public ConfigurationProperty getConfigurationProperty() {
+      return this.configurationProperty;
+    }
+
+  }
+
+}

--- a/apollo-client-extension/apollo-client-springboot2-extension/src/main/java/org/springframework/boot/context/properties/bind/ApolloCollectionBinder.java
+++ b/apollo-client-extension/apollo-client-springboot2-extension/src/main/java/org/springframework/boot/context/properties/bind/ApolloCollectionBinder.java
@@ -1,0 +1,80 @@
+package org.springframework.boot.context.properties.bind;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Supplier;
+
+import org.springframework.boot.context.properties.bind.AggregateElementBinder;
+import org.springframework.boot.context.properties.bind.ApolloBinder.ApolloContext;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.source.ConfigurationPropertyName;
+import org.springframework.core.CollectionFactory;
+import org.springframework.core.ResolvableType;
+
+class ApolloCollectionBinder extends ApolloIndexedElementsBinder<Collection<Object>> {
+
+	ApolloCollectionBinder(ApolloContext context) {
+		super(context);
+	}
+
+	@Override
+	protected Object bindAggregate(ConfigurationPropertyName name, Bindable<?> target,
+			AggregateElementBinder elementBinder) {
+		Class<?> collectionType = (target.getValue() != null) ? List.class
+				: target.getType().resolve(Object.class);
+		ResolvableType aggregateType = ResolvableType.forClassWithGenerics(List.class,
+				target.getType().asCollection().getGenerics());
+		ResolvableType elementType = target.getType().asCollection().getGeneric();
+		ApolloIndexedCollectionSupplier result = new ApolloIndexedCollectionSupplier(
+				() -> CollectionFactory.createCollection(collectionType, 0));
+		bindIndexed(name, target, elementBinder, aggregateType, elementType, result);
+		if (result.wasSupplied()) {
+			return result.get();
+		}
+		return null;
+	}
+
+	@Override
+	protected Collection<Object> merge(Supplier<?> existing,
+			Collection<Object> additional) {
+		Collection<Object> existingCollection = getExistingIfPossible(existing);
+		if (existingCollection == null) {
+			return additional;
+		}
+		try {
+			existingCollection.clear();
+			existingCollection.addAll(additional);
+			return copyIfPossible(existingCollection);
+		}
+		catch (UnsupportedOperationException ex) {
+			return createNewCollection(additional);
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	private Collection<Object> getExistingIfPossible(Supplier<?> existing) {
+		try {
+			return (Collection<Object>) existing.get();
+		}
+		catch (Exception ex) {
+			return null;
+		}
+	}
+
+	private Collection<Object> copyIfPossible(Collection<Object> collection) {
+		try {
+			return createNewCollection(collection);
+		}
+		catch (Exception ex) {
+			return collection;
+		}
+	}
+
+	private Collection<Object> createNewCollection(Collection<Object> collection) {
+		Collection<Object> result = CollectionFactory
+				.createCollection(collection.getClass(), collection.size());
+		result.addAll(collection);
+		return result;
+	}
+
+}

--- a/apollo-client-extension/apollo-client-springboot2-extension/src/main/java/org/springframework/boot/context/properties/bind/ApolloIndexedElementsBinder.java
+++ b/apollo-client-extension/apollo-client-springboot2-extension/src/main/java/org/springframework/boot/context/properties/bind/ApolloIndexedElementsBinder.java
@@ -1,0 +1,146 @@
+package org.springframework.boot.context.properties.bind;
+
+import java.lang.annotation.Annotation;
+import java.util.Collection;
+import java.util.List;
+import java.util.TreeSet;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import org.springframework.boot.context.properties.bind.ApolloBinder.ApolloContext;
+import org.springframework.boot.context.properties.source.ConfigurationProperty;
+import org.springframework.boot.context.properties.source.ConfigurationPropertyName;
+import org.springframework.boot.context.properties.source.ConfigurationPropertyName.Form;
+import org.springframework.boot.context.properties.source.ConfigurationPropertySource;
+import org.springframework.boot.context.properties.source.IterableConfigurationPropertySource;
+import org.springframework.core.ResolvableType;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.util.StringUtils;
+
+abstract class ApolloIndexedElementsBinder<T> extends ApolloAggregateBinder<T> {
+
+  private static final String INDEX_ZERO = "[0]";
+
+  ApolloIndexedElementsBinder(ApolloContext context) {
+    super(context);
+  }
+
+  @Override
+  protected boolean isAllowRecursiveBinding(ConfigurationPropertySource source) {
+    return source == null || source instanceof IterableConfigurationPropertySource;
+  }
+
+  /**
+   * Bind indexed elements to the supplied collection.
+   * @param name the name of the property to bind
+   * @param target the target bindable
+   * @param elementBinder the binder to use for elements
+   * @param aggregateType the aggregate type, may be a collection or an array
+   * @param elementType the element type
+   * @param result the destination for results
+   */
+  protected final void bindIndexed(ConfigurationPropertyName name, Bindable<?> target,
+      AggregateElementBinder elementBinder, ResolvableType aggregateType,
+      ResolvableType elementType, ApolloIndexedCollectionSupplier result) {
+    for (ConfigurationPropertySource source : getContext().getSources()) {
+      bindIndexed(source, name, target, elementBinder, result, aggregateType,
+          elementType);
+      if (result.wasSupplied() && result.get() != null) {
+        return;
+      }
+    }
+  }
+
+  private void bindIndexed(ConfigurationPropertySource source,
+      ConfigurationPropertyName root, Bindable<?> target,
+      AggregateElementBinder elementBinder, ApolloIndexedCollectionSupplier collection,
+      ResolvableType aggregateType, ResolvableType elementType) {
+    ConfigurationProperty property = source.getConfigurationProperty(root);
+    if (property != null) {
+      bindValue(target, collection.get(), aggregateType, elementType,
+          property.getValue());
+    }
+    else {
+      bindIndexed(source, root, elementBinder, collection, elementType);
+    }
+  }
+
+  private void bindValue(Bindable<?> target, Collection<Object> collection,
+      ResolvableType aggregateType, ResolvableType elementType, Object value) {
+    if (value instanceof String && !StringUtils.hasText((String) value)) {
+      return;
+    }
+    Object aggregate = convert(value, aggregateType, target.getAnnotations());
+    ResolvableType collectionType = ResolvableType
+        .forClassWithGenerics(collection.getClass(), elementType);
+    Collection<Object> elements = convert(aggregate, collectionType);
+    collection.addAll(elements);
+  }
+
+  private void bindIndexed(ConfigurationPropertySource source,
+      ConfigurationPropertyName root, AggregateElementBinder elementBinder,
+      ApolloIndexedCollectionSupplier collection, ResolvableType elementType) {
+    MultiValueMap<String, ConfigurationProperty> knownIndexedChildren = getKnownIndexedChildren(
+        source, root);
+    for (int i = 0; i < Integer.MAX_VALUE; i++) {
+      ConfigurationPropertyName name = root
+          .append((i != 0) ? "[" + i + "]" : INDEX_ZERO);
+      Object value = elementBinder.bind(name, Bindable.of(elementType), source);
+      if (value == null) {
+        break;
+      }
+      knownIndexedChildren.remove(name.getLastElement(Form.UNIFORM));
+      collection.get().add(value);
+    }
+    assertNoUnboundChildren(knownIndexedChildren);
+  }
+
+  private MultiValueMap<String, ConfigurationProperty> getKnownIndexedChildren(
+      ConfigurationPropertySource source, ConfigurationPropertyName root) {
+    MultiValueMap<String, ConfigurationProperty> children = new LinkedMultiValueMap<>();
+    if (!(source instanceof IterableConfigurationPropertySource)) {
+      return children;
+    }
+    for (ConfigurationPropertyName name : (IterableConfigurationPropertySource) source
+        .filter(root::isAncestorOf)) {
+      ConfigurationPropertyName choppedName = name
+          .chop(root.getNumberOfElements() + 1);
+      if (choppedName.isLastElementIndexed()) {
+        String key = choppedName.getLastElement(Form.UNIFORM);
+        ConfigurationProperty value = source.getConfigurationProperty(name);
+        children.add(key, value);
+      }
+    }
+    return children;
+  }
+
+  private void assertNoUnboundChildren(
+      MultiValueMap<String, ConfigurationProperty> children) {
+    if (!children.isEmpty()) {
+      throw new UnboundConfigurationPropertiesException(
+          children.values().stream().flatMap(List::stream)
+              .collect(Collectors.toCollection(TreeSet::new)));
+    }
+  }
+
+  private <C> C convert(Object value, ResolvableType type, Annotation... annotations) {
+    value = getContext().getPlaceholdersResolver().resolvePlaceholders(value);
+    return getContext().getConverter().convert(value, type, annotations);
+  }
+
+  /**
+   * {@link AggregateBinder.AggregateSupplier AggregateSupplier} for an indexed
+   * collection.
+   */
+  protected static class ApolloIndexedCollectionSupplier
+      extends ApolloAggregateSupplier<Collection<Object>> {
+
+    public ApolloIndexedCollectionSupplier(Supplier<Collection<Object>> supplier) {
+      super(supplier);
+    }
+
+  }
+
+}
+

--- a/apollo-client-extension/apollo-client-springboot2-extension/src/main/java/org/springframework/boot/context/properties/bind/ApolloJavaBeanBinder.java
+++ b/apollo-client-extension/apollo-client-springboot2-extension/src/main/java/org/springframework/boot/context/properties/bind/ApolloJavaBeanBinder.java
@@ -1,0 +1,378 @@
+package org.springframework.boot.context.properties.bind;
+
+import java.beans.Introspector;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.function.Supplier;
+
+import org.springframework.beans.BeanUtils;
+import org.springframework.boot.context.properties.bind.ApolloBinder.ApolloContext;
+import org.springframework.boot.context.properties.source.ConfigurationPropertyName;
+import org.springframework.boot.context.properties.source.ConfigurationPropertyState;
+import org.springframework.core.MethodParameter;
+import org.springframework.core.ResolvableType;
+import org.springframework.core.annotation.AnnotationUtils;
+
+import com.ctrip.framework.apollo.build.ApolloInjector;
+import com.ctrip.framework.apollo.spring.annotation.AutoRefresh;
+import com.ctrip.framework.apollo.spring.annotation.RefreshEnabled;
+import com.ctrip.framework.apollo.spring.annotation.RefreshField;
+import com.ctrip.framework.apollo.util.ConfigUtil;
+
+/**
+ * {@link BeanBinder} for mutable Java Beans.
+ *
+ *  @author wangbo(wangle_r@163.com)
+ */
+class ApolloJavaBeanBinder implements ExtensionBinder {
+  private ConfigUtil configUtil;
+  
+  public ApolloJavaBeanBinder() {
+    super();
+    this.configUtil = ApolloInjector.getInstance(ConfigUtil.class);
+  }
+
+  @Override
+  public <T> T bind(ConfigurationPropertyName name, Bindable<T> target, ApolloContext context,
+      BeanPropertyBinder propertyBinder) {
+    boolean hasKnownBindableProperties = context.streamSources().anyMatch((
+        s) -> s.containsDescendantOf(name) == ConfigurationPropertyState.PRESENT);
+    ApolloBeanExtension<T> bean = ApolloBeanExtension.get(target, hasKnownBindableProperties);
+    if (bean == null) {
+      return null;
+    }
+    ApolloBeanExtensionSupplier<T> beanSupplier = bean.getSupplier(target);
+    boolean bound = bind(propertyBinder, bean, beanSupplier, target);
+    return (bound ? beanSupplier.get() : null);
+  }
+
+  private <T> boolean bind(BeanPropertyBinder propertyBinder, ApolloBeanExtension<T> bean,
+      ApolloBeanExtensionSupplier<T> beanSupplier, Bindable<T> target) {
+    boolean bound = false;
+    for (Map.Entry<String, ApolloBeanExtensionProperty> entry : bean.getProperties().entrySet()) {
+      bound |= bind(beanSupplier, propertyBinder, entry.getValue(), target);
+    }
+    return bound;
+  }
+
+  private <T> boolean bind(ApolloBeanExtensionSupplier<T> beanSupplier,
+      BeanPropertyBinder propertyBinder, ApolloBeanExtensionProperty property, Bindable<T> target) {
+    if(configUtil.isAutoUpdateInjectedSpringPropertiesEnabled()) {
+      /**
+       * 
+       */
+      if(hasRefresh(target, property)) {
+        String propertyName = property.getName();
+        ResolvableType type = property.getType();
+        Supplier<Object> value = property.getValue(beanSupplier);
+        Annotation[] annotations = property.getAnnotations();
+        Object bound = propertyBinder.bindProperty(propertyName,
+            Bindable.of(type).withSuppliedValue(value).withAnnotations(annotations));
+        if (bound == null) {
+          return false;
+        }
+        if (property.isSettable()) {
+          property.setValue(beanSupplier, bound);
+        }
+        else if (value == null || !bound.equals(value.get())) {
+          throw new IllegalStateException(
+              "No setter found for property: " + property.getName());
+        }
+      }
+    }
+    return true;
+  }
+
+  private <T> boolean hasRefresh(Bindable<T> target, ApolloBeanExtensionProperty property) {
+    /*
+     * @RefreshEnabled has the highest priority
+     */
+    if(target.getAnnotation(RefreshEnabled.class) != null) {
+      return true;
+    }
+    /*
+     * Determine if @RefreshField exists, and enable automatic updates
+     */
+    
+    if(property.getField() != null) {
+      RefreshField refreshField =  property.getField().getAnnotation(RefreshField.class);
+      if(refreshField != null) {
+        return refreshField.value();
+      }
+    }
+    if(property.getSetMethod() != null) {
+      RefreshField refreshField =  AnnotationUtils.findAnnotation(property.getSetMethod(), RefreshField.class);
+      if(refreshField != null) {
+        return refreshField.value();
+      }
+    }
+    
+    /*
+     * If @Refreshfield does not exist, determine if @Autorefresh does
+     */
+    AutoRefresh autoRefresh = target.getAnnotation(AutoRefresh.class);
+    if(autoRefresh != null) {
+      return autoRefresh.value();
+    }
+    /*
+     * The default enable automatic updates
+     */
+    return true;
+  }
+
+  /**
+   * The bean being bound.
+   */
+  private static class ApolloBeanExtension<T> {
+
+    private static ApolloBeanExtension<?> cached;
+
+    private final Class<?> type;
+
+    private final ResolvableType resolvableType;
+
+    private final Map<String, ApolloBeanExtensionProperty> properties = new LinkedHashMap<>();
+
+    ApolloBeanExtension(ResolvableType resolvableType, Class<?> type) {
+      this.resolvableType = resolvableType;
+      this.type = type;
+      putProperties(type);
+    }
+
+    private void putProperties(Class<?> type) {
+      while (type != null && !Object.class.equals(type)) {
+        for (Method method : type.getDeclaredMethods()) {
+          if (isCandidate(method)) {
+            addMethod(method);
+          }
+        }
+        for (Field field : type.getDeclaredFields()) {
+          addField(field);
+        }
+        type = type.getSuperclass();
+      }
+    }
+
+    private boolean isCandidate(Method method) {
+      int modifiers = method.getModifiers();
+      return Modifier.isPublic(modifiers) && !Modifier.isAbstract(modifiers)
+          && !Modifier.isStatic(modifiers)
+          && !Object.class.equals(method.getDeclaringClass())
+          && !Class.class.equals(method.getDeclaringClass());
+    }
+
+    private void addMethod(Method method) {
+      addMethodIfPossible(method, "get", 0, ApolloBeanExtensionProperty::addGetter);
+      addMethodIfPossible(method, "is", 0, ApolloBeanExtensionProperty::addGetter);
+      addMethodIfPossible(method, "set", 1, ApolloBeanExtensionProperty::addSetter);
+    }
+
+    private void addMethodIfPossible(Method method, String prefix, int parameterCount,
+        BiConsumer<ApolloBeanExtensionProperty, Method> consumer) {
+      if (method.getParameterCount() == parameterCount
+          && method.getName().startsWith(prefix)
+          && method.getName().length() > prefix.length()) {
+        String propertyName = Introspector
+            .decapitalize(method.getName().substring(prefix.length()));
+        consumer.accept(this.properties.computeIfAbsent(propertyName,
+            this::getBeanProperty), method);
+      }
+    }
+
+    private ApolloBeanExtensionProperty getBeanProperty(String name) {
+      return new ApolloBeanExtensionProperty(name, this.resolvableType);
+    }
+
+    private void addField(Field field) {
+      ApolloBeanExtensionProperty property = this.properties.get(field.getName());
+      if (property != null) {
+        property.addField(field);
+      }
+    }
+
+    public Class<?> getType() {
+      return this.type;
+    }
+
+    public Map<String, ApolloBeanExtensionProperty> getProperties() {
+      return this.properties;
+    }
+
+    @SuppressWarnings("unchecked")
+    public ApolloBeanExtensionSupplier<T> getSupplier(Bindable<T> target) {
+      return new ApolloBeanExtensionSupplier<>(() -> {
+        T instance = null;
+        if (target.getValue() != null) {
+          instance = target.getValue().get();
+        }
+        if (instance == null) {
+          instance = (T) BeanUtils.instantiateClass(this.type);
+        }
+        return instance;
+      });
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> ApolloBeanExtension<T> get(Bindable<T> bindable, boolean canCallGetValue) {
+      Class<?> type = bindable.getType().resolve(Object.class);
+      Supplier<T> value = bindable.getValue();
+      T instance = null;
+      if (canCallGetValue && value != null) {
+        instance = value.get();
+        type = (instance != null) ? instance.getClass() : type;
+      }
+      if (instance == null && !isInstantiable(type)) {
+        return null;
+      }
+      ApolloBeanExtension<?> bean = ApolloBeanExtension.cached;
+      if (bean == null || !type.equals(bean.getType())) {
+        bean = new ApolloBeanExtension<>(bindable.getType(), type);
+        cached = bean;
+      }
+      return (ApolloBeanExtension<T>) bean;
+    }
+
+    private static boolean isInstantiable(Class<?> type) {
+      if (type.isInterface()) {
+        return false;
+      }
+      try {
+        type.getDeclaredConstructor();
+        return true;
+      }
+      catch (Exception ex) {
+        return false;
+      }
+    }
+
+  }
+
+  private static class ApolloBeanExtensionSupplier<T> implements Supplier<T> {
+
+    private final Supplier<T> factory;
+
+    private T instance;
+
+    ApolloBeanExtensionSupplier(Supplier<T> factory) {
+      this.factory = factory;
+    }
+
+    @Override
+    public T get() {
+      if (this.instance == null) {
+        this.instance = this.factory.get();
+      }
+      return this.instance;
+    }
+
+  }
+
+  /**
+   * A bean property being bound.
+   */
+  private static class ApolloBeanExtensionProperty {
+
+    private final String name;
+
+    private final ResolvableType declaringClassType;
+
+    private Method getter;
+
+    private Method setter;
+
+    private Field field;
+    ApolloBeanExtensionProperty(String name, ResolvableType declaringClassType) {
+      this.name = BeanPropertyName.toDashedForm(name);
+      this.declaringClassType = declaringClassType;
+      
+    }
+
+    public void addGetter(Method getter) {
+      if (this.getter == null) {
+        this.getter = getter;
+      }
+    }
+
+    public void addSetter(Method setter) {
+      if (this.setter == null) {
+        this.setter = setter;
+      }
+    }
+
+    public void addField(Field field) {
+      if (this.field == null) {
+        this.field = field;
+      }
+    }
+
+    public String getName() {
+      return this.name;
+    }
+
+    public ResolvableType getType() {
+      if (this.setter != null) {
+        MethodParameter methodParameter = new MethodParameter(this.setter, 0);
+        return ResolvableType.forMethodParameter(methodParameter,
+            this.declaringClassType);
+      }
+      MethodParameter methodParameter = new MethodParameter(this.getter, -1);
+      return ResolvableType.forMethodParameter(methodParameter,
+          this.declaringClassType);
+    }
+
+    public Annotation[] getAnnotations() {
+      try {
+        return (this.field != null) ? this.field.getDeclaredAnnotations() : null;
+      }
+      catch (Exception ex) {
+        return null;
+      }
+    }
+
+    public Method getSetMethod() {
+      return setter;
+    }
+
+    public Field getField() {
+      return field;
+    }
+
+    public Supplier<Object> getValue(Supplier<?> instance) {
+      if (this.getter == null) {
+        return null;
+      }
+      return () -> {
+        try {
+          this.getter.setAccessible(true);
+          return this.getter.invoke(instance.get());
+        }
+        catch (Exception ex) {
+          throw new IllegalStateException(
+              "Unable to get value for property " + this.name, ex);
+        }
+      };
+    }
+
+    public boolean isSettable() {
+      return this.setter != null;
+    }
+
+    public void setValue(Supplier<?> instance, Object value) {
+      try {
+        this.setter.setAccessible(true);
+        this.setter.invoke(instance.get(), value);
+      }
+      catch (Exception ex) {
+        throw new IllegalStateException(
+            "Unable to set value for property " + this.name, ex);
+      }
+    }
+
+  }
+
+}

--- a/apollo-client-extension/apollo-client-springboot2-extension/src/main/java/org/springframework/boot/context/properties/bind/ApolloMapBinder.java
+++ b/apollo-client-extension/apollo-client-springboot2-extension/src/main/java/org/springframework/boot/context/properties/bind/ApolloMapBinder.java
@@ -1,0 +1,216 @@
+package org.springframework.boot.context.properties.bind;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Properties;
+import java.util.function.Supplier;
+
+import org.springframework.boot.context.properties.bind.AggregateBinder;
+import org.springframework.boot.context.properties.bind.AggregateElementBinder;
+import org.springframework.boot.context.properties.bind.ApolloBinder.ApolloContext;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.source.ConfigurationProperty;
+import org.springframework.boot.context.properties.source.ConfigurationPropertyName;
+import org.springframework.boot.context.properties.source.ConfigurationPropertyName.Form;
+import org.springframework.boot.context.properties.source.ConfigurationPropertySource;
+import org.springframework.boot.context.properties.source.ConfigurationPropertyState;
+import org.springframework.boot.context.properties.source.IterableConfigurationPropertySource;
+import org.springframework.core.CollectionFactory;
+import org.springframework.core.ResolvableType;
+import org.springframework.util.ClassUtils;
+
+/**
+ * {@link AggregateBinder} for Maps.
+ *
+ * @author Phillip Webb
+ * @author Madhura Bhave
+ */
+class ApolloMapBinder extends ApolloAggregateBinder<Map<Object, Object>> {
+
+	private static final Bindable<Map<String, String>> STRING_STRING_MAP = Bindable
+			.mapOf(String.class, String.class);
+
+	ApolloMapBinder(ApolloContext context) {
+		super(context);
+	}
+
+	@Override
+	protected boolean isAllowRecursiveBinding(ConfigurationPropertySource source) {
+		return true;
+	}
+
+	@Override
+	protected Object bindAggregate(ConfigurationPropertyName name, Bindable<?> target,
+			AggregateElementBinder elementBinder) {
+		Map<Object, Object> map = CollectionFactory.createMap((target.getValue() != null)
+				? Map.class : target.getType().resolve(Object.class), 0);
+		Bindable<?> resolvedTarget = resolveTarget(target);
+		boolean hasDescendants = getContext().streamSources().anyMatch((source) -> source
+				.containsDescendantOf(name) == ConfigurationPropertyState.PRESENT);
+		for (ConfigurationPropertySource source : getContext().getSources()) {
+			if (!ConfigurationPropertyName.EMPTY.equals(name)) {
+				ConfigurationProperty property = source.getConfigurationProperty(name);
+				if (property != null && !hasDescendants) {
+					return getContext().getConverter().convert(property.getValue(),
+							target);
+				}
+				source = source.filter(name::isAncestorOf);
+			}
+			new ApolloEntryBinder(name, resolvedTarget, elementBinder).bindEntries(source, map);
+		}
+		return map.isEmpty() ? null : map;
+	}
+
+	private Bindable<?> resolveTarget(Bindable<?> target) {
+		Class<?> type = target.getType().resolve(Object.class);
+		if (Properties.class.isAssignableFrom(type)) {
+			return STRING_STRING_MAP;
+		}
+		return target;
+	}
+
+	@Override
+	protected Map<Object, Object> merge(Supplier<?> existing,
+			Map<Object, Object> additional) {
+		Map<Object, Object> existingMap = getExistingIfPossible(existing);
+		if (existingMap == null) {
+			return additional;
+		}
+		try {
+			existingMap.putAll(additional);
+			return copyIfPossible(existingMap);
+		}
+		catch (UnsupportedOperationException ex) {
+			Map<Object, Object> result = createNewMap(additional.getClass(), existingMap);
+			result.putAll(additional);
+			return result;
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	private Map<Object, Object> getExistingIfPossible(Supplier<?> existing) {
+		try {
+			return (Map<Object, Object>) existing.get();
+		}
+		catch (Exception ex) {
+			return null;
+		}
+	}
+
+	private Map<Object, Object> copyIfPossible(Map<Object, Object> map) {
+		try {
+			return createNewMap(map.getClass(), map);
+		}
+		catch (Exception ex) {
+			return map;
+		}
+	}
+
+	private Map<Object, Object> createNewMap(Class<?> mapClass, Map<Object, Object> map) {
+		Map<Object, Object> result = CollectionFactory.createMap(mapClass, map.size());
+		result.putAll(map);
+		return result;
+	}
+
+	private class ApolloEntryBinder {
+
+		private final ConfigurationPropertyName root;
+
+		private final AggregateElementBinder elementBinder;
+
+		private final ResolvableType mapType;
+
+		private final ResolvableType keyType;
+
+		private final ResolvableType valueType;
+
+		ApolloEntryBinder(ConfigurationPropertyName root, Bindable<?> target,
+				AggregateElementBinder elementBinder) {
+			this.root = root;
+			this.elementBinder = elementBinder;
+			this.mapType = target.getType().asMap();
+			this.keyType = this.mapType.getGeneric(0);
+			this.valueType = this.mapType.getGeneric(1);
+		}
+
+		public void bindEntries(ConfigurationPropertySource source,
+				Map<Object, Object> map) {
+			if (source instanceof IterableConfigurationPropertySource) {
+				for (ConfigurationPropertyName name : (IterableConfigurationPropertySource) source) {
+					Bindable<?> valueBindable = getValueBindable(name);
+					ConfigurationPropertyName entryName = getEntryName(source, name);
+					Object key = getContext().getConverter()
+							.convert(getKeyName(entryName), this.keyType);
+					map.computeIfAbsent(key,
+							(k) -> this.elementBinder.bind(entryName, valueBindable));
+				}
+			}
+		}
+
+		private Bindable<?> getValueBindable(ConfigurationPropertyName name) {
+			if (!this.root.isParentOf(name) && isValueTreatedAsNestedMap()) {
+				return Bindable.of(this.mapType);
+			}
+			return Bindable.of(this.valueType);
+		}
+
+		private ConfigurationPropertyName getEntryName(ConfigurationPropertySource source,
+				ConfigurationPropertyName name) {
+			Class<?> resolved = this.valueType.resolve(Object.class);
+			if (Collection.class.isAssignableFrom(resolved) || this.valueType.isArray()) {
+				return chopNameAtNumericIndex(name);
+			}
+			if (!this.root.isParentOf(name)
+					&& (isValueTreatedAsNestedMap() || !isScalarValue(source, name))) {
+				return name.chop(this.root.getNumberOfElements() + 1);
+			}
+			return name;
+		}
+
+		private ConfigurationPropertyName chopNameAtNumericIndex(
+				ConfigurationPropertyName name) {
+			int start = this.root.getNumberOfElements() + 1;
+			int size = name.getNumberOfElements();
+			for (int i = start; i < size; i++) {
+				if (name.isNumericIndex(i)) {
+					return name.chop(i);
+				}
+			}
+			return name;
+		}
+
+		private boolean isValueTreatedAsNestedMap() {
+			return Object.class.equals(this.valueType.resolve(Object.class));
+		}
+
+		private boolean isScalarValue(ConfigurationPropertySource source,
+				ConfigurationPropertyName name) {
+			Class<?> resolved = this.valueType.resolve(Object.class);
+			String packageName = ClassUtils.getPackageName(resolved);
+			if (!packageName.startsWith("java.lang") && !resolved.isEnum()) {
+				return false;
+			}
+			ConfigurationProperty property = source.getConfigurationProperty(name);
+			if (property == null) {
+				return false;
+			}
+			Object value = property.getValue();
+			value = getContext().getPlaceholdersResolver().resolvePlaceholders(value);
+			return getContext().getConverter().canConvert(value, this.valueType);
+		}
+
+		private String getKeyName(ConfigurationPropertyName name) {
+			StringBuilder result = new StringBuilder();
+			for (int i = this.root.getNumberOfElements(); i < name
+					.getNumberOfElements(); i++) {
+				if (result.length() != 0) {
+					result.append('.');
+				}
+				result.append(name.getElement(i, Form.ORIGINAL));
+			}
+			return result.toString();
+		}
+
+	}
+
+}

--- a/apollo-client-extension/apollo-client-springboot2-extension/src/main/java/org/springframework/boot/context/properties/bind/ExtensionBinder.java
+++ b/apollo-client-extension/apollo-client-springboot2-extension/src/main/java/org/springframework/boot/context/properties/bind/ExtensionBinder.java
@@ -1,0 +1,28 @@
+package org.springframework.boot.context.properties.bind;
+
+import org.springframework.boot.context.properties.bind.ApolloBinder.ApolloContext;
+import org.springframework.boot.context.properties.bind.BeanBinder;
+import org.springframework.boot.context.properties.bind.BeanPropertyBinder;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.source.ConfigurationPropertyName;
+
+/**
+ * 
+ * @author wangbo(wangle_r@163.com)
+ *
+ */
+public interface ExtensionBinder {
+
+  /**
+   * Return a bound bean instance or {@code null} if the {@link BeanBinder} does not
+   * support the specified {@link Bindable}.
+   * @param name the name being bound
+   * @param target the bindable to bind
+   * @param context the bind context
+   * @param propertyBinder property binder
+   * @param <T> the source type
+   * @return a bound instance or {@code null}
+   */
+  <T> T bind(ConfigurationPropertyName name, Bindable<T> target, ApolloContext context,
+      BeanPropertyBinder propertyBinder);
+}

--- a/apollo-client-extension/apollo-client-springboot2-extension/src/main/resources/META-INF/spring.factories
+++ b/apollo-client-extension/apollo-client-springboot2-extension/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+com.ctrip.framework.apollo.spring.boot.extension.ApolloRefreshExtensionAutoConfiguration

--- a/apollo-client-extension/pom.xml
+++ b/apollo-client-extension/pom.xml
@@ -1,0 +1,14 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.ctrip.framework.apollo</groupId>
+    <artifactId>apollo</artifactId>
+    <version>1.4.0</version>
+  </parent>
+  <artifactId>apollo-client-extension</artifactId>
+  <packaging>pom</packaging>
+  <modules>
+      <module>apollo-client-springboot2-extension</module>
+      <module>apollo-client-springboot-extension</module>
+  </modules>
+</project>

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/ClientConfigConsts.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/ClientConfigConsts.java
@@ -1,0 +1,16 @@
+package com.ctrip.framework.apollo;
+/**
+ * @author wangbo(wangle_r@163.com)
+ */
+public interface ClientConfigConsts {
+  final String APOLLO_AUTO_UPDATE_INJECTED_SPRING_PROPERTIE = "apollo.autoUpdateInjectedSpringProperties";
+  final String APOLLO_LONG_POLLING_INITIAL_DELAY_IN_MILLS = "apollo.longPollingInitialDelayInMills";
+  final String APOLLO_CACHE_DIR = "apollo.cacheDir";
+  final String APOLLO_CONFIG_CACHE_SIZE = "apollo.configCacheSize";
+  final String APOLLO_CONNECT_TIMEOUT = "apollo.connectTimeout";
+  final String APOLLO_LOAD_CONFIG_QPS = "apollo.loadConfigQPS";
+  final String APOLLO_REFRESH_INTERVAL = "apollo.refreshInterval";
+  final String APOLLO_READ_TIMEOUT = "apollo.readTimeout";
+  final String APOLLO_LONG_POLL_QPS = "apollo.longPollQPS";
+  final String APOLLO_CONFIG_SERVICE = "apollo.configService";
+}

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/build/ApolloInjector.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/build/ApolloInjector.java
@@ -17,7 +17,7 @@ public class ApolloInjector {
       synchronized (lock) {
         if (s_injector == null) {
           try {
-            s_injector = ServiceBootstrap.loadFirst(Injector.class);
+            s_injector = ServiceBootstrap.loadFirst(Injector.class, ServiceBootstrap.ASC);
           } catch (Throwable ex) {
             ApolloConfigException exception = new ApolloConfigException("Unable to initialize Apollo Injector!", ex);
             Tracer.logError(exception);

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/ConfigServiceLocator.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/ConfigServiceLocator.java
@@ -1,7 +1,5 @@
 package com.ctrip.framework.apollo.internals;
 
-import com.ctrip.framework.apollo.core.ServiceNameConsts;
-import com.ctrip.framework.foundation.Foundation;
 import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Map;
@@ -12,7 +10,9 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.ctrip.framework.apollo.ClientConfigConsts;
 import com.ctrip.framework.apollo.build.ApolloInjector;
+import com.ctrip.framework.apollo.core.ServiceNameConsts;
 import com.ctrip.framework.apollo.core.dto.ServiceDTO;
 import com.ctrip.framework.apollo.core.utils.ApolloThreadFactory;
 import com.ctrip.framework.apollo.exceptions.ApolloConfigException;
@@ -23,6 +23,7 @@ import com.ctrip.framework.apollo.util.ExceptionUtil;
 import com.ctrip.framework.apollo.util.http.HttpRequest;
 import com.ctrip.framework.apollo.util.http.HttpResponse;
 import com.ctrip.framework.apollo.util.http.HttpUtil;
+import com.ctrip.framework.foundation.Foundation;
 import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
@@ -72,14 +73,14 @@ public class ConfigServiceLocator {
 
   private List<ServiceDTO> getCustomizedConfigService() {
     // 1. Get from System Property
-    String configServices = System.getProperty("apollo.configService");
+    String configServices = System.getProperty(ClientConfigConsts.APOLLO_CONFIG_SERVICE);
     if (Strings.isNullOrEmpty(configServices)) {
       // 2. Get from OS environment variable
       configServices = System.getenv("APOLLO_CONFIGSERVICE");
     }
     if (Strings.isNullOrEmpty(configServices)) {
       // 3. Get from server.properties
-      configServices = Foundation.server().getProperty("apollo.configService", null);
+      configServices = Foundation.server().getProperty(ClientConfigConsts.APOLLO_CONFIG_SERVICE, null);
     }
 
     if (Strings.isNullOrEmpty(configServices)) {

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/DefaultInjector.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/DefaultInjector.java
@@ -64,4 +64,9 @@ public class DefaultInjector implements Injector {
       bind(YamlParser.class).in(Singleton.class);
     }
   }
+
+  @Override
+  public int getOrder() {
+    return 0;
+  }
 }

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/Injector.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/Injector.java
@@ -1,9 +1,11 @@
 package com.ctrip.framework.apollo.internals;
 
+import com.ctrip.framework.apollo.core.spi.Ordered;
+
 /**
  * @author Jason Song(song_s@ctrip.com)
  */
-public interface Injector {
+public interface Injector  extends Ordered{
 
   /**
    * Returns the appropriate instance for the given injection type

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/PropertiesConfigFile.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/PropertiesConfigFile.java
@@ -3,9 +3,6 @@ package com.ctrip.framework.apollo.internals;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.ctrip.framework.apollo.core.enums.ConfigFileFormat;
 import com.ctrip.framework.apollo.core.utils.PropertiesUtil;
 import com.ctrip.framework.apollo.exceptions.ApolloConfigException;

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/annotation/ApolloAnnotationProcessor.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/annotation/ApolloAnnotationProcessor.java
@@ -1,18 +1,18 @@
 package com.ctrip.framework.apollo.spring.annotation;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Set;
+
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.util.ReflectionUtils;
+
 import com.ctrip.framework.apollo.Config;
 import com.ctrip.framework.apollo.ConfigChangeListener;
 import com.ctrip.framework.apollo.ConfigService;
 import com.ctrip.framework.apollo.model.ConfigChangeEvent;
 import com.google.common.base.Preconditions;
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.util.Collections;
-import java.util.Set;
-
 import com.google.common.collect.Sets;
-import org.springframework.core.annotation.AnnotationUtils;
-import org.springframework.util.ReflectionUtils;
 
 /**
  * Apollo Annotation Processor for Spring Application

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/annotation/ApolloProcessor.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/annotation/ApolloProcessor.java
@@ -18,7 +18,7 @@ public abstract class ApolloProcessor implements BeanPostProcessor, PriorityOrde
   @Override
   public Object postProcessBeforeInitialization(Object bean, String beanName)
       throws BeansException {
-    Class clazz = bean.getClass();
+    Class<?> clazz = bean.getClass();
     for (Field field : findAllField(clazz)) {
       processField(bean, beanName, field);
     }
@@ -50,7 +50,7 @@ public abstract class ApolloProcessor implements BeanPostProcessor, PriorityOrde
     return Ordered.LOWEST_PRECEDENCE;
   }
 
-  private List<Field> findAllField(Class clazz) {
+  private List<Field> findAllField(Class<?> clazz) {
     final List<Field> res = new LinkedList<>();
     ReflectionUtils.doWithFields(clazz, new ReflectionUtils.FieldCallback() {
       @Override
@@ -61,7 +61,7 @@ public abstract class ApolloProcessor implements BeanPostProcessor, PriorityOrde
     return res;
   }
 
-  private List<Method> findAllMethod(Class clazz) {
+  private List<Method> findAllMethod(Class<?> clazz) {
     final List<Method> res = new LinkedList<>();
     ReflectionUtils.doWithMethods(clazz, new ReflectionUtils.MethodCallback() {
       @Override

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/annotation/AutoRefresh.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/annotation/AutoRefresh.java
@@ -1,0 +1,62 @@
+package com.ctrip.framework.apollo.spring.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * 
+ * Used to enable or disable automatic update of field values in spring and springboot.<br/><br />
+ * 
+ * Want the annotation play a role, "Apollo. AutoUpdateInjectedSpringProperties = true" must be set.<br/> <br />
+ * 
+ * Support springboot &#064;configurationproperties annotation of the class.<br/><br />
+ * 
+ * Both &#064;Autorefresh and &#064;Refreshfield exist. &#064;Refreshfield has a higher priority <br/><br />
+ * 
+ * Default enabled automatic update 
+ * 
+ * @author wangbo(wangle_r@163.com)
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE})
+@Documented
+@Inherited
+public @interface AutoRefresh {
+  public static final boolean enabled = true;
+  public static final boolean disabled = false;
+  /**
+   * enabled / disabled auto refresh, default disabled automatic update 
+   */
+  boolean value() default enabled;
+
+  /**
+   * Apollo namespace for the config, The class marked &#064;configurationproperties in springboot is used above 
+   */
+  String[] namespaces() default  {};
+
+  /**
+   * 
+   * The keys interested by the listener, will only be notified if any of the interested keys is changed.
+   * <br />
+   * If neither of {@code interestedKeys} and {@code interestedKeyPrefixes} is specified then the {@code listener} will be notified when any key is changed.
+   * <br />
+   * , The class marked &#064;configurationproperties in springboot is used above 
+   */
+  String[] interestedKeys() default {};
+
+  /**
+   * The key prefixes that the listener is interested in, will be notified if and only if the changed keys start with anyone of the prefixes.
+   * The prefixes will simply be used to determine whether the {@code listener} should be notified or not using {@code changedKey.startsWith(prefix)}.
+   * e.g. "spring." means that {@code listener} is interested in keys that starts with "spring.", such as "spring.banner", "spring.jpa", etc.
+   * and "application" means that {@code listener} is interested in keys that starts with "application", such as "applicationName", "application.port", etc.
+   * <br />
+   * If neither of {@code interestedKeys} and {@code interestedKeyPrefixes} is specified then the {@code listener} will be notified when whatever key is changed.
+   * <br />
+   * The class marked &#064;configurationproperties in springboot is used above 
+   */
+  String[] interestedKeyPrefixes() default {};
+}

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/annotation/RefreshDisabled.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/annotation/RefreshDisabled.java
@@ -1,0 +1,28 @@
+package com.ctrip.framework.apollo.spring.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * 
+ * Used to disable automatic update of field values in spring and springboot.<br/><br />
+ * 
+ * Want the annotation play a role, "Apollo. AutoUpdateInjectedSpringProperties = true" must be set.<br/> <br />
+ * 
+ * Support springboot &#064;configurationproperties annotation of the class.<br/><br />
+ * 
+ * &#064;RefreshEnabled, &#064;RefreshDisabled has a higher priority than &#064;Autorefresh and &#064;RefreshField
+ * 
+ * @author wangbo(wangle_r@163.com)
+ */
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE})
+@Documented
+@Inherited
+public @interface RefreshDisabled {
+}

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/annotation/RefreshEnabled.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/annotation/RefreshEnabled.java
@@ -1,0 +1,33 @@
+package com.ctrip.framework.apollo.spring.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * 
+ * Used to enable automatic update of field values in spring and springboot.<br/><br />
+ * 
+ * Want the annotation play a role, "Apollo. AutoUpdateInjectedSpringProperties = true" must be set.<br/> <br />
+ * 
+ * Support springboot &#064;configurationproperties annotation of the class.<br/><br />
+ * 
+ * &#064;RefreshEnabled, &#064;RefreshDisabled has a higher priority than &#064;Autorefresh and &#064;RefreshField
+ * 
+ * @author wangbo(wangle_r@163.com)
+ */
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE})
+@Documented
+@Inherited
+public @interface RefreshEnabled {
+  String[] namespaces() default  {};
+
+  String[] interestedKeys() default {};
+
+  String[] interestedKeyPrefixes() default {};
+}

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/annotation/RefreshField.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/annotation/RefreshField.java
@@ -1,0 +1,30 @@
+package com.ctrip.framework.apollo.spring.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Used to enable or disable automatic update of field values in spring and springboot, This can be used on fields, and methods.<br/><br />
+ * 
+ * Want the annotation play a role, "Apollo. AutoUpdateInjectedSpringProperties = true" must be set.<br/> <br />
+ * 
+ * Support springboot &#064;Configurationproperties annotation of the class. But it can only be used on classes and set methods.<br/><br />
+ * 
+ * Default enabled automatic update 
+ * 
+ * @author wangbo(wangle_r@163.com)
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.METHOD})
+@Documented
+public @interface RefreshField {
+  public static final boolean enabled = true;
+  public static final boolean disabled = false;
+  /**
+   * enabled / disabled auto refresh, default enabled
+   */
+  boolean value() default enabled;
+}

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/boot/AbstractRefreshConfigurationProperties.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/boot/AbstractRefreshConfigurationProperties.java
@@ -1,0 +1,55 @@
+package com.ctrip.framework.apollo.spring.boot;
+
+import java.util.Properties;
+import java.util.Set;
+
+import org.springframework.context.ApplicationContext;
+
+import com.ctrip.framework.apollo.model.ConfigChangeEvent;
+
+public abstract class AbstractRefreshConfigurationProperties implements RefreshConfigurationProperties{
+  /**
+   * Update the property values of the object through the bean object
+   * 
+   * @param bean
+   * @param changeEvent
+   */
+  @Override
+  public void refreshBindingBean(Object bean, ConfigChangeEvent changeEvent) {
+    String beanName = bean.getClass().getName();
+    refreshBinding(bean, beanName, changeEventToProperties(changeEvent));
+  }
+
+  /**
+   * Update the property value of the object associated with that beanName through beanName
+   * 
+   * @param beanName
+   * @param changeEvent
+   */
+  @Override
+  public void refreshBinding(String beanName, ConfigChangeEvent changeEvent) {
+    Object bean = this.getApplicationContext().getBean(beanName);
+    refreshBinding(bean, beanName, changeEventToProperties(changeEvent));
+  }
+
+  /**
+   * @param bean
+   * @param beanName
+   * @param changeEvent
+   */
+  @Override
+  public void refreshBinding(Object bean, String beanName, ConfigChangeEvent changeEvent) {
+    refreshBinding(bean, beanName, changeEventToProperties(changeEvent));
+  }
+  
+  private Properties changeEventToProperties(ConfigChangeEvent changeEvent) {
+    Set<String> keys = changeEvent.changedKeys();
+    Properties properties = new Properties();
+    for (String key : keys) {
+      properties.put(key, changeEvent.getChange(key).getNewValue());
+    }
+    return properties;
+  }
+
+  protected abstract ApplicationContext getApplicationContext();
+}

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/boot/AbstractRefreshConfigurationProperties.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/boot/AbstractRefreshConfigurationProperties.java
@@ -6,7 +6,10 @@ import java.util.Set;
 import org.springframework.context.ApplicationContext;
 
 import com.ctrip.framework.apollo.model.ConfigChangeEvent;
-
+/**
+ * Update the @configurationproperties field value
+ * @author wangbo(wangle_r@163.com)
+ */
 public abstract class AbstractRefreshConfigurationProperties implements RefreshConfigurationProperties{
   /**
    * Update the property values of the object through the bean object

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/boot/ApolloApplicationContextInitializer.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/boot/ApolloApplicationContextInitializer.java
@@ -1,5 +1,6 @@
 package com.ctrip.framework.apollo.spring.boot;
 
+import com.ctrip.framework.apollo.ClientConfigConsts;
 import com.ctrip.framework.apollo.Config;
 import com.ctrip.framework.apollo.ConfigService;
 import com.ctrip.framework.apollo.core.ConfigConsts;
@@ -60,8 +61,8 @@ public class ApolloApplicationContextInitializer implements
 
   private static final Logger logger = LoggerFactory.getLogger(ApolloApplicationContextInitializer.class);
   private static final Splitter NAMESPACE_SPLITTER = Splitter.on(",").omitEmptyStrings().trimResults();
-  private static final String[] APOLLO_SYSTEM_PROPERTIES = {"app.id", ConfigConsts.APOLLO_CLUSTER_KEY,
-      "apollo.cacheDir", ConfigConsts.APOLLO_META_KEY};
+  private static final String[] APOLLO_SYSTEM_PROPERTIES = {ConfigConsts.APOLLO_CLUSTER_KEY,
+      ClientConfigConsts.APOLLO_CACHE_DIR, ConfigConsts.APOLLO_META_KEY};
 
   private final ConfigPropertySourceFactory configPropertySourceFactory = SpringInjector
       .getInstance(ConfigPropertySourceFactory.class);
@@ -116,6 +117,11 @@ public class ApolloApplicationContextInitializer implements
     for (String propertyName : APOLLO_SYSTEM_PROPERTIES) {
       fillSystemPropertyFromEnvironment(environment, propertyName);
     }
+    
+    /*
+     */
+    fillSystemPropertyFromEnvironment(environment, ConfigConsts.APOLLO_APP_ID, ConfigConsts.APP_ID);
+    fillSystemPropertyFromEnvironment(environment, ConfigConsts.APOLLO_ENV, ConfigConsts.ENV);
   }
 
   private void fillSystemPropertyFromEnvironment(ConfigurableEnvironment environment, String propertyName) {
@@ -125,6 +131,27 @@ public class ApolloApplicationContextInitializer implements
 
     String propertyValue = environment.getProperty(propertyName);
 
+    if (Strings.isNullOrEmpty(propertyValue)) {
+      return;
+    }
+
+    System.setProperty(propertyName, propertyValue);
+  }
+  
+  private void fillSystemPropertyFromEnvironment(ConfigurableEnvironment environment, String propertyName, String name) {
+    if (System.getProperty(propertyName) != null) {
+      return;
+    }
+    
+    if (System.getProperty(name) != null) {
+      System.setProperty(propertyName, System.getProperty(name));
+    }
+
+    String propertyValue = environment.getProperty(propertyName);
+    
+    if (Strings.isNullOrEmpty(propertyValue)) {
+      propertyValue = environment.getProperty(name);
+    }
     if (Strings.isNullOrEmpty(propertyValue)) {
       return;
     }

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/boot/ApolloAutoConfiguration.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/boot/ApolloAutoConfiguration.java
@@ -3,6 +3,7 @@ package com.ctrip.framework.apollo.spring.boot;
 import com.ctrip.framework.apollo.spring.config.ConfigPropertySourcesProcessor;
 import com.ctrip.framework.apollo.spring.config.PropertySourcesConstants;
 import com.ctrip.framework.apollo.spring.config.PropertySourcesProcessor;
+
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/boot/BeanFactoryMetadata.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/boot/BeanFactoryMetadata.java
@@ -1,0 +1,9 @@
+package com.ctrip.framework.apollo.spring.boot;
+
+import java.lang.annotation.Annotation;
+/**
+ * @author wangbo(wangle_r@163.com)
+ */
+public interface BeanFactoryMetadata {
+  <A extends Annotation> A findFactoryAnnotation(String beanName, Class<A> type);
+}

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/boot/RefreshConfigurationProperties.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/boot/RefreshConfigurationProperties.java
@@ -1,0 +1,15 @@
+package com.ctrip.framework.apollo.spring.boot;
+
+import java.util.Properties;
+
+import com.ctrip.framework.apollo.model.ConfigChangeEvent;
+/**
+ * Update the @configurationproperties field value
+ * @author wangbo(wangle_r@163.com)
+ */
+public interface RefreshConfigurationProperties {
+  public void refreshBindingBean(Object bean, ConfigChangeEvent changeEvent);
+  public void refreshBinding(String beanName, ConfigChangeEvent changeEvent);
+  public void refreshBinding(Object bean, String beanName, ConfigChangeEvent changeEvent);
+  public void refreshBinding(Object bean, String beanName, Properties properties);
+}

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/config/ConfigPropertySourceFactory.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/config/ConfigPropertySourceFactory.java
@@ -1,23 +1,26 @@
 package com.ctrip.framework.apollo.spring.config;
 
 import java.util.List;
+import java.util.Map;
 
 import com.ctrip.framework.apollo.Config;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 
 public class ConfigPropertySourceFactory {
 
-  private final List<ConfigPropertySource> configPropertySources = Lists.newLinkedList();
+  private final Map<String, ConfigPropertySource> configPropertySources = Maps.newLinkedHashMap();
 
   public ConfigPropertySource getConfigPropertySource(String name, Config source) {
+    if(configPropertySources.containsKey(name)) {
+      return configPropertySources.get(name);
+    }
     ConfigPropertySource configPropertySource = new ConfigPropertySource(name, source);
-
-    configPropertySources.add(configPropertySource);
-
+    configPropertySources.put(name, configPropertySource);
     return configPropertySource;
   }
 
   public List<ConfigPropertySource> getAllConfigPropertySources() {
-    return Lists.newLinkedList(configPropertySources);
+    return Lists.newLinkedList(configPropertySources.values());
   }
 }

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/config/PropertySourcesConstants.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/config/PropertySourcesConstants.java
@@ -1,9 +1,34 @@
 package com.ctrip.framework.apollo.spring.config;
 
+import com.ctrip.framework.apollo.ClientConfigConsts;
+import com.ctrip.framework.apollo.spring.annotation.AutoRefresh;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
 public interface PropertySourcesConstants {
   String APOLLO_PROPERTY_SOURCE_NAME = "ApolloPropertySources";
   String APOLLO_BOOTSTRAP_PROPERTY_SOURCE_NAME = "ApolloBootstrapPropertySources";
   String APOLLO_BOOTSTRAP_ENABLED = "apollo.bootstrap.enabled";
   String APOLLO_BOOTSTRAP_EAGER_LOAD_ENABLED = "apollo.bootstrap.eagerLoad.enabled";
   String APOLLO_BOOTSTRAP_NAMESPACES = "apollo.bootstrap.namespaces";
+  
+  /**
+   * Whether or not the springboot ConfigurationProperties automatic update is enabled. If not enabled by default, the configuration will only be valid for classes annotated with {@link ConfigurationProperties}.
+   * Usage:
+   * <ol>
+   * <li>
+   * Automatic update is enabled for classes under the specified package. When the configuration value is package path (packages), automatic refresh is only enabled for classes under the specified package annotated by ConfigurationProperties. This can be the fully qualified name of the class, 
+   * </li>
+   * <li>
+   * Auto-refresh is enabled for all classes. When the configuration value is true, auto-refresh is enabled for all classes annotated with ConfigurationProperties
+   * </li>
+   * <li>
+   * Disable automatic updates, and will not be disabled if not configured or configured to false
+   * </li>
+   * <li>
+   * Individual class updates are specified through annotations. It is possible to enable automatic updates of individual classes through the {@link AutoRefresh} annotation, and even if the {@link ClientConfigConsts#APOLLO_AUTO_UPDATE_CONFIGURATION_PROPERTIES} is not enabled
+   * </li>
+   * <ol>
+   */
+  String APOLLO_AUTO_REFRESH_CONFIGURATION_PROPERTIE = "apollo.autoRefreshConfigurationProperties";
 }

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/property/AutoUpdateConfigChangeListener.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/property/AutoUpdateConfigChangeListener.java
@@ -1,18 +1,18 @@
 package com.ctrip.framework.apollo.spring.property;
 
-import com.ctrip.framework.apollo.ConfigChangeListener;
-import com.ctrip.framework.apollo.enums.PropertyChangeType;
-import com.ctrip.framework.apollo.model.ConfigChange;
-import com.ctrip.framework.apollo.model.ConfigChangeEvent;
-import com.ctrip.framework.apollo.spring.util.SpringInjector;
-import com.google.gson.Gson;
 import java.lang.reflect.Field;
 import java.lang.reflect.Type;
 import java.util.Collection;
-import java.util.Objects;
 import java.util.Set;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.ctrip.framework.apollo.ConfigChangeListener;
+import com.ctrip.framework.apollo.model.ConfigChangeEvent;
+import com.ctrip.framework.apollo.spring.util.SpringInjector;
+import com.google.gson.Gson;
+
 import org.springframework.beans.TypeConverter;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
@@ -58,7 +58,9 @@ public class AutoUpdateConfigChangeListener implements ConfigChangeListener{
 
       // 2. update the value
       for (SpringValue val : targetValues) {
-        updateSpringValue(val);
+        if(val.isIsefresh()) {
+          updateSpringValue(val);
+        }
       }
     }
   }

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/property/PlaceholderHelper.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/property/PlaceholderHelper.java
@@ -1,10 +1,11 @@
 package com.ctrip.framework.apollo.spring.property;
 
-import com.google.common.base.Strings;
-import com.google.common.collect.Sets;
 import java.util.Set;
 import java.util.Stack;
-import org.springframework.beans.factory.BeanFactory;
+
+import com.google.common.base.Strings;
+import com.google.common.collect.Sets;
+
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.BeanExpressionContext;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/property/SpringValue.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/property/SpringValue.java
@@ -5,6 +5,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
+
 import org.springframework.core.MethodParameter;
 
 /**
@@ -24,6 +25,8 @@ public class SpringValue {
   private Class<?> targetType;
   private Type genericType;
   private boolean isJson;
+  //it will refresh by default
+  private boolean isefresh = true;
 
   public SpringValue(String key, String placeholder, Object bean, String beanName, Field field, boolean isJson) {
     this.beanRef = new WeakReference<>(bean);
@@ -47,6 +50,35 @@ public class SpringValue {
     Class<?>[] paramTps = method.getParameterTypes();
     this.targetType = paramTps[0];
     this.isJson = isJson;
+    if(isJson){
+      this.genericType = method.getGenericParameterTypes()[0];
+    }
+  }
+  
+  public SpringValue(String key, String placeholder, Object bean, String beanName, Field field, boolean isJson, boolean isefresh) {
+    this.beanRef = new WeakReference<>(bean);
+    this.beanName = beanName;
+    this.field = field;
+    this.key = key;
+    this.placeholder = placeholder;
+    this.targetType = field.getType();
+    this.isJson = isJson;
+    this.isefresh = isefresh;
+    if(isJson){
+      this.genericType = field.getGenericType();
+    }
+  }
+  
+  public SpringValue(String key, String placeholder, Object bean, String beanName, Method method, boolean isJson, boolean isefresh) {
+    this.beanRef = new WeakReference<>(bean);
+    this.beanName = beanName;
+    this.methodParameter = new MethodParameter(method, 0);
+    this.key = key;
+    this.placeholder = placeholder;
+    Class<?>[] paramTps = method.getParameterTypes();
+    this.targetType = paramTps[0];
+    this.isJson = isJson;
+    this.isefresh = isefresh;
     if(isJson){
       this.genericType = method.getGenericParameterTypes()[0];
     }
@@ -114,6 +146,10 @@ public class SpringValue {
 
   boolean isTargetBeanValid() {
     return beanRef.get() != null;
+  }
+  
+  public boolean isIsefresh() {
+    return isefresh;
   }
 
   @Override

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/util/ApolloRefreshUtil.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/util/ApolloRefreshUtil.java
@@ -1,0 +1,157 @@
+package com.ctrip.framework.apollo.spring.util;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import com.ctrip.framework.apollo.spring.annotation.AutoRefresh;
+import com.ctrip.framework.apollo.spring.annotation.RefreshDisabled;
+import com.ctrip.framework.apollo.spring.annotation.RefreshEnabled;
+import com.ctrip.framework.apollo.spring.annotation.RefreshField;
+import com.ctrip.framework.apollo.spring.boot.BeanFactoryMetadata;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.core.annotation.AnnotationUtils;
+
+/**
+ * @author wangbo(wangle_r@163.com)
+ */
+public class ApolloRefreshUtil {
+  
+  public static ConfigurationProperties findConfigurationPropertiesAnnotation(Class<?> clazz, String beanName, BeanFactoryMetadata beans) {
+    ConfigurationProperties annotation = AnnotationUtils.findAnnotation(clazz, ConfigurationProperties.class);
+    if (annotation == null) {
+      annotation = beans.findFactoryAnnotation(beanName, ConfigurationProperties.class);
+    }
+    return annotation;
+  }
+
+  public static AutoRefresh findAutoRefreshAnnotation(Class<?> clazz, String beanName, BeanFactoryMetadata beans) {
+    AutoRefresh annotation = AnnotationUtils.findAnnotation(clazz, AutoRefresh.class);
+    if (annotation == null) {
+      annotation = beans.findFactoryAnnotation(beanName, AutoRefresh.class);
+    }
+    return annotation;
+  }
+
+  public static RefreshDisabled findRefreshDisabledAnnotation(Class<?> clazz, String beanName, BeanFactoryMetadata beans) {
+    RefreshDisabled annotation = AnnotationUtils.findAnnotation(clazz, RefreshDisabled.class);
+    if (annotation == null) {
+      annotation = beans.findFactoryAnnotation(beanName, RefreshDisabled.class);
+    }
+    return annotation;
+  }
+
+  public static RefreshEnabled findRefreshEnabledAnnotation(Class<?> clazz, String beanName, BeanFactoryMetadata beans) {
+    RefreshEnabled annotation = AnnotationUtils.findAnnotation(clazz, RefreshEnabled.class);
+    if (annotation == null) {
+      annotation = beans.findFactoryAnnotation(beanName, RefreshEnabled.class);
+    }
+    return annotation;
+  }
+  
+  /**
+   * Determine whether &#064;{@link RefreshEnabled}, &#064;{@link RefreshDisabled} exists, and enable or disable automatic refresh of records，
+   * If it does not exist, it will refresh by default
+   */
+  public static boolean hasRefresh(Class<?> clazz) {
+    
+    /*
+     * @RefreshEnabled, @Refreshdisabled has a higher priority than @Autorefresh and @RefreshField
+     */
+    RefreshEnabled refreshEnabled = AnnotationUtils.findAnnotation(clazz, RefreshEnabled.class);
+    if(refreshEnabled != null) {
+      return true;
+    }
+    
+    
+    RefreshDisabled refreshDisabled = AnnotationUtils.findAnnotation(clazz, RefreshDisabled.class);
+    if(refreshDisabled != null) {
+      return false;
+    }
+    
+    //There is no @RefreshEnabled, @Refreshdisabled, @AutoRefresh,  @RefreshField, it will refresh by default 
+    return true;
+  }
+  
+  /**
+   * Determine whether &#064;{@link RefreshEnabled}, &#064;{@link RefreshDisabled}, &#064;{@link RefreshField}, &#064;{@link AutoRefresh} exists, and enable or disable automatic refresh of records，
+   * If it does not exist, it will refresh by default
+   */
+  public static boolean hasRefresh(Class<?> clazz, Method method) {
+    
+    /*
+     * @RefreshEnabled, @Refreshdisabled has a higher priority than @Autorefresh and @RefreshField
+     */
+    RefreshEnabled refreshEnabled = AnnotationUtils.findAnnotation(clazz, RefreshEnabled.class);
+    if(refreshEnabled != null) {
+      return true;
+    }
+    
+    
+    RefreshDisabled refreshDisabled = AnnotationUtils.findAnnotation(clazz, RefreshDisabled.class);
+    if(refreshDisabled != null) {
+      return false;
+    }
+    
+    /*
+     * Both @autorefresh and @refreshfield exist. @refreshfield has a higher priority
+     */
+    RefreshField refreshField = method.getAnnotation(RefreshField.class);
+    if(refreshField != null) {
+      return refreshField.value();
+    }
+    
+    /*
+     * There is no @RefreshEnabled, @Refreshdisabled, @RefreshField, Determines whether @Autorefresh exists on the class
+     */
+    AutoRefresh refreshs = AnnotationUtils.findAnnotation(clazz, AutoRefresh.class);
+    if(refreshs != null) {
+      return refreshs.value();
+    }
+    
+    //There is no @RefreshEnabled, @Refreshdisabled, @AutoRefresh,  @RefreshField, it will refresh by default
+    return true;
+  }
+  
+  
+  /**
+   * Determine whether &#064;{@link RefreshEnabled}, &#064;{@link RefreshDisabled}, &#064;{@link RefreshField}, &#064;{@link AutoRefresh} exists, and enable or disable automatic refresh of records，
+   * If it does not exist, it will refresh by default
+   */
+  public static boolean hasRefresh(Class<?> clazz, Field field) {
+    
+    /*
+     * @RefreshEnabled, @Refreshdisabled has a higher priority than @Autorefresh and @RefreshField
+     */
+    RefreshEnabled refreshEnabled = AnnotationUtils.findAnnotation(clazz, RefreshEnabled.class);
+    if(refreshEnabled != null) {
+      return true;
+    }
+    
+    
+    RefreshDisabled refreshDisabled = AnnotationUtils.findAnnotation(clazz, RefreshDisabled.class);
+    if(refreshDisabled != null) {
+      return false;
+    }
+    
+    /*
+     * Both @autorefresh and @refreshfield exist. @refreshfield has a higher priority
+     */
+    RefreshField refreshField = field.getAnnotation(RefreshField.class);
+    if(refreshField != null) {
+      return refreshField.value();
+    }
+    
+    /*
+     * There is no @RefreshEnabled, @Refreshdisabled, @RefreshField, Determines whether @Autorefresh exists on the class
+     */
+    AutoRefresh refreshs = AnnotationUtils.findAnnotation(clazz, AutoRefresh.class);
+    if(refreshs != null) {
+      return refreshs.value();
+    }
+    
+    //There is no @RefreshEnabled, @Refreshdisabled, @AutoRefresh,  @RefreshField, it will refresh by default 
+    return true;
+  }
+  
+}

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/util/ConfigUtil.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/util/ConfigUtil.java
@@ -1,24 +1,27 @@
 package com.ctrip.framework.apollo.util;
 
-import com.google.common.util.concurrent.RateLimiter;
 import java.io.File;
 import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.ctrip.framework.apollo.ClientConfigConsts;
 import com.ctrip.framework.apollo.core.ConfigConsts;
 import com.ctrip.framework.apollo.core.MetaDomainConsts;
 import com.ctrip.framework.apollo.core.enums.Env;
 import com.ctrip.framework.apollo.core.enums.EnvUtils;
 import com.ctrip.framework.foundation.Foundation;
 import com.google.common.base.Strings;
+import com.google.common.util.concurrent.RateLimiter;
 
 /**
  * @author Jason Song(song_s@ctrip.com)
  */
 public class ConfigUtil {
   private static final Logger logger = LoggerFactory.getLogger(ConfigUtil.class);
+  private static final String WINDOWS_OPT_DATA = "C:\\opt\\data\\%s";
+  private static final String OPT_DATA = "/opt/data/%s";
   private int refreshInterval = 5;
   private TimeUnit refreshIntervalTimeUnit = TimeUnit.MINUTES;
   private int connectTimeout = 1000; //1 second
@@ -117,7 +120,7 @@ public class ConfigUtil {
   }
 
   private void initConnectTimeout() {
-    String customizedConnectTimeout = System.getProperty("apollo.connectTimeout");
+    String customizedConnectTimeout = System.getProperty(ClientConfigConsts.APOLLO_CONNECT_TIMEOUT);
     if (!Strings.isNullOrEmpty(customizedConnectTimeout)) {
       try {
         connectTimeout = Integer.parseInt(customizedConnectTimeout);
@@ -132,7 +135,7 @@ public class ConfigUtil {
   }
 
   private void initReadTimeout() {
-    String customizedReadTimeout = System.getProperty("apollo.readTimeout");
+    String customizedReadTimeout = System.getProperty(ClientConfigConsts.APOLLO_READ_TIMEOUT);
     if (!Strings.isNullOrEmpty(customizedReadTimeout)) {
       try {
         readTimeout = Integer.parseInt(customizedReadTimeout);
@@ -147,7 +150,7 @@ public class ConfigUtil {
   }
 
   private void initRefreshInterval() {
-    String customizedRefreshInterval = System.getProperty("apollo.refreshInterval");
+    String customizedRefreshInterval = System.getProperty(ClientConfigConsts.APOLLO_REFRESH_INTERVAL);
     if (!Strings.isNullOrEmpty(customizedRefreshInterval)) {
       try {
         refreshInterval = Integer.parseInt(customizedRefreshInterval);
@@ -166,7 +169,7 @@ public class ConfigUtil {
   }
 
   private void initQPS() {
-    String customizedLoadConfigQPS = System.getProperty("apollo.loadConfigQPS");
+    String customizedLoadConfigQPS = System.getProperty(ClientConfigConsts.APOLLO_LOAD_CONFIG_QPS);
     if (!Strings.isNullOrEmpty(customizedLoadConfigQPS)) {
       try {
         loadConfigQPS = Integer.parseInt(customizedLoadConfigQPS);
@@ -175,7 +178,7 @@ public class ConfigUtil {
       }
     }
 
-    String customizedLongPollQPS = System.getProperty("apollo.longPollQPS");
+    String customizedLongPollQPS = System.getProperty(ClientConfigConsts.APOLLO_LONG_POLL_QPS);
     if (!Strings.isNullOrEmpty(customizedLongPollQPS)) {
       try {
         longPollQPS = Integer.parseInt(customizedLongPollQPS);
@@ -208,20 +211,20 @@ public class ConfigUtil {
       return cacheRoot + File.separator + getAppId();
     }
 
-    cacheRoot = isOSWindows() ? "C:\\opt\\data\\%s" : "/opt/data/%s";
+    cacheRoot = isOSWindows() ? WINDOWS_OPT_DATA : OPT_DATA;
     return String.format(cacheRoot, getAppId());
   }
 
   private String getCustomizedCacheRoot() {
     // 1. Get from System Property
-    String cacheRoot = System.getProperty("apollo.cacheDir");
+    String cacheRoot = System.getProperty(ClientConfigConsts.APOLLO_CACHE_DIR);
     if (Strings.isNullOrEmpty(cacheRoot)) {
       // 2. Get from OS environment variable
       cacheRoot = System.getenv("APOLLO_CACHEDIR");
     }
     if (Strings.isNullOrEmpty(cacheRoot)) {
       // 3. Get from server.properties
-      cacheRoot = Foundation.server().getProperty("apollo.cacheDir", null);
+      cacheRoot = Foundation.server().getProperty(ClientConfigConsts.APOLLO_CACHE_DIR, null);
     }
 
     return cacheRoot;
@@ -245,7 +248,7 @@ public class ConfigUtil {
   }
 
   private void initMaxConfigCacheSize() {
-    String customizedConfigCacheSize = System.getProperty("apollo.configCacheSize");
+    String customizedConfigCacheSize = System.getProperty(ClientConfigConsts.APOLLO_CONFIG_CACHE_SIZE);
     if (!Strings.isNullOrEmpty(customizedConfigCacheSize)) {
       try {
         maxConfigCacheSize = Long.valueOf(customizedConfigCacheSize);
@@ -268,7 +271,7 @@ public class ConfigUtil {
   }
 
   private void initLongPollingInitialDelayInMills() {
-    String customizedLongPollingInitialDelay = System.getProperty("apollo.longPollingInitialDelayInMills");
+    String customizedLongPollingInitialDelay = System.getProperty(ClientConfigConsts.APOLLO_LONG_POLLING_INITIAL_DELAY_IN_MILLS);
     if (!Strings.isNullOrEmpty(customizedLongPollingInitialDelay)) {
       try {
         longPollingInitialDelayInMills = Long.valueOf(customizedLongPollingInitialDelay);
@@ -284,10 +287,10 @@ public class ConfigUtil {
 
   private void initAutoUpdateInjectedSpringProperties() {
     // 1. Get from System Property
-    String enableAutoUpdate = System.getProperty("apollo.autoUpdateInjectedSpringProperties");
+    String enableAutoUpdate = System.getProperty(ClientConfigConsts.APOLLO_AUTO_UPDATE_INJECTED_SPRING_PROPERTIE);
     if (Strings.isNullOrEmpty(enableAutoUpdate)) {
       // 2. Get from app.properties
-      enableAutoUpdate = Foundation.app().getProperty("apollo.autoUpdateInjectedSpringProperties", null);
+      enableAutoUpdate = Foundation.app().getProperty(ClientConfigConsts.APOLLO_AUTO_UPDATE_INJECTED_SPRING_PROPERTIE, null);
     }
     if (!Strings.isNullOrEmpty(enableAutoUpdate)) {
       autoUpdateInjectedSpringProperties = Boolean.parseBoolean(enableAutoUpdate.trim());

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/build/MockInjector.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/build/MockInjector.java
@@ -61,4 +61,9 @@ public class MockInjector implements Injector {
     classTable.clear();
     delegate = null;
   }
+
+  @Override
+  public int getOrder() {
+    return 1;
+  }
 }

--- a/apollo-core/src/main/java/com/ctrip/framework/apollo/core/ConfigConsts.java
+++ b/apollo-core/src/main/java/com/ctrip/framework/apollo/core/ConfigConsts.java
@@ -9,4 +9,16 @@ public interface ConfigConsts {
   String CONFIG_FILE_CONTENT_KEY = "content";
   String NO_APPID_PLACEHOLDER = "ApolloNoAppIdPlaceHolder";
   long NOTIFICATION_ID_PLACEHOLDER = -1;
+  String APOLLO_APP_ID = "apollo.app.id";
+  /**
+   * It is recommended to use {@link #APOLLO_APP_ID}
+   */
+  String APP_ID = "app.id";
+  String APOLLO_IDC = "apollo.idc";
+  
+  String APOLLO_ENV = "apollo.env";
+  /**
+   * It is recommended to use {@link #APOLLO_ENV}
+   */
+  String ENV =  "env";
 }

--- a/apollo-core/src/main/java/com/ctrip/framework/apollo/core/MetaDomainConsts.java
+++ b/apollo-core/src/main/java/com/ctrip/framework/apollo/core/MetaDomainConsts.java
@@ -1,9 +1,6 @@
 package com.ctrip.framework.apollo.core;
 
-import com.ctrip.framework.apollo.core.enums.Env;
 import java.util.Collections;
-import java.util.Comparator;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executors;
@@ -14,6 +11,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.ctrip.framework.apollo.core.enums.Env;
 import com.ctrip.framework.apollo.core.spi.MetaServerProvider;
 import com.ctrip.framework.apollo.core.utils.ApolloThreadFactory;
 import com.ctrip.framework.apollo.core.utils.NetUtil;
@@ -108,18 +106,7 @@ public class MetaDomainConsts {
   }
 
   private static List<MetaServerProvider> initMetaServerProviders() {
-    Iterator<MetaServerProvider> metaServerProviderIterator = ServiceBootstrap.loadAll(MetaServerProvider.class);
-
-    List<MetaServerProvider> metaServerProviders = Lists.newArrayList(metaServerProviderIterator);
-
-    Collections.sort(metaServerProviders, new Comparator<MetaServerProvider>() {
-      @Override
-      public int compare(MetaServerProvider o1, MetaServerProvider o2) {
-        // the smaller order has higher priority
-        return Integer.compare(o1.getOrder(), o2.getOrder());
-      }
-    });
-
+    List<MetaServerProvider> metaServerProviders = ServiceBootstrap.loadAll(MetaServerProvider.class, ServiceBootstrap.ASC);
     return metaServerProviders;
   }
 

--- a/apollo-core/src/main/java/com/ctrip/framework/apollo/core/utils/StringUtils.java
+++ b/apollo-core/src/main/java/com/ctrip/framework/apollo/core/utils/StringUtils.java
@@ -368,4 +368,20 @@ public class StringUtils {
 
     return buf.toString();
   }
+  
+  /**
+   * <pre>
+   * StringUtils.normalizeSyctemEnv(null)      ==> null
+   * StringUtils.normalizeSyctemEnv("abc.def.df")  ==> ABC_DEF_DF
+   * </pre>
+   *
+   * @param str
+   * @return
+   */
+  public static String normalizeSyctemEnv(String str) {
+    if (str == null) {
+      return null;
+    }
+    return str.replace(".", "_").toUpperCase();
+  }
 }

--- a/apollo-core/src/main/java/com/ctrip/framework/apollo/tracer/Tracer.java
+++ b/apollo-core/src/main/java/com/ctrip/framework/apollo/tracer/Tracer.java
@@ -28,7 +28,7 @@ public abstract class Tracer {
       if (producerManager == null) {
         synchronized (lock) {
           if (producerManager == null) {
-            producerManager = ServiceBootstrap.loadFirst(MessageProducerManager.class);
+            producerManager = ServiceBootstrap.loadFirst(MessageProducerManager.class, ServiceBootstrap.ASC);
           }
         }
       }

--- a/apollo-core/src/main/java/com/ctrip/framework/apollo/tracer/internals/DefaultMessageProducerManager.java
+++ b/apollo-core/src/main/java/com/ctrip/framework/apollo/tracer/internals/DefaultMessageProducerManager.java
@@ -24,4 +24,9 @@ public class DefaultMessageProducerManager implements MessageProducerManager {
   public MessageProducer getProducer() {
     return producer;
   }
+
+  @Override
+  public int getOrder() {
+    return 0;
+  }
 }

--- a/apollo-core/src/main/java/com/ctrip/framework/apollo/tracer/internals/NullMessageProducer.java
+++ b/apollo-core/src/main/java/com/ctrip/framework/apollo/tracer/internals/NullMessageProducer.java
@@ -1,5 +1,6 @@
 package com.ctrip.framework.apollo.tracer.internals;
 
+import com.ctrip.framework.apollo.core.spi.Ordered;
 import com.ctrip.framework.apollo.tracer.spi.MessageProducer;
 import com.ctrip.framework.apollo.tracer.spi.Transaction;
 
@@ -28,5 +29,10 @@ public class NullMessageProducer implements MessageProducer {
   @Override
   public Transaction newTransaction(String type, String name) {
     return NULL_TRANSACTION;
+  }
+
+  @Override
+  public int getOrder() {
+    return Ordered.LOWEST_PRECEDENCE;
   }
 }

--- a/apollo-core/src/main/java/com/ctrip/framework/apollo/tracer/internals/NullMessageProducerManager.java
+++ b/apollo-core/src/main/java/com/ctrip/framework/apollo/tracer/internals/NullMessageProducerManager.java
@@ -1,5 +1,6 @@
 package com.ctrip.framework.apollo.tracer.internals;
 
+import com.ctrip.framework.apollo.core.spi.Ordered;
 import com.ctrip.framework.apollo.tracer.spi.MessageProducer;
 import com.ctrip.framework.apollo.tracer.spi.MessageProducerManager;
 
@@ -12,5 +13,10 @@ public class NullMessageProducerManager implements MessageProducerManager {
   @Override
   public MessageProducer getProducer() {
     return producer;
+  }
+
+  @Override
+  public int getOrder() {
+    return Ordered.LOWEST_PRECEDENCE;
   }
 }

--- a/apollo-core/src/main/java/com/ctrip/framework/apollo/tracer/internals/cat/CatMessageProducer.java
+++ b/apollo-core/src/main/java/com/ctrip/framework/apollo/tracer/internals/cat/CatMessageProducer.java
@@ -81,4 +81,9 @@ public class CatMessageProducer implements MessageProducer {
       throw new IllegalStateException(ex);
     }
   }
+
+  @Override
+  public int getOrder() {
+    return 0;
+  }
 }

--- a/apollo-core/src/main/java/com/ctrip/framework/apollo/tracer/spi/MessageProducer.java
+++ b/apollo-core/src/main/java/com/ctrip/framework/apollo/tracer/spi/MessageProducer.java
@@ -1,9 +1,11 @@
 package com.ctrip.framework.apollo.tracer.spi;
 
+import com.ctrip.framework.apollo.core.spi.Ordered;
+
 /**
  * @author Jason Song(song_s@ctrip.com)
  */
-public interface MessageProducer {
+public interface MessageProducer  extends Ordered{
   /**
    * Log an error.
    *

--- a/apollo-core/src/main/java/com/ctrip/framework/apollo/tracer/spi/MessageProducerManager.java
+++ b/apollo-core/src/main/java/com/ctrip/framework/apollo/tracer/spi/MessageProducerManager.java
@@ -1,9 +1,11 @@
 package com.ctrip.framework.apollo.tracer.spi;
 
+import com.ctrip.framework.apollo.core.spi.Ordered;
+
 /**
  * @author Jason Song(song_s@ctrip.com)
  */
-public interface MessageProducerManager {
+public interface MessageProducerManager  extends Ordered{
   /**
    * @return the message producer
    */

--- a/apollo-core/src/main/java/com/ctrip/framework/foundation/Foundation.java
+++ b/apollo-core/src/main/java/com/ctrip/framework/foundation/Foundation.java
@@ -26,7 +26,7 @@ public abstract class Foundation {
         // Double locking to make sure only one thread initializes ProviderManager.
         synchronized (lock) {
           if (s_manager == null) {
-            s_manager = ServiceBootstrap.loadFirst(ProviderManager.class);
+            s_manager = ServiceBootstrap.loadFirst(ProviderManager.class, ServiceBootstrap.ASC);
           }
         }
       }

--- a/apollo-core/src/main/java/com/ctrip/framework/foundation/internals/DefaultProviderManager.java
+++ b/apollo-core/src/main/java/com/ctrip/framework/foundation/internals/DefaultProviderManager.java
@@ -3,13 +3,14 @@ package com.ctrip.framework.foundation.internals;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import com.ctrip.framework.foundation.internals.provider.DefaultApplicationProvider;
-import com.ctrip.framework.foundation.internals.provider.DefaultNetworkProvider;
-import com.ctrip.framework.foundation.internals.provider.DefaultServerProvider;
-import com.ctrip.framework.foundation.spi.ProviderManager;
-import com.ctrip.framework.foundation.spi.provider.Provider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.ctrip.framework.foundation.spi.ProviderManager;
+import com.ctrip.framework.foundation.spi.provider.ApplicationProvider;
+import com.ctrip.framework.foundation.spi.provider.NetworkProvider;
+import com.ctrip.framework.foundation.spi.provider.Provider;
+import com.ctrip.framework.foundation.spi.provider.ServerProvider;
 
 public class DefaultProviderManager implements ProviderManager {
   private static final Logger logger = LoggerFactory.getLogger(DefaultProviderManager.class);
@@ -17,18 +18,22 @@ public class DefaultProviderManager implements ProviderManager {
 
   public DefaultProviderManager() {
     // Load per-application configuration, like app id, from classpath://META-INF/app.properties
-    Provider applicationProvider = new DefaultApplicationProvider();
+    //Provider applicationProvider = new DefaultApplicationProvider();
+    
+    ApplicationProvider  applicationProvider = ServiceBootstrap.loadFirst(ApplicationProvider.class, ServiceBootstrap.ASC);
     applicationProvider.initialize();
     register(applicationProvider);
 
     // Load network parameters
-    Provider networkProvider = new DefaultNetworkProvider();
+    //Provider networkProvider = new DefaultNetworkProvider();
+    NetworkProvider networkProvider = ServiceBootstrap.loadFirst(NetworkProvider.class, ServiceBootstrap.ASC);
     networkProvider.initialize();
     register(networkProvider);
 
     // Load environment (fat, fws, uat, prod ...) and dc, from /opt/settings/server.properties, JVM property and/or OS
     // environment variables.
-    Provider serverProvider = new DefaultServerProvider();
+    //Provider serverProvider = new DefaultServerProvider();
+    ServerProvider serverProvider = ServiceBootstrap.loadFirst(ServerProvider.class, ServiceBootstrap.ASC);
     serverProvider.initialize();
     register(serverProvider);
   }
@@ -74,5 +79,10 @@ public class DefaultProviderManager implements ProviderManager {
     }
     sb.append("(DefaultProviderManager)").append("\n");
     return sb.toString();
+  }
+
+  @Override
+  public int getOrder() {
+    return 0;
   }
 }

--- a/apollo-core/src/main/java/com/ctrip/framework/foundation/internals/NetworkInterfaceManager.java
+++ b/apollo-core/src/main/java/com/ctrip/framework/foundation/internals/NetworkInterfaceManager.java
@@ -10,7 +10,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Enumeration;
 import java.util.List;
-import java.util.Objects;
 
 public enum NetworkInterfaceManager {
   INSTANCE;

--- a/apollo-core/src/main/java/com/ctrip/framework/foundation/internals/NullProviderManager.java
+++ b/apollo-core/src/main/java/com/ctrip/framework/foundation/internals/NullProviderManager.java
@@ -1,5 +1,6 @@
 package com.ctrip.framework.foundation.internals;
 
+import com.ctrip.framework.apollo.core.spi.Ordered;
 import com.ctrip.framework.foundation.internals.provider.NullProvider;
 import com.ctrip.framework.foundation.spi.ProviderManager;
 
@@ -19,5 +20,10 @@ public class NullProviderManager implements ProviderManager {
   @Override
   public String toString() {
     return provider.toString();
+  }
+
+  @Override
+  public int getOrder() {
+    return Ordered.LOWEST_PRECEDENCE;
   }
 }

--- a/apollo-core/src/main/java/com/ctrip/framework/foundation/internals/ServiceBootstrap.java
+++ b/apollo-core/src/main/java/com/ctrip/framework/foundation/internals/ServiceBootstrap.java
@@ -1,9 +1,34 @@
 package com.ctrip.framework.foundation.internals;
 
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.Iterator;
+import java.util.List;
 import java.util.ServiceLoader;
 
+import com.ctrip.framework.apollo.core.spi.Ordered;
+import com.google.common.collect.Lists;
+
 public class ServiceBootstrap {
+  /**
+   * the smaller order has higher priority
+   */
+  public static final Comparator<Ordered> ASC =  new Comparator<Ordered>() {
+    @Override
+    public int compare(Ordered o1, Ordered o2) {
+      return Integer.compare(o1.getOrder(), o2.getOrder());
+    }
+  };
+  /**
+   * Larger orders have higher priority
+   */
+  public static final Comparator<Ordered> DESC =  new Comparator<Ordered>() {
+    @Override
+    public int compare(Ordered o1, Ordered o2) {
+      return Integer.compare(o2.getOrder(), o1.getOrder());
+    }
+  };
+  
   public static <S> S loadFirst(Class<S> clazz) {
     Iterator<S> iterator = loadAll(clazz);
     if (!iterator.hasNext()) {
@@ -13,10 +38,43 @@ public class ServiceBootstrap {
     }
     return iterator.next();
   }
-
+  
   public static <S> Iterator<S> loadAll(Class<S> clazz) {
     ServiceLoader<S> loader = ServiceLoader.load(clazz);
-
     return loader.iterator();
   }
+  
+  /**
+   * Sort the results
+   * @param <S>
+   * @param clazz
+   * @param comparator
+   * @return
+   */
+  public static <S extends Ordered> List<S> loadAll(Class<S> clazz, Comparator<Ordered> comparator) {
+    Iterator<S> iterator = loadAll(clazz);
+    if (!iterator.hasNext()) {
+      throw new IllegalStateException(String.format(
+          "No implementation defined in /META-INF/services/%s, please check whether the file exists and has the right implementation class!",
+          clazz.getName()));
+    }
+    List<S> loaders = Lists.newArrayList(iterator);
+    if(loaders.size() > 1) {
+      Collections.sort(loaders, comparator);
+    }
+    return loaders;
+  }
+
+  /**
+   * Sort the results first， returns the first of the sorted results
+   * @param <S>
+   * @param clazz
+   * @param comparator
+   * @return
+   */
+  public static <S extends Ordered> S loadFirst(Class<S> clazz, Comparator<Ordered> comparator) {
+    List<S> loaders = loadAll(clazz, comparator);
+    return loaders.get(0);
+  }
+  
 }

--- a/apollo-core/src/main/java/com/ctrip/framework/foundation/internals/provider/DefaultApplicationProvider.java
+++ b/apollo-core/src/main/java/com/ctrip/framework/foundation/internals/provider/DefaultApplicationProvider.java
@@ -8,12 +8,15 @@ import java.util.Properties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.ctrip.framework.apollo.core.ConfigConsts;
+import com.ctrip.framework.apollo.core.utils.StringUtils;
 import com.ctrip.framework.foundation.internals.Utils;
 import com.ctrip.framework.foundation.internals.io.BOMInputStream;
 import com.ctrip.framework.foundation.spi.provider.ApplicationProvider;
 import com.ctrip.framework.foundation.spi.provider.Provider;
 
 public class DefaultApplicationProvider implements ApplicationProvider {
+  private static final String[] APP_IDS = {ConfigConsts.APOLLO_APP_ID, ConfigConsts.APP_ID};
   private static final Logger logger = LoggerFactory.getLogger(DefaultApplicationProvider.class);
   public static final String APP_PROPERTIES_CLASSPATH = "/META-INF/app.properties";
   private Properties m_appProperties = new Properties();
@@ -63,7 +66,7 @@ public class DefaultApplicationProvider implements ApplicationProvider {
 
   @Override
   public String getProperty(String name, String defaultValue) {
-    if ("app.id".equals(name)) {
+    if (ConfigConsts.APOLLO_APP_ID.equals(name) || ConfigConsts.APP_ID.equals(name)) {
       String val = getAppId();
       return val == null ? defaultValue : val;
     } else {
@@ -78,36 +81,52 @@ public class DefaultApplicationProvider implements ApplicationProvider {
   }
 
   private void initAppId() {
+    /**
+     * support ‘apollo.app.id’ 
+     */
+    for (String app_id : APP_IDS) {
+      if(initAppId(app_id)) {
+        return ;
+      }
+    }
+    m_appId = null;
+    logger.warn("app.id is not available from System Property and {}. It is set to null", APP_PROPERTIES_CLASSPATH);
+  }
+
+  private boolean initAppId(String app_id) {
     // 1. Get app.id from System Property
-    m_appId = System.getProperty("app.id");
+    m_appId = System.getProperty(app_id);
     if (!Utils.isBlank(m_appId)) {
       m_appId = m_appId.trim();
       logger.info("App ID is set to {} by app.id property from System Property", m_appId);
-      return;
+      return true;
     }
-
+ 
     //2. Try to get app id from OS environment variable
-    m_appId = System.getenv("APP_ID");
+    m_appId = System.getenv(StringUtils.normalizeSyctemEnv(app_id));
     if (!Utils.isBlank(m_appId)) {
       m_appId = m_appId.trim();
       logger.info("App ID is set to {} by APP_ID property from OS environment variable", m_appId);
-      return;
+      return true;
     }
-
+ 
     // 3. Try to get app id from app.properties.
-    m_appId = m_appProperties.getProperty("app.id");
+    m_appId = m_appProperties.getProperty(app_id);
     if (!Utils.isBlank(m_appId)) {
       m_appId = m_appId.trim();
       logger.info("App ID is set to {} by app.id property from {}", m_appId, APP_PROPERTIES_CLASSPATH);
-      return;
+      return true;
     }
-
-    m_appId = null;
-    logger.warn("app.id is not available from System Property and {}. It is set to null", APP_PROPERTIES_CLASSPATH);
+    return false;
   }
 
   @Override
   public String toString() {
     return "appId [" + getAppId() + "] properties: " + m_appProperties + " (DefaultApplicationProvider)";
+  }
+
+  @Override
+  public int getOrder() {
+    return 0;
   }
 }

--- a/apollo-core/src/main/java/com/ctrip/framework/foundation/internals/provider/DefaultNetworkProvider.java
+++ b/apollo-core/src/main/java/com/ctrip/framework/foundation/internals/provider/DefaultNetworkProvider.java
@@ -42,4 +42,9 @@ public class DefaultNetworkProvider implements NetworkProvider {
   public String toString() {
     return "hostName [" + getHostName() + "] hostIP [" + getHostAddress() + "] (DefaultNetworkProvider)";
   }
+
+  @Override
+  public int getOrder() {
+    return 0;
+  }
 }

--- a/apollo-core/src/main/java/com/ctrip/framework/foundation/internals/provider/DefaultServerProvider.java
+++ b/apollo-core/src/main/java/com/ctrip/framework/foundation/internals/provider/DefaultServerProvider.java
@@ -7,14 +7,20 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.Properties;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.ctrip.framework.apollo.core.ConfigConsts;
+import com.ctrip.framework.apollo.core.utils.StringUtils;
 import com.ctrip.framework.foundation.internals.Utils;
 import com.ctrip.framework.foundation.internals.io.BOMInputStream;
 import com.ctrip.framework.foundation.spi.provider.Provider;
 import com.ctrip.framework.foundation.spi.provider.ServerProvider;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class DefaultServerProvider implements ServerProvider {
+  private static final String[] IDCS = {ConfigConsts.APOLLO_IDC, "idc"};
+  private static final String[] ENVS = {ConfigConsts.APOLLO_ENV, ConfigConsts.ENV};
+  
   private static final Logger logger = LoggerFactory.getLogger(DefaultServerProvider.class);
   private static final String SERVER_PROPERTIES_LINUX = "/opt/settings/server.properties";
   private static final String SERVER_PROPERTIES_WINDOWS = "C:/opt/settings/server.properties";
@@ -83,10 +89,10 @@ public class DefaultServerProvider implements ServerProvider {
 
   @Override
   public String getProperty(String name, String defaultValue) {
-    if ("env".equalsIgnoreCase(name)) {
+    if (ConfigConsts.APOLLO_ENV.equals(name) || ConfigConsts.ENV.equalsIgnoreCase(name)) {
       String val = getEnvType();
       return val == null ? defaultValue : val;
-    } else if ("dc".equalsIgnoreCase(name)) {
+    } else if (ConfigConsts.APOLLO_IDC.equals(name) ||  "dc".equalsIgnoreCase(name)) {
       String val = getDataCenter();
       return val == null ? defaultValue : val;
     } else {
@@ -101,68 +107,95 @@ public class DefaultServerProvider implements ServerProvider {
   }
 
   private void initEnvType() {
-    // 1. Try to get environment from JVM system property
-    m_env = System.getProperty("env");
-    if (!Utils.isBlank(m_env)) {
-      m_env = m_env.trim();
-      logger.info("Environment is set to [{}] by JVM system property 'env'.", m_env);
-      return;
+    /**
+     * support ‘apollo.env’ 
+     */
+    for (String env : ENVS) {
+      if(initEnvType(env)) {
+        return;
+      }
     }
-
-    // 2. Try to get environment from OS environment variable
-    m_env = System.getenv("ENV");
-    if (!Utils.isBlank(m_env)) {
-      m_env = m_env.trim();
-      logger.info("Environment is set to [{}] by OS env variable 'ENV'.", m_env);
-      return;
-    }
-
-    // 3. Try to get environment from file "server.properties"
-    m_env = m_serverProperties.getProperty("env");
-    if (!Utils.isBlank(m_env)) {
-      m_env = m_env.trim();
-      logger.info("Environment is set to [{}] by property 'env' in server.properties.", m_env);
-      return;
-    }
-
+    
     // 4. Set environment to null.
     m_env = null;
     logger.info("Environment is set to null. Because it is not available in either (1) JVM system property 'env', (2) OS env variable 'ENV' nor (3) property 'env' from the properties InputStream.");
   }
 
-  private void initDataCenter() {
+  private boolean initEnvType(String env) {
     // 1. Try to get environment from JVM system property
-    m_dc = System.getProperty("idc");
-    if (!Utils.isBlank(m_dc)) {
-      m_dc = m_dc.trim();
-      logger.info("Data Center is set to [{}] by JVM system property 'idc'.", m_dc);
-      return;
+    m_env = System.getProperty(env);
+    if (!Utils.isBlank(m_env)) {
+      m_env = m_env.trim();
+      logger.info("Environment is set to [{}] by JVM system property 'env'.", m_env);
+      return true;
     }
-
-    // 2. Try to get idc from OS environment variable
-    m_dc = System.getenv("IDC");
-    if (!Utils.isBlank(m_dc)) {
-      m_dc = m_dc.trim();
-      logger.info("Data Center is set to [{}] by OS env variable 'IDC'.", m_dc);
-      return;
+ 
+    // 2. Try to get environment from OS environment variable
+    m_env = System.getenv(StringUtils.normalizeSyctemEnv(env));
+    if (!Utils.isBlank(m_env)) {
+      m_env = m_env.trim();
+      logger.info("Environment is set to [{}] by OS env variable 'ENV'.", m_env);
+      return true;
     }
-
-    // 3. Try to get idc from from file "server.properties"
-    m_dc = m_serverProperties.getProperty("idc");
-    if (!Utils.isBlank(m_dc)) {
-      m_dc = m_dc.trim();
-      logger.info("Data Center is set to [{}] by property 'idc' in server.properties.", m_dc);
-      return;
+ 
+    // 3. Try to get environment from file "server.properties"
+    m_env = m_serverProperties.getProperty(env);
+    if (!Utils.isBlank(m_env)) {
+      m_env = m_env.trim();
+      logger.info("Environment is set to [{}] by property 'env' in server.properties.", m_env);
+      return true;
     }
-
+    return false;
+  }
+  
+  private void initDataCenter() {
+    /**
+     * support ‘apollo.idc’ 
+     */
+    for (String idc : IDCS) {
+      if(initDataCenter(idc)) {
+        return;
+      }
+    }
     // 4. Set Data Center to null.
     m_dc = null;
     logger.debug("Data Center is set to null. Because it is not available in either (1) JVM system property 'idc', (2) OS env variable 'IDC' nor (3) property 'idc' from the properties InputStream.");
+  }
+  private boolean initDataCenter(String idc) {
+    // 1. Try to get environment from JVM system property
+    m_dc = System.getProperty(idc);
+    if (!Utils.isBlank(m_dc)) {
+      m_dc = m_dc.trim();
+      logger.info("Data Center is set to [{}] by JVM system property 'idc'.", m_dc);
+      return true;
+    }
+
+    // 2. Try to get idc from OS environment variable
+    m_dc = System.getenv(StringUtils.normalizeSyctemEnv(idc));
+    if (!Utils.isBlank(m_dc)) {
+      m_dc = m_dc.trim();
+      logger.info("Data Center is set to [{}] by OS env variable 'IDC'.", m_dc);
+      return true;
+    }
+
+    // 3. Try to get idc from from file "server.properties"
+    m_dc = m_serverProperties.getProperty(idc);
+    if (!Utils.isBlank(m_dc)) {
+      m_dc = m_dc.trim();
+      logger.info("Data Center is set to [{}] by property 'idc' in server.properties.", m_dc);
+      return true;
+    }
+    return false;
   }
 
   @Override
   public String toString() {
     return "environment [" + getEnvType() + "] data center [" + getDataCenter() + "] properties: " + m_serverProperties
         + " (DefaultServerProvider)";
+  }
+
+  @Override
+  public int getOrder() {
+    return 0;
   }
 }

--- a/apollo-core/src/main/java/com/ctrip/framework/foundation/internals/provider/NullProvider.java
+++ b/apollo-core/src/main/java/com/ctrip/framework/foundation/internals/provider/NullProvider.java
@@ -2,6 +2,7 @@ package com.ctrip.framework.foundation.internals.provider;
 
 import java.io.InputStream;
 
+import com.ctrip.framework.apollo.core.spi.Ordered;
 import com.ctrip.framework.foundation.spi.provider.ApplicationProvider;
 import com.ctrip.framework.foundation.spi.provider.NetworkProvider;
 import com.ctrip.framework.foundation.spi.provider.Provider;
@@ -71,5 +72,10 @@ public class NullProvider implements ApplicationProvider, NetworkProvider, Serve
   @Override
   public String toString() {
     return "(NullProvider)";
+  }
+
+  @Override
+  public int getOrder() {
+    return Ordered.LOWEST_PRECEDENCE;
   }
 }

--- a/apollo-core/src/main/java/com/ctrip/framework/foundation/spi/ProviderManager.java
+++ b/apollo-core/src/main/java/com/ctrip/framework/foundation/spi/ProviderManager.java
@@ -1,8 +1,9 @@
 package com.ctrip.framework.foundation.spi;
 
+import com.ctrip.framework.apollo.core.spi.Ordered;
 import com.ctrip.framework.foundation.spi.provider.Provider;
 
-public interface ProviderManager {
+public interface ProviderManager extends Ordered{
   public String getProperty(String name, String defaultValue);
 
   public <T extends Provider> T provider(Class<T> clazz);

--- a/apollo-core/src/main/java/com/ctrip/framework/foundation/spi/provider/Provider.java
+++ b/apollo-core/src/main/java/com/ctrip/framework/foundation/spi/provider/Provider.java
@@ -1,6 +1,8 @@
 package com.ctrip.framework.foundation.spi.provider;
 
-public interface Provider {
+import com.ctrip.framework.apollo.core.spi.Ordered;
+
+public interface Provider extends Ordered{
   /**
    * @return the current provider's type
    */

--- a/apollo-core/src/main/resources/META-INF/services/com.ctrip.framework.foundation.spi.provider.ApplicationProvider
+++ b/apollo-core/src/main/resources/META-INF/services/com.ctrip.framework.foundation.spi.provider.ApplicationProvider
@@ -1,0 +1,1 @@
+com.ctrip.framework.foundation.internals.provider.DefaultApplicationProvider

--- a/apollo-core/src/main/resources/META-INF/services/com.ctrip.framework.foundation.spi.provider.NetworkProvider
+++ b/apollo-core/src/main/resources/META-INF/services/com.ctrip.framework.foundation.spi.provider.NetworkProvider
@@ -1,0 +1,1 @@
+com.ctrip.framework.foundation.internals.provider.DefaultNetworkProvider

--- a/apollo-core/src/main/resources/META-INF/services/com.ctrip.framework.foundation.spi.provider.ServerProvider
+++ b/apollo-core/src/main/resources/META-INF/services/com.ctrip.framework.foundation.spi.provider.ServerProvider
@@ -1,0 +1,1 @@
+com.ctrip.framework.foundation.internals.provider.DefaultServerProvider

--- a/apollo-core/src/test/java/com/ctrip/framework/apollo/tracer/internals/MockMessageProducerManager.java
+++ b/apollo-core/src/test/java/com/ctrip/framework/apollo/tracer/internals/MockMessageProducerManager.java
@@ -17,4 +17,9 @@ public class MockMessageProducerManager implements MessageProducerManager {
   public static void setProducer(MessageProducer producer) {
     s_producer = producer;
   }
+
+  @Override
+  public int getOrder() {
+    return 0;
+  }
 }

--- a/apollo-core/src/test/java/com/ctrip/framework/foundation/internals/ServiceBootstrapTest.java
+++ b/apollo-core/src/test/java/com/ctrip/framework/foundation/internals/ServiceBootstrapTest.java
@@ -1,10 +1,20 @@
 package com.ctrip.framework.foundation.internals;
 
-import org.junit.Test;
+import static org.junit.Assert.assertTrue;
 
+import java.util.List;
 import java.util.ServiceConfigurationError;
 
-import static org.junit.Assert.assertTrue;
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ctrip.framework.apollo.core.spi.MetaServerProvider;
+import com.ctrip.framework.apollo.tracer.spi.MessageProducerManager;
+import com.ctrip.framework.foundation.spi.ProviderManager;
+import com.ctrip.framework.foundation.spi.provider.ApplicationProvider;
+import com.ctrip.framework.foundation.spi.provider.NetworkProvider;
+import com.ctrip.framework.foundation.spi.provider.Provider;
+import com.ctrip.framework.foundation.spi.provider.ServerProvider;
 
 /**
  * @author Jason Song(song_s@ctrip.com)
@@ -36,6 +46,59 @@ public class ServiceBootstrapTest {
     ServiceBootstrap.loadFirst(Interface5.class);
   }
 
+  @Test
+  public void loadAllWithServiceImplSortASC() throws Exception {
+    List<MetaServerProvider> metaServerProviders = ServiceBootstrap.loadAll(MetaServerProvider.class, ServiceBootstrap.ASC);
+    MetaServerProvider lastMetaServerProvider = null;
+    for (MetaServerProvider metaServerProvider : metaServerProviders) {
+      if(lastMetaServerProvider == null) {
+        lastMetaServerProvider  = metaServerProvider;
+        continue;
+      }
+      Assert.assertTrue(lastMetaServerProvider.getOrder() < metaServerProvider.getOrder());
+      
+      lastMetaServerProvider  = metaServerProvider;
+    }
+  }
+  
+  @Test
+  public void loadAllWithServiceImplSortDESC() throws Exception {
+    List<MetaServerProvider> metaServerProviders = ServiceBootstrap.loadAll(MetaServerProvider.class, ServiceBootstrap.DESC);
+    MetaServerProvider lastMetaServerProvider = null;
+    for (MetaServerProvider metaServerProvider : metaServerProviders) {
+      if(lastMetaServerProvider == null) {
+        lastMetaServerProvider  = metaServerProvider;
+        continue;
+      }
+      Assert.assertTrue(lastMetaServerProvider.getOrder() > metaServerProvider.getOrder());
+      
+      lastMetaServerProvider  = metaServerProvider;
+    }
+  }
+  
+  @Test
+  public void loadFirstWithServiceImplSort() throws Exception {
+    Provider applicationProvider = ServiceBootstrap.loadFirst(ApplicationProvider.class, ServiceBootstrap.ASC);
+    
+    Assert.assertTrue(applicationProvider instanceof ApplicationProvider);
+    
+    Provider networkProvider = ServiceBootstrap.loadFirst(NetworkProvider.class, ServiceBootstrap.ASC);
+    
+    Assert.assertTrue(networkProvider instanceof NetworkProvider);
+    
+    Provider serverProvider = ServiceBootstrap.loadFirst(ServerProvider.class, ServiceBootstrap.ASC);
+    
+    Assert.assertTrue(serverProvider instanceof ServerProvider);
+    
+    ProviderManager providerManager = ServiceBootstrap.loadFirst(ProviderManager.class, ServiceBootstrap.ASC);
+    
+    Assert.assertTrue(providerManager instanceof ProviderManager);
+    
+    MessageProducerManager messageProducerManager = ServiceBootstrap.loadFirst(MessageProducerManager.class, ServiceBootstrap.ASC);
+    
+    Assert.assertTrue(messageProducerManager instanceof MessageProducerManager);
+  }
+  
   private interface Interface1 {
   }
 

--- a/apollo-demo/pom.xml
+++ b/apollo-demo/pom.xml
@@ -14,10 +14,28 @@
 		<java.version>1.7</java.version>
 		<github.path>${project.artifactId}</github.path>
 	</properties>
+    <!-- 
+     <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>1.5.16.RELEASE</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+     -->
 	<dependencies>
 		<dependency>
 			<groupId>com.ctrip.framework.apollo</groupId>
 			<artifactId>apollo-client</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.ctrip.framework.apollo</groupId>
+			<artifactId>apollo-client-springboot2-extension</artifactId>
 			<version>${project.version}</version>
 		</dependency>
 		<!-- for spring demo -->
@@ -44,6 +62,7 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-context</artifactId>
+            <!-- <version>1.3.5.RELEASE</version>  -->
 		</dependency>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
@@ -61,6 +80,11 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>jcl-over-slf4j</artifactId>
+		</dependency>
+		<dependency>
+		    <groupId>org.springframework.boot</groupId>
+		    <artifactId>spring-boot-configuration-processor</artifactId>
+		    <optional>true</optional>
 		</dependency>
 	</dependencies>
 </project>

--- a/apollo-demo/src/main/java/com/ctrip/framework/apollo/demo/spring/springBootDemo/autorefresh/AutoRefreshConfigurationPropertiesRedisConfig.java
+++ b/apollo-demo/src/main/java/com/ctrip/framework/apollo/demo/spring/springBootDemo/autorefresh/AutoRefreshConfigurationPropertiesRedisConfig.java
@@ -1,0 +1,99 @@
+package com.ctrip.framework.apollo.demo.spring.springBootDemo.autorefresh;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.cloud.context.config.annotation.RefreshScope;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+
+/**
+ * You may set up data like the following in Apollo:
+ * <br /><br />
+ * Properties Sample: application.properties
+ * <pre>
+ * redis.cache.enabled = true
+ * redis.cache.expireSeconds = 100
+ * redis.cache.clusterNodes = 1,2
+ * redis.cache.commandTimeout = 50
+ * redis.cache.someMap.key1 = a
+ * redis.cache.someMap.key2 = b
+ * redis.cache.someList[0] = c
+ * redis.cache.someList[1] = d
+ * </pre>
+ *
+ * Yaml Sample: application.yaml
+ * <pre>
+ * redis:
+ *   cache:
+ *     enabled: true
+ *     expireSeconds: 100
+ *     clusterNodes: 1,2
+ *     commandTimeout: 50
+ *     someMap:
+ *       key1: a
+ *       key2: b
+ *     someList:
+ *     - c
+ *     - d
+ * </pre>
+ *
+ * To make <code>@ConditionalOnProperty</code> work properly, <code>apollo.bootstrap.enabled</code> should be set to true
+ * and <code>redis.cache.enabled</code> should also be set to true. Check 'src/main/resources/application.yml' for more information.
+ *
+ * @author Jason Song(song_s@ctrip.com)
+ */
+@ConditionalOnProperty("redis.cache.enabled")
+@ConfigurationProperties(prefix = "redis.cache")
+@Component
+public class AutoRefreshConfigurationPropertiesRedisConfig {
+
+  private static final Logger logger = LoggerFactory.getLogger(AutoRefreshConfigurationPropertiesRedisConfig.class);
+
+  private int expireSeconds;
+  private String clusterNodes;
+  private int commandTimeout;
+
+  private Map<String, String> someMap = Maps.newLinkedHashMap();
+  private List<String> someList = Lists.newLinkedList();
+
+  @PostConstruct
+  private void initialize() {
+    logger.info(
+        "SampleRedisConfig initialized - expireSeconds: {}, clusterNodes: {}, commandTimeout: {}, someMap: {}, someList: {}",
+        expireSeconds, clusterNodes, commandTimeout, someMap, someList);
+  }
+
+  public void setExpireSeconds(int expireSeconds) {
+    this.expireSeconds = expireSeconds;
+  }
+
+  public void setClusterNodes(String clusterNodes) {
+    this.clusterNodes = clusterNodes;
+  }
+
+  public void setCommandTimeout(int commandTimeout) {
+    this.commandTimeout = commandTimeout;
+  }
+
+  public Map<String, String> getSomeMap() {
+    return someMap;
+  }
+
+  public List<String> getSomeList() {
+    return someList;
+  }
+
+  @Override
+  public String toString() {
+    return String.format(
+        "[SampleRedisConfig] expireSeconds: %d, clusterNodes: %s, commandTimeout: %d, someMap: %s, someList: %s",
+            expireSeconds, clusterNodes, commandTimeout, someMap, someList);
+  }
+}

--- a/apollo-demo/src/main/java/com/ctrip/framework/apollo/demo/spring/springBootDemo/autorefresh/SpringBootRefreshSampleApplication2.java
+++ b/apollo-demo/src/main/java/com/ctrip/framework/apollo/demo/spring/springBootDemo/autorefresh/SpringBootRefreshSampleApplication2.java
@@ -1,0 +1,43 @@
+package com.ctrip.framework.apollo.demo.spring.springBootDemo.autorefresh;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.ApplicationContext;
+
+import com.ctrip.framework.apollo.ClientConfigConsts;
+import com.ctrip.framework.apollo.spring.boot.RefreshConfigurationProperties;
+import com.google.common.base.Charsets;
+import com.google.common.base.Strings;
+
+/**
+ * @author Jason Song(song_s@ctrip.com)
+ */
+@SpringBootApplication
+public class SpringBootRefreshSampleApplication2 {
+
+  public static void main(String[] args) throws IOException {
+    //
+    System.setProperty(ClientConfigConsts.APOLLO_AUTO_UPDATE_INJECTED_SPRING_PROPERTIE, "false");
+    ApplicationContext context = new SpringApplicationBuilder(SpringBootRefreshSampleApplication2.class).run(args);
+    AutoRefreshConfigurationPropertiesRedisConfig refreshEnabledRedisConfig = context.getBean(AutoRefreshConfigurationPropertiesRedisConfig.class);
+    
+    RefreshConfigurationProperties refreshConfigurationProperties = context.getBean(RefreshConfigurationProperties.class);
+System.out.println(refreshConfigurationProperties);
+    System.out.println("SpringBootSampleApplication Demo. Input any key except quit to print the values. Input quit to exit.");
+    while (true) {
+      System.out.print("> ");
+      String input = new BufferedReader(new InputStreamReader(System.in, Charsets.UTF_8)).readLine();
+      if (!Strings.isNullOrEmpty(input) && input.trim().equalsIgnoreCase("quit")) {
+        System.exit(0);
+      }
+
+      System.out.println(refreshEnabledRedisConfig);
+      System.out.println(context.getEnvironment().getProperty("redis.cache.expireSeconds"));
+    }
+  }
+  
+}

--- a/apollo-demo/src/main/java/com/ctrip/framework/apollo/demo/spring/springBootDemo/autorefreshannotation/AutoRefreshDisabledBean.java
+++ b/apollo-demo/src/main/java/com/ctrip/framework/apollo/demo/spring/springBootDemo/autorefreshannotation/AutoRefreshDisabledBean.java
@@ -1,0 +1,80 @@
+package com.ctrip.framework.apollo.demo.spring.springBootDemo.autorefreshannotation;
+
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.ctrip.framework.apollo.spring.annotation.ApolloJsonValue;
+import com.ctrip.framework.apollo.spring.annotation.AutoRefresh;
+import com.ctrip.framework.apollo.spring.annotation.RefreshField;
+
+/**
+ * @author Jason Song(song_s@ctrip.com)
+ */
+@Component
+@AutoRefresh(AutoRefresh.disabled)
+public class AutoRefreshDisabledBean {
+  private static final Logger logger = LoggerFactory.getLogger(AutoRefreshDisabledBean.class);
+
+  private int timeout;
+  private int batch;
+  private List<JsonBean> jsonBeans;
+
+  /**
+   * ApolloJsonValue annotated on fields example, the default value is specified as empty list - []
+   * <br />
+   * jsonBeanProperty=[{"someString":"hello","someInt":100},{"someString":"world!","someInt":200}]
+   */
+  @ApolloJsonValue("${jsonBeanProperty:[]}")
+  private List<JsonBean> anotherJsonBeans;
+
+  /**
+   * 应该起作用
+   * @param batch
+   */
+  @Value("${batch:100}")
+  @RefreshField(RefreshField.enabled)
+  public void setBatch(int batch) {
+    logger.info("updating batch, old value: {}, new value: {}", this.batch, batch);
+    this.batch = batch;
+  }
+
+  @Value("${timeout:200}")
+  public void setTimeout(int timeout) {
+    logger.info("updating timeout, old value: {}, new value: {}", this.timeout, timeout);
+    this.timeout = timeout;
+  }
+
+  /**
+   * ApolloJsonValue annotated on methods example, the default value is specified as empty list - []
+   * <br />
+   * jsonBeanProperty=[{"someString":"hello","someInt":100},{"someString":"world!","someInt":200}]
+   */
+  @ApolloJsonValue("${jsonBeanProperty:[]}")
+  public void setJsonBeans(List<JsonBean> jsonBeans) {
+    logger.info("updating json beans, old value: {}, new value: {}", this.jsonBeans, jsonBeans);
+    this.jsonBeans = jsonBeans;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("[RefreshDisabledBean] timeout: %d, batch: %d, jsonBeans: %s", timeout, batch, jsonBeans);
+  }
+
+  private static class JsonBean{
+
+    private String someString;
+    private int someInt;
+
+    @Override
+    public String toString() {
+      return "JsonBean{" +
+          "someString='" + someString + '\'' +
+          ", someInt=" + someInt +
+          '}';
+    }
+  }
+}

--- a/apollo-demo/src/main/java/com/ctrip/framework/apollo/demo/spring/springBootDemo/autorefreshannotation/AutoRefreshDisabledFiledRedisConfig.java
+++ b/apollo-demo/src/main/java/com/ctrip/framework/apollo/demo/spring/springBootDemo/autorefreshannotation/AutoRefreshDisabledFiledRedisConfig.java
@@ -1,0 +1,109 @@
+package com.ctrip.framework.apollo.demo.spring.springBootDemo.autorefreshannotation;
+
+import java.util.List;
+import java.util.Map;
+
+import javax.annotation.PostConstruct;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import com.ctrip.framework.apollo.spring.annotation.AutoRefresh;
+import com.ctrip.framework.apollo.spring.annotation.RefreshField;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+
+/**
+ * You may set up data like the following in Apollo:
+ * <br /><br />
+ * Properties Sample: application.properties
+ * <pre>
+ * redis.cache.enabled = true
+ * redis.cache.expireSeconds = 100
+ * redis.cache.clusterNodes = 1,2
+ * redis.cache.commandTimeout = 50
+ * redis.cache.someMap.key1 = a
+ * redis.cache.someMap.key2 = b
+ * redis.cache.someList[0] = c
+ * redis.cache.someList[1] = d
+ * </pre>
+ *
+ * Yaml Sample: application.yaml
+ * <pre>
+ * redis:
+ *   cache:
+ *     enabled: true
+ *     expireSeconds: 100
+ *     clusterNodes: 1,2
+ *     commandTimeout: 50
+ *     someMap:
+ *       key1: a
+ *       key2: b
+ *     someList:
+ *     - c
+ *     - d
+ * </pre>
+ *
+ * To make <code>@ConditionalOnProperty</code> work properly, <code>apollo.bootstrap.enabled</code> should be set to true
+ * and <code>redis.cache.enabled</code> should also be set to true. Check 'src/main/resources/application.yml' for more information.
+ *
+ * @author Jason Song(song_s@ctrip.com)
+ */
+@ConditionalOnProperty("redis.cache.enabled")
+@ConfigurationProperties(prefix = "redis.cache")
+@AutoRefresh(AutoRefresh.disabled)
+@Component
+public class AutoRefreshDisabledFiledRedisConfig {
+
+  private static final Logger logger = LoggerFactory.getLogger(AutoRefreshDisabledFiledRedisConfig.class);
+
+  private int expireSeconds;
+  private String clusterNodes;
+  private int commandTimeout;
+
+  private Map<String, String> someMap = Maps.newLinkedHashMap();
+  private List<String> someList = Lists.newLinkedList();
+
+  @PostConstruct
+  private void initialize() {
+    logger.info(
+        "RefreshDisabledFiledRedisConfig initialized - expireSeconds: {}, clusterNodes: {}, commandTimeout: {}, someMap: {}, someList: {}",
+        expireSeconds, clusterNodes, commandTimeout, someMap, someList);
+  }
+
+  /**
+   * 应该起作用
+   * @param expireSeconds
+   */
+  @RefreshField(RefreshField.enabled)
+  public void setExpireSeconds(int expireSeconds) {
+    this.expireSeconds = expireSeconds;
+  }
+
+  @RefreshField(RefreshField.enabled)
+  public void setClusterNodes(String clusterNodes) {
+    this.clusterNodes = clusterNodes;
+  }
+
+  public void setCommandTimeout(int commandTimeout) {
+    this.commandTimeout = commandTimeout;
+  }
+
+  public Map<String, String> getSomeMap() {
+    return someMap;
+  }
+
+  public List<String> getSomeList() {
+    return someList;
+  }
+
+  @Override
+  public String toString() {
+    return String.format(
+        "[RefreshDisabledFiledRedisConfig] expireSeconds: %d, clusterNodes: %s, commandTimeout: %d, someMap: %s, someList: %s",
+            expireSeconds, clusterNodes, commandTimeout, someMap, someList);
+  }
+}

--- a/apollo-demo/src/main/java/com/ctrip/framework/apollo/demo/spring/springBootDemo/autorefreshannotation/AutoRefreshEnabledBean.java
+++ b/apollo-demo/src/main/java/com/ctrip/framework/apollo/demo/spring/springBootDemo/autorefreshannotation/AutoRefreshEnabledBean.java
@@ -1,0 +1,80 @@
+package com.ctrip.framework.apollo.demo.spring.springBootDemo.autorefreshannotation;
+
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.ctrip.framework.apollo.spring.annotation.ApolloJsonValue;
+import com.ctrip.framework.apollo.spring.annotation.AutoRefresh;
+import com.ctrip.framework.apollo.spring.annotation.RefreshField;
+
+/**
+ * @author Jason Song(song_s@ctrip.com)
+ */
+@Component
+@AutoRefresh(AutoRefresh.enabled)
+public class AutoRefreshEnabledBean {
+  private static final Logger logger = LoggerFactory.getLogger(AutoRefreshEnabledBean.class);
+
+  private int timeout;
+  private int batch;
+  private List<JsonBean> jsonBeans;
+
+  /**
+   * ApolloJsonValue annotated on fields example, the default value is specified as empty list - []
+   * <br />
+   * jsonBeanProperty=[{"someString":"hello","someInt":100},{"someString":"world!","someInt":200}]
+   */
+  @ApolloJsonValue("${jsonBeanProperty:[]}")
+  private List<JsonBean> anotherJsonBeans;
+
+  /**
+   * 应该起作用
+   * @param batch
+   */
+  @Value("${batch:100}")
+  @RefreshField(RefreshField.disabled)
+  public void setBatch(int batch) {
+    logger.info("updating batch, old value: {}, new value: {}", this.batch, batch);
+    this.batch = batch;
+  }
+
+  @Value("${timeout:200}")
+  public void setTimeout(int timeout) {
+    logger.info("updating timeout, old value: {}, new value: {}", this.timeout, timeout);
+    this.timeout = timeout;
+  }
+
+  /**
+   * ApolloJsonValue annotated on methods example, the default value is specified as empty list - []
+   * <br />
+   * jsonBeanProperty=[{"someString":"hello","someInt":100},{"someString":"world!","someInt":200}]
+   */
+  @ApolloJsonValue("${jsonBeanProperty:[]}")
+  public void setJsonBeans(List<JsonBean> jsonBeans) {
+    logger.info("updating json beans, old value: {}, new value: {}", this.jsonBeans, jsonBeans);
+    this.jsonBeans = jsonBeans;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("[AutoRefreshEnabledBean] timeout: %d, batch: %d, jsonBeans: %s", timeout, batch, jsonBeans);
+  }
+
+  private static class JsonBean{
+
+    private String someString;
+    private int someInt;
+
+    @Override
+    public String toString() {
+      return "JsonBean{" +
+          "someString='" + someString + '\'' +
+          ", someInt=" + someInt +
+          '}';
+    }
+  }
+}

--- a/apollo-demo/src/main/java/com/ctrip/framework/apollo/demo/spring/springBootDemo/autorefreshannotation/AutoRefreshEnabledFiledRedisConfig.java
+++ b/apollo-demo/src/main/java/com/ctrip/framework/apollo/demo/spring/springBootDemo/autorefreshannotation/AutoRefreshEnabledFiledRedisConfig.java
@@ -1,0 +1,109 @@
+package com.ctrip.framework.apollo.demo.spring.springBootDemo.autorefreshannotation;
+
+import java.util.List;
+import java.util.Map;
+
+import javax.annotation.PostConstruct;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import com.ctrip.framework.apollo.spring.annotation.AutoRefresh;
+import com.ctrip.framework.apollo.spring.annotation.RefreshField;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+
+/**
+ * You may set up data like the following in Apollo:
+ * <br /><br />
+ * Properties Sample: application.properties
+ * <pre>
+ * redis.cache.enabled = true
+ * redis.cache.expireSeconds = 100
+ * redis.cache.clusterNodes = 1,2
+ * redis.cache.commandTimeout = 50
+ * redis.cache.someMap.key1 = a
+ * redis.cache.someMap.key2 = b
+ * redis.cache.someList[0] = c
+ * redis.cache.someList[1] = d
+ * </pre>
+ *
+ * Yaml Sample: application.yaml
+ * <pre>
+ * redis:
+ *   cache:
+ *     enabled: true
+ *     expireSeconds: 100
+ *     clusterNodes: 1,2
+ *     commandTimeout: 50
+ *     someMap:
+ *       key1: a
+ *       key2: b
+ *     someList:
+ *     - c
+ *     - d
+ * </pre>
+ *
+ * To make <code>@ConditionalOnProperty</code> work properly, <code>apollo.bootstrap.enabled</code> should be set to true
+ * and <code>redis.cache.enabled</code> should also be set to true. Check 'src/main/resources/application.yml' for more information.
+ *
+ * @author Jason Song(song_s@ctrip.com)
+ */
+@ConditionalOnProperty("redis.cache.enabled")
+@ConfigurationProperties(prefix = "redis.cache")
+@AutoRefresh(AutoRefresh.enabled)
+@Component
+public class AutoRefreshEnabledFiledRedisConfig {
+
+  private static final Logger logger = LoggerFactory.getLogger(AutoRefreshEnabledFiledRedisConfig.class);
+
+  private int expireSeconds;
+  private String clusterNodes;
+  private int commandTimeout;
+
+  private Map<String, String> someMap = Maps.newLinkedHashMap();
+  private List<String> someList = Lists.newLinkedList();
+
+  @PostConstruct
+  private void initialize() {
+    logger.info(
+        "RefreshEnabledFiledRedisConfig initialized - expireSeconds: {}, clusterNodes: {}, commandTimeout: {}, someMap: {}, someList: {}",
+        expireSeconds, clusterNodes, commandTimeout, someMap, someList);
+  }
+
+  /**
+   * 起作用
+   * @param expireSeconds
+   */
+  @RefreshField(RefreshField.disabled)
+  public void setExpireSeconds(int expireSeconds) {
+    this.expireSeconds = expireSeconds;
+  }
+
+  @RefreshField(RefreshField.disabled)
+  public void setClusterNodes(String clusterNodes) {
+    this.clusterNodes = clusterNodes;
+  }
+
+  public void setCommandTimeout(int commandTimeout) {
+    this.commandTimeout = commandTimeout;
+  }
+
+  public Map<String, String> getSomeMap() {
+    return someMap;
+  }
+
+  public List<String> getSomeList() {
+    return someList;
+  }
+
+  @Override
+  public String toString() {
+    return String.format(
+        "[RefreshEnabledFiledRedisConfig] expireSeconds: %d, clusterNodes: %s, commandTimeout: %d, someMap: %s, someList: %s",
+            expireSeconds, clusterNodes, commandTimeout, someMap, someList);
+  }
+}

--- a/apollo-demo/src/main/java/com/ctrip/framework/apollo/demo/spring/springBootDemo/autorefreshannotation/RefreshDisabledBean.java
+++ b/apollo-demo/src/main/java/com/ctrip/framework/apollo/demo/spring/springBootDemo/autorefreshannotation/RefreshDisabledBean.java
@@ -1,0 +1,79 @@
+package com.ctrip.framework.apollo.demo.spring.springBootDemo.autorefreshannotation;
+
+import com.ctrip.framework.apollo.spring.annotation.ApolloJsonValue;
+import com.ctrip.framework.apollo.spring.annotation.RefreshDisabled;
+import com.ctrip.framework.apollo.spring.annotation.RefreshField;
+
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Jason Song(song_s@ctrip.com)
+ */
+@Component
+@RefreshDisabled
+public class RefreshDisabledBean {
+  private static final Logger logger = LoggerFactory.getLogger(RefreshDisabledBean.class);
+
+  private int timeout;
+  private int batch;
+  private List<JsonBean> jsonBeans;
+
+  /**
+   * ApolloJsonValue annotated on fields example, the default value is specified as empty list - []
+   * <br />
+   * jsonBeanProperty=[{"someString":"hello","someInt":100},{"someString":"world!","someInt":200}]
+   */
+  @ApolloJsonValue("${jsonBeanProperty:[]}")
+  private List<JsonBean> anotherJsonBeans;
+
+  /**
+   * 不应该起作用
+   * @param batch
+   */
+  @Value("${batch:100}")
+  @RefreshField(RefreshField.enabled)
+  public void setBatch(int batch) {
+    logger.info("updating batch, old value: {}, new value: {}", this.batch, batch);
+    this.batch = batch;
+  }
+
+  @Value("${timeout:200}")
+  public void setTimeout(int timeout) {
+    logger.info("updating timeout, old value: {}, new value: {}", this.timeout, timeout);
+    this.timeout = timeout;
+  }
+
+  /**
+   * ApolloJsonValue annotated on methods example, the default value is specified as empty list - []
+   * <br />
+   * jsonBeanProperty=[{"someString":"hello","someInt":100},{"someString":"world!","someInt":200}]
+   */
+  @ApolloJsonValue("${jsonBeanProperty:[]}")
+  public void setJsonBeans(List<JsonBean> jsonBeans) {
+    logger.info("updating json beans, old value: {}, new value: {}", this.jsonBeans, jsonBeans);
+    this.jsonBeans = jsonBeans;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("[RefreshDisabledBean] timeout: %d, batch: %d, jsonBeans: %s", timeout, batch, jsonBeans);
+  }
+
+  private static class JsonBean{
+
+    private String someString;
+    private int someInt;
+
+    @Override
+    public String toString() {
+      return "JsonBean{" +
+          "someString='" + someString + '\'' +
+          ", someInt=" + someInt +
+          '}';
+    }
+  }
+}

--- a/apollo-demo/src/main/java/com/ctrip/framework/apollo/demo/spring/springBootDemo/autorefreshannotation/RefreshDisabledFiledRedisConfig.java
+++ b/apollo-demo/src/main/java/com/ctrip/framework/apollo/demo/spring/springBootDemo/autorefreshannotation/RefreshDisabledFiledRedisConfig.java
@@ -1,0 +1,110 @@
+package com.ctrip.framework.apollo.demo.spring.springBootDemo.autorefreshannotation;
+
+import java.util.List;
+import java.util.Map;
+
+import javax.annotation.PostConstruct;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.ctrip.framework.apollo.spring.annotation.RefreshDisabled;
+import com.ctrip.framework.apollo.spring.annotation.RefreshField;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * You may set up data like the following in Apollo:
+ * <br /><br />
+ * Properties Sample: application.properties
+ * <pre>
+ * redis.cache.enabled = true
+ * redis.cache.expireSeconds = 100
+ * redis.cache.clusterNodes = 1,2
+ * redis.cache.commandTimeout = 50
+ * redis.cache.someMap.key1 = a
+ * redis.cache.someMap.key2 = b
+ * redis.cache.someList[0] = c
+ * redis.cache.someList[1] = d
+ * </pre>
+ *
+ * Yaml Sample: application.yaml
+ * <pre>
+ * redis:
+ *   cache:
+ *     enabled: true
+ *     expireSeconds: 100
+ *     clusterNodes: 1,2
+ *     commandTimeout: 50
+ *     someMap:
+ *       key1: a
+ *       key2: b
+ *     someList:
+ *     - c
+ *     - d
+ * </pre>
+ *
+ * To make <code>@ConditionalOnProperty</code> work properly, <code>apollo.bootstrap.enabled</code> should be set to true
+ * and <code>redis.cache.enabled</code> should also be set to true. Check 'src/main/resources/application.yml' for more information.
+ *
+ * @author Jason Song(song_s@ctrip.com)
+ */
+@ConditionalOnProperty("redis.cache.enabled")
+@ConfigurationProperties(prefix = "redis.cache")
+@RefreshDisabled
+@Component
+public class RefreshDisabledFiledRedisConfig {
+
+  private static final Logger logger = LoggerFactory.getLogger(RefreshDisabledFiledRedisConfig.class);
+
+  private int expireSeconds;
+  private String clusterNodes;
+  private int commandTimeout;
+
+  private Map<String, String> someMap = Maps.newLinkedHashMap();
+  private List<String> someList = Lists.newLinkedList();
+
+  @PostConstruct
+  private void initialize() {
+    logger.info(
+        "RefreshDisabledFiledRedisConfig initialized - expireSeconds: {}, clusterNodes: {}, commandTimeout: {}, someMap: {}, someList: {}",
+        expireSeconds, clusterNodes, commandTimeout, someMap, someList);
+  }
+
+  /**
+   * 不应该起作用
+   * @param expireSeconds
+   */
+  @RefreshField(RefreshField.enabled)
+  public void setExpireSeconds(int expireSeconds) {
+    this.expireSeconds = expireSeconds;
+  }
+
+  @RefreshField(RefreshField.enabled)
+  public void setClusterNodes(String clusterNodes) {
+    this.clusterNodes = clusterNodes;
+  }
+
+  public void setCommandTimeout(int commandTimeout) {
+    this.commandTimeout = commandTimeout;
+  }
+
+  public Map<String, String> getSomeMap() {
+    return someMap;
+  }
+
+  public List<String> getSomeList() {
+    return someList;
+  }
+
+  @Override
+  public String toString() {
+    return String.format(
+        "[RefreshDisabledFiledRedisConfig] expireSeconds: %d, clusterNodes: %s, commandTimeout: %d, someMap: %s, someList: %s",
+            expireSeconds, clusterNodes, commandTimeout, someMap, someList);
+  }
+}

--- a/apollo-demo/src/main/java/com/ctrip/framework/apollo/demo/spring/springBootDemo/autorefreshannotation/RefreshEnabledBean.java
+++ b/apollo-demo/src/main/java/com/ctrip/framework/apollo/demo/spring/springBootDemo/autorefreshannotation/RefreshEnabledBean.java
@@ -1,0 +1,81 @@
+package com.ctrip.framework.apollo.demo.spring.springBootDemo.autorefreshannotation;
+
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.ctrip.framework.apollo.spring.annotation.ApolloJsonValue;
+import com.ctrip.framework.apollo.spring.annotation.RefreshEnabled;
+import com.ctrip.framework.apollo.spring.annotation.RefreshField;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Jason Song(song_s@ctrip.com)
+ */
+@Component
+@RefreshEnabled
+public class RefreshEnabledBean {
+  private static final Logger logger = LoggerFactory.getLogger(RefreshEnabledBean.class);
+
+  private int timeout;
+  private int batch;
+  private List<JsonBean> jsonBeans;
+
+  /**
+   * ApolloJsonValue annotated on fields example, the default value is specified as empty list - []
+   * <br />
+   * jsonBeanProperty=[{"someString":"hello","someInt":100},{"someString":"world!","someInt":200}]
+   */
+  @ApolloJsonValue("${jsonBeanProperty:[]}")
+  private List<JsonBean> anotherJsonBeans;
+
+  /**
+   * 不应该起作用
+   * @param batch
+   */
+  @Value("${batch:100}")
+  @RefreshField(RefreshField.disabled)
+  public void setBatch(int batch) {
+    logger.info("updating batch, old value: {}, new value: {}", this.batch, batch);
+    this.batch = batch;
+  }
+
+  @Value("${timeout:200}")
+  public void setTimeout(int timeout) {
+    logger.info("updating timeout, old value: {}, new value: {}", this.timeout, timeout);
+    this.timeout = timeout;
+  }
+
+  /**
+   * ApolloJsonValue annotated on methods example, the default value is specified as empty list - []
+   * <br />
+   * jsonBeanProperty=[{"someString":"hello","someInt":100},{"someString":"world!","someInt":200}]
+   */
+  @ApolloJsonValue("${jsonBeanProperty:[]}")
+  public void setJsonBeans(List<JsonBean> jsonBeans) {
+    logger.info("updating json beans, old value: {}, new value: {}", this.jsonBeans, jsonBeans);
+    this.jsonBeans = jsonBeans;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("[RefreshEnabledBean] timeout: %d, batch: %d, jsonBeans: %s", timeout, batch, jsonBeans);
+  }
+
+  private static class JsonBean{
+
+    private String someString;
+    private int someInt;
+
+    @Override
+    public String toString() {
+      return "JsonBean{" +
+          "someString='" + someString + '\'' +
+          ", someInt=" + someInt +
+          '}';
+    }
+  }
+}

--- a/apollo-demo/src/main/java/com/ctrip/framework/apollo/demo/spring/springBootDemo/autorefreshannotation/RefreshEnabledFiledRedisConfig.java
+++ b/apollo-demo/src/main/java/com/ctrip/framework/apollo/demo/spring/springBootDemo/autorefreshannotation/RefreshEnabledFiledRedisConfig.java
@@ -1,0 +1,110 @@
+package com.ctrip.framework.apollo.demo.spring.springBootDemo.autorefreshannotation;
+
+import java.util.List;
+import java.util.Map;
+
+import javax.annotation.PostConstruct;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.ctrip.framework.apollo.spring.annotation.RefreshEnabled;
+import com.ctrip.framework.apollo.spring.annotation.RefreshField;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * You may set up data like the following in Apollo:
+ * <br /><br />
+ * Properties Sample: application.properties
+ * <pre>
+ * redis.cache.enabled = true
+ * redis.cache.expireSeconds = 100
+ * redis.cache.clusterNodes = 1,2
+ * redis.cache.commandTimeout = 50
+ * redis.cache.someMap.key1 = a
+ * redis.cache.someMap.key2 = b
+ * redis.cache.someList[0] = c
+ * redis.cache.someList[1] = d
+ * </pre>
+ *
+ * Yaml Sample: application.yaml
+ * <pre>
+ * redis:
+ *   cache:
+ *     enabled: true
+ *     expireSeconds: 100
+ *     clusterNodes: 1,2
+ *     commandTimeout: 50
+ *     someMap:
+ *       key1: a
+ *       key2: b
+ *     someList:
+ *     - c
+ *     - d
+ * </pre>
+ *
+ * To make <code>@ConditionalOnProperty</code> work properly, <code>apollo.bootstrap.enabled</code> should be set to true
+ * and <code>redis.cache.enabled</code> should also be set to true. Check 'src/main/resources/application.yml' for more information.
+ *
+ * @author Jason Song(song_s@ctrip.com)
+ */
+@ConditionalOnProperty("redis.cache.enabled")
+@ConfigurationProperties(prefix = "redis.cache")
+@RefreshEnabled
+@Component
+public class RefreshEnabledFiledRedisConfig {
+
+  private static final Logger logger = LoggerFactory.getLogger(RefreshEnabledFiledRedisConfig.class);
+
+  private int expireSeconds;
+  private String clusterNodes;
+  private int commandTimeout;
+
+  private Map<String, String> someMap = Maps.newLinkedHashMap();
+  private List<String> someList = Lists.newLinkedList();
+
+  @PostConstruct
+  private void initialize() {
+    logger.info(
+        "RefreshEnabledFiledRedisConfig initialized - expireSeconds: {}, clusterNodes: {}, commandTimeout: {}, someMap: {}, someList: {}",
+        expireSeconds, clusterNodes, commandTimeout, someMap, someList);
+  }
+
+  /**
+   * 不起作用
+   * @param expireSeconds
+   */
+  @RefreshField(RefreshField.disabled)
+  public void setExpireSeconds(int expireSeconds) {
+    this.expireSeconds = expireSeconds;
+  }
+
+  @RefreshField(RefreshField.disabled)
+  public void setClusterNodes(String clusterNodes) {
+    this.clusterNodes = clusterNodes;
+  }
+
+  public void setCommandTimeout(int commandTimeout) {
+    this.commandTimeout = commandTimeout;
+  }
+
+  public Map<String, String> getSomeMap() {
+    return someMap;
+  }
+
+  public List<String> getSomeList() {
+    return someList;
+  }
+
+  @Override
+  public String toString() {
+    return String.format(
+        "[RefreshEnabledFiledRedisConfig] expireSeconds: %d, clusterNodes: %s, commandTimeout: %d, someMap: %s, someList: %s",
+            expireSeconds, clusterNodes, commandTimeout, someMap, someList);
+  }
+}

--- a/apollo-demo/src/main/java/com/ctrip/framework/apollo/demo/spring/springBootDemo/autorefreshannotation/RefreshEnabledRedisConfig.java
+++ b/apollo-demo/src/main/java/com/ctrip/framework/apollo/demo/spring/springBootDemo/autorefreshannotation/RefreshEnabledRedisConfig.java
@@ -1,0 +1,103 @@
+package com.ctrip.framework.apollo.demo.spring.springBootDemo.autorefreshannotation;
+
+import java.util.List;
+import java.util.Map;
+
+import javax.annotation.PostConstruct;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.ctrip.framework.apollo.spring.annotation.RefreshEnabled;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * You may set up data like the following in Apollo:
+ * <br /><br />
+ * Properties Sample: application.properties
+ * <pre>
+ * redis.cache.enabled = true
+ * redis.cache.expireSeconds = 100
+ * redis.cache.clusterNodes = 1,2
+ * redis.cache.commandTimeout = 50
+ * redis.cache.someMap.key1 = a
+ * redis.cache.someMap.key2 = b
+ * redis.cache.someList[0] = c
+ * redis.cache.someList[1] = d
+ * </pre>
+ *
+ * Yaml Sample: application.yaml
+ * <pre>
+ * redis:
+ *   cache:
+ *     enabled: true
+ *     expireSeconds: 100
+ *     clusterNodes: 1,2
+ *     commandTimeout: 50
+ *     someMap:
+ *       key1: a
+ *       key2: b
+ *     someList:
+ *     - c
+ *     - d
+ * </pre>
+ *
+ * To make <code>@ConditionalOnProperty</code> work properly, <code>apollo.bootstrap.enabled</code> should be set to true
+ * and <code>redis.cache.enabled</code> should also be set to true. Check 'src/main/resources/application.yml' for more information.
+ *
+ * @author Jason Song(song_s@ctrip.com)
+ */
+@ConditionalOnProperty("redis.cache.enabled")
+@ConfigurationProperties(prefix = "redis.cache")
+@RefreshEnabled
+@Component
+public class RefreshEnabledRedisConfig {
+
+  private static final Logger logger = LoggerFactory.getLogger(RefreshEnabledRedisConfig.class);
+
+  private int expireSeconds;
+  private String clusterNodes;
+  private int commandTimeout;
+
+  private Map<String, String> someMap = Maps.newLinkedHashMap();
+  private List<String> someList = Lists.newLinkedList();
+
+  @PostConstruct
+  private void initialize() {
+    logger.info(
+        "RefreshEnabledRedisConfig initialized - expireSeconds: {}, clusterNodes: {}, commandTimeout: {}, someMap: {}, someList: {}",
+        expireSeconds, clusterNodes, commandTimeout, someMap, someList);
+  }
+
+  public void setExpireSeconds(int expireSeconds) {
+    this.expireSeconds = expireSeconds;
+  }
+
+  public void setClusterNodes(String clusterNodes) {
+    this.clusterNodes = clusterNodes;
+  }
+
+  public void setCommandTimeout(int commandTimeout) {
+    this.commandTimeout = commandTimeout;
+  }
+
+  public Map<String, String> getSomeMap() {
+    return someMap;
+  }
+
+  public List<String> getSomeList() {
+    return someList;
+  }
+
+  @Override
+  public String toString() {
+    return String.format(
+        "[RefreshEnabledRedisConfig] expireSeconds: %d, clusterNodes: %s, commandTimeout: %d, someMap: %s, someList: %s",
+            expireSeconds, clusterNodes, commandTimeout, someMap, someList);
+  }
+}

--- a/apollo-demo/src/main/java/com/ctrip/framework/apollo/demo/spring/springBootDemo/autorefreshannotation/SpringBootRefreshSampleApplication.java
+++ b/apollo-demo/src/main/java/com/ctrip/framework/apollo/demo/spring/springBootDemo/autorefreshannotation/SpringBootRefreshSampleApplication.java
@@ -1,0 +1,78 @@
+package com.ctrip.framework.apollo.demo.spring.springBootDemo.autorefreshannotation;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+import com.ctrip.framework.apollo.spring.boot.RefreshConfigurationProperties;
+import com.google.common.base.Charsets;
+import com.google.common.base.Strings;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.ApplicationContext;
+
+/**
+ * @author Jason Song(song_s@ctrip.com)
+ */
+@SpringBootApplication
+public class SpringBootRefreshSampleApplication {
+
+  public static void main(String[] args) throws IOException {
+    ApplicationContext context = new SpringApplicationBuilder(SpringBootRefreshSampleApplication.class).run(args);
+    RefreshEnabledRedisConfig refreshEnabledRedisConfig = context.getBean(RefreshEnabledRedisConfig.class);
+    RefreshEnabledFiledRedisConfig refreshEnabledFiledRedisConfig = context.getBean(RefreshEnabledFiledRedisConfig.class);
+    RefreshDisabledFiledRedisConfig refreshDisabledFiledRedisConfig = context.getBean(RefreshDisabledFiledRedisConfig.class);
+    RefreshDisabledBean refreshDisabledBean = context.getBean(RefreshDisabledBean.class);
+    RefreshEnabledBean refreshEnabledBean = context.getBean(RefreshEnabledBean.class);
+    
+    AutoRefreshEnabledFiledRedisConfig autorefreshEnabledFiledRedisConfig = context.getBean(AutoRefreshEnabledFiledRedisConfig.class);
+    AutoRefreshDisabledFiledRedisConfig autorefreshDisabledFiledRedisConfig = context.getBean(AutoRefreshDisabledFiledRedisConfig.class);
+    AutoRefreshDisabledBean autorefreshDisabledBean = context.getBean(AutoRefreshDisabledBean.class);
+    AutoRefreshEnabledBean autorefreshEnabledBean = context.getBean(AutoRefreshEnabledBean.class);
+    
+    RefreshConfigurationProperties refreshConfigurationProperties = context.getBean(RefreshConfigurationProperties.class);
+System.out.println(refreshConfigurationProperties);
+    System.out.println("SpringBootSampleApplication Demo. Input any key except quit to print the values. Input quit to exit.");
+    while (true) {
+      System.out.print("> ");
+      String input = new BufferedReader(new InputStreamReader(System.in, Charsets.UTF_8)).readLine();
+      if (!Strings.isNullOrEmpty(input) && input.trim().equalsIgnoreCase("quit")) {
+        System.exit(0);
+      }
+
+      switch (input) {
+        case "1":
+          System.out.println(refreshEnabledRedisConfig);
+          break;
+        case "2":
+          System.out.println(refreshEnabledFiledRedisConfig);
+          break;
+        case "3":
+          System.out.println(refreshDisabledFiledRedisConfig);
+          break;
+        case "4":
+          System.out.println(refreshDisabledBean);
+          break;
+        case "5":
+          System.out.println(refreshEnabledBean);
+          break;
+        case "6":
+          System.out.println(autorefreshEnabledFiledRedisConfig);
+          break;
+        case "7":
+          System.out.println(autorefreshDisabledFiledRedisConfig);
+          break;
+        case "8":
+          System.out.println(autorefreshDisabledBean);
+          break;
+        case "9":
+          System.out.println(autorefreshEnabledBean);
+          break;
+        default:
+          break;
+      }
+    }
+  }
+  
+}

--- a/apollo-demo/src/main/resources/META-INF/app.properties
+++ b/apollo-demo/src/main/resources/META-INF/app.properties
@@ -1,3 +1,3 @@
 # test
 app.id=100004458
-apollo.meta=http://localhost:8080
+#apollo.meta=http://localhost:8080

--- a/apollo-demo/src/main/resources/META-INF/app.properties
+++ b/apollo-demo/src/main/resources/META-INF/app.properties
@@ -1,2 +1,3 @@
 # test
 app.id=100004458
+apollo.meta=http://localhost:8080

--- a/apollo-demo/src/main/resources/application.yml
+++ b/apollo-demo/src/main/resources/application.yml
@@ -4,3 +4,6 @@ apollo:
     # will inject 'application' and 'TEST1.apollo' namespaces in bootstrap phase
     namespaces: application,TEST1.apollo,application.yaml
 apollo.autoRefreshConfigurationProperties: com.ctrip.framework.apollo.demo.spring.springBootDemo.autorefresh
+apollo.app.id: 100004458
+apollo.meta: http://localhost:8080
+apollo.env: dev

--- a/apollo-demo/src/main/resources/application.yml
+++ b/apollo-demo/src/main/resources/application.yml
@@ -5,5 +5,4 @@ apollo:
     namespaces: application,TEST1.apollo,application.yaml
 apollo.autoRefreshConfigurationProperties: com.ctrip.framework.apollo.demo.spring.springBootDemo.autorefresh
 apollo.app.id: 100004458
-apollo.meta: http://localhost:8080
 apollo.env: dev

--- a/apollo-demo/src/main/resources/application.yml
+++ b/apollo-demo/src/main/resources/application.yml
@@ -3,3 +3,4 @@ apollo:
     enabled: true
     # will inject 'application' and 'TEST1.apollo' namespaces in bootstrap phase
     namespaces: application,TEST1.apollo,application.yaml
+apollo.autoRefreshConfigurationProperties: com.ctrip.framework.apollo.demo.spring.springBootDemo.autorefresh

--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,7 @@
 		<module>apollo-demo</module>
 		<module>apollo-mockserver</module>
 		<module>apollo-openapi</module>
+        <module>apollo-client-extension</module>
 	</modules>
 
 	<dependencyManagement>


### PR DESCRIPTION
## 实现功能：  
通过注解对配置类的更新进行控制
## 功能目的：  
在启用自动更新的情况下，对配置类值自动更新，提供更细粒度的控制

## 功能描述
#### 对应如下配置项添加 apollo 前缀支持，可解决配置key冲突问题
1. 添加 apollo.app.id 配置项支持，同时保留 app.id
2. 添加 apollo.idc 配置项支持，同时保留 idc
3. 添加 apollo.env 配置项支持，同时保留 env

#### 对部分SPI接口继承 Ordered 接口，使其可以让用户自定义这部分接口，并且 order 值越小优先级预高，通过spi机制加载时取其排序后的第一个
#### 实现对配置类属性自动更新，更细粒度的控制，通过 @RefreshDisabled 可以实现对某一个类禁用自动更新，通过@AutoRefresh + @RefreshField 可以实现对某一个类全部禁用[启用]，但对其中某个属性启用[禁用]
#### 实现springboot @Configurationproperties 配置类的自动更新功能
    1. 通过 注解 @RefreshEnabled 对整个类启用， @AutoRefresh + @RefreshField 可以实现对某一个类全部禁用[启用]，但对其中某个属性启用[禁用]
    2. 通过 apollo.autoRefreshConfigurationProperties 可以启用，值可以是： packageNames、qualifiedName、true、false, 默认值为false，优先级低于注解
    3. @RefreshEnabled、  @RefreshDisabled 优先级最高，@RefreshField优先级高于 @AutoRefresh
#### 调整 没有启用自动更新，则不要更新内存

#### 针对springboot @Configurationproperties 更新, 作为扩展方式提供，分为springboo1.x 和springboot 2.x 两个版本，
     apollo-client-springboot-extension -> springboo1.x  
     apollo-client-springboot2-extension -> springboo2.x

