### PR TITLE
client's SPI for customizing spring processors' loading

### DIFF
--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/annotation/ApolloConfigRegistrar.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/annotation/ApolloConfigRegistrar.java
@@ -1,47 +1,20 @@
 package com.ctrip.framework.apollo.spring.annotation;
 
-import com.ctrip.framework.apollo.spring.property.SpringValueDefinitionProcessor;
-import java.util.HashMap;
-import java.util.Map;
+import com.ctrip.framework.apollo.spring.spi.ApolloConfigRegistrarHelper;
+import com.ctrip.framework.foundation.internals.ServiceBootstrap;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
-import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
-import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.core.type.AnnotationMetadata;
-
-import com.ctrip.framework.apollo.spring.config.PropertySourcesProcessor;
-import com.ctrip.framework.apollo.spring.util.BeanRegistrationUtil;
-import com.google.common.collect.Lists;
 
 /**
  * @author Jason Song(song_s@ctrip.com)
  */
 public class ApolloConfigRegistrar implements ImportBeanDefinitionRegistrar {
+
+  private ApolloConfigRegistrarHelper helper = ServiceBootstrap.loadPrimary(ApolloConfigRegistrarHelper.class);
+
   @Override
   public void registerBeanDefinitions(AnnotationMetadata importingClassMetadata, BeanDefinitionRegistry registry) {
-    AnnotationAttributes attributes = AnnotationAttributes.fromMap(importingClassMetadata
-        .getAnnotationAttributes(EnableApolloConfig.class.getName()));
-    String[] namespaces = attributes.getStringArray("value");
-    int order = attributes.getNumber("order");
-    PropertySourcesProcessor.addNamespaces(Lists.newArrayList(namespaces), order);
-
-    Map<String, Object> propertySourcesPlaceholderPropertyValues = new HashMap<>();
-    // to make sure the default PropertySourcesPlaceholderConfigurer's priority is higher than PropertyPlaceholderConfigurer
-    propertySourcesPlaceholderPropertyValues.put("order", 0);
-
-    BeanRegistrationUtil.registerBeanDefinitionIfNotExists(registry, PropertySourcesPlaceholderConfigurer.class.getName(),
-        PropertySourcesPlaceholderConfigurer.class, propertySourcesPlaceholderPropertyValues);
-
-    BeanRegistrationUtil.registerBeanDefinitionIfNotExists(registry, PropertySourcesProcessor.class.getName(),
-        PropertySourcesProcessor.class);
-
-    BeanRegistrationUtil.registerBeanDefinitionIfNotExists(registry, ApolloAnnotationProcessor.class.getName(),
-        ApolloAnnotationProcessor.class);
-
-    BeanRegistrationUtil.registerBeanDefinitionIfNotExists(registry, SpringValueProcessor.class.getName(), SpringValueProcessor.class);
-    BeanRegistrationUtil.registerBeanDefinitionIfNotExists(registry, SpringValueDefinitionProcessor.class.getName(), SpringValueDefinitionProcessor.class);
-
-    BeanRegistrationUtil.registerBeanDefinitionIfNotExists(registry, ApolloJsonValueProcessor.class.getName(),
-            ApolloJsonValueProcessor.class);
+    helper.registerBeanDefinitions(importingClassMetadata, registry);
   }
 }

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/config/ConfigPropertySourcesProcessor.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/config/ConfigPropertySourcesProcessor.java
@@ -1,17 +1,10 @@
 package com.ctrip.framework.apollo.spring.config;
 
-import com.ctrip.framework.apollo.spring.annotation.SpringValueProcessor;
-import com.ctrip.framework.apollo.spring.property.SpringValueDefinitionProcessor;
-import com.ctrip.framework.apollo.spring.annotation.ApolloJsonValueProcessor;
-import java.util.HashMap;
-import java.util.Map;
+import com.ctrip.framework.apollo.spring.spi.ConfigPropertySourcesProcessorHelper;
+import com.ctrip.framework.foundation.internals.ServiceBootstrap;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProcessor;
-import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
-
-import com.ctrip.framework.apollo.spring.annotation.ApolloAnnotationProcessor;
-import com.ctrip.framework.apollo.spring.util.BeanRegistrationUtil;
 
 /**
  * Apollo Property Sources processor for Spring XML Based Application
@@ -21,31 +14,10 @@ import com.ctrip.framework.apollo.spring.util.BeanRegistrationUtil;
 public class ConfigPropertySourcesProcessor extends PropertySourcesProcessor
     implements BeanDefinitionRegistryPostProcessor {
 
+  private ConfigPropertySourcesProcessorHelper helper = ServiceBootstrap.loadPrimary(ConfigPropertySourcesProcessorHelper.class);
+
   @Override
   public void postProcessBeanDefinitionRegistry(BeanDefinitionRegistry registry) throws BeansException {
-    Map<String, Object> propertySourcesPlaceholderPropertyValues = new HashMap<>();
-    // to make sure the default PropertySourcesPlaceholderConfigurer's priority is higher than PropertyPlaceholderConfigurer
-    propertySourcesPlaceholderPropertyValues.put("order", 0);
-
-    BeanRegistrationUtil.registerBeanDefinitionIfNotExists(registry, PropertySourcesPlaceholderConfigurer.class.getName(),
-        PropertySourcesPlaceholderConfigurer.class, propertySourcesPlaceholderPropertyValues);
-    BeanRegistrationUtil.registerBeanDefinitionIfNotExists(registry, ApolloAnnotationProcessor.class.getName(),
-        ApolloAnnotationProcessor.class);
-    BeanRegistrationUtil.registerBeanDefinitionIfNotExists(registry, SpringValueProcessor.class.getName(), SpringValueProcessor.class);
-    BeanRegistrationUtil.registerBeanDefinitionIfNotExists(registry, ApolloJsonValueProcessor.class.getName(),
-        ApolloJsonValueProcessor.class);
-
-    processSpringValueDefinition(registry);
-  }
-
-  /**
-   * For Spring 3.x versions, the BeanDefinitionRegistryPostProcessor would not be
-   * instantiated if it is added in postProcessBeanDefinitionRegistry phase, so we have to manually
-   * call the postProcessBeanDefinitionRegistry method of SpringValueDefinitionProcessor here...
-   */
-  private void processSpringValueDefinition(BeanDefinitionRegistry registry) {
-    SpringValueDefinitionProcessor springValueDefinitionProcessor = new SpringValueDefinitionProcessor();
-
-    springValueDefinitionProcessor.postProcessBeanDefinitionRegistry(registry);
+    helper.postProcessBeanDefinitionRegistry(registry);
   }
 }

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/spi/ApolloConfigRegistrarHelper.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/spi/ApolloConfigRegistrarHelper.java
@@ -1,0 +1,10 @@
+package com.ctrip.framework.apollo.spring.spi;
+
+import com.ctrip.framework.apollo.core.spi.Ordered;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.core.type.AnnotationMetadata;
+
+public interface ApolloConfigRegistrarHelper extends Ordered {
+
+  void registerBeanDefinitions(AnnotationMetadata importingClassMetadata, BeanDefinitionRegistry registry);
+}

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/spi/ConfigPropertySourcesProcessorHelper.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/spi/ConfigPropertySourcesProcessorHelper.java
@@ -1,0 +1,10 @@
+package com.ctrip.framework.apollo.spring.spi;
+
+import com.ctrip.framework.apollo.core.spi.Ordered;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+
+public interface ConfigPropertySourcesProcessorHelper extends Ordered {
+
+  void postProcessBeanDefinitionRegistry(BeanDefinitionRegistry registry) throws BeansException;
+}

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/spi/DefaultApolloConfigRegistrarHelper.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/spi/DefaultApolloConfigRegistrarHelper.java
@@ -1,0 +1,51 @@
+package com.ctrip.framework.apollo.spring.spi;
+
+import com.ctrip.framework.apollo.core.spi.Ordered;
+import com.ctrip.framework.apollo.spring.annotation.ApolloAnnotationProcessor;
+import com.ctrip.framework.apollo.spring.annotation.ApolloJsonValueProcessor;
+import com.ctrip.framework.apollo.spring.annotation.EnableApolloConfig;
+import com.ctrip.framework.apollo.spring.annotation.SpringValueProcessor;
+import com.ctrip.framework.apollo.spring.config.PropertySourcesProcessor;
+import com.ctrip.framework.apollo.spring.property.SpringValueDefinitionProcessor;
+import com.ctrip.framework.apollo.spring.util.BeanRegistrationUtil;
+import com.google.common.collect.Lists;
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
+import org.springframework.core.annotation.AnnotationAttributes;
+import org.springframework.core.type.AnnotationMetadata;
+
+public class DefaultApolloConfigRegistrarHelper implements ApolloConfigRegistrarHelper {
+
+  @Override
+  public void registerBeanDefinitions(AnnotationMetadata importingClassMetadata, BeanDefinitionRegistry registry) {
+    AnnotationAttributes attributes = AnnotationAttributes
+        .fromMap(importingClassMetadata.getAnnotationAttributes(EnableApolloConfig.class.getName()));
+    String[] namespaces = attributes.getStringArray("value");
+    int order = attributes.getNumber("order");
+    PropertySourcesProcessor.addNamespaces(Lists.newArrayList(namespaces), order);
+
+    Map<String, Object> propertySourcesPlaceholderPropertyValues = new HashMap<>();
+    // to make sure the default PropertySourcesPlaceholderConfigurer's priority is higher than PropertyPlaceholderConfigurer
+    propertySourcesPlaceholderPropertyValues.put("order", 0);
+
+    BeanRegistrationUtil.registerBeanDefinitionIfNotExists(registry, PropertySourcesPlaceholderConfigurer.class.getName(),
+        PropertySourcesPlaceholderConfigurer.class, propertySourcesPlaceholderPropertyValues);
+    BeanRegistrationUtil.registerBeanDefinitionIfNotExists(registry, PropertySourcesProcessor.class.getName(),
+        PropertySourcesProcessor.class);
+    BeanRegistrationUtil.registerBeanDefinitionIfNotExists(registry, ApolloAnnotationProcessor.class.getName(),
+        ApolloAnnotationProcessor.class);
+    BeanRegistrationUtil.registerBeanDefinitionIfNotExists(registry, SpringValueProcessor.class.getName(),
+        SpringValueProcessor.class);
+    BeanRegistrationUtil.registerBeanDefinitionIfNotExists(registry, SpringValueDefinitionProcessor.class.getName(),
+        SpringValueDefinitionProcessor.class);
+    BeanRegistrationUtil.registerBeanDefinitionIfNotExists(registry, ApolloJsonValueProcessor.class.getName(),
+        ApolloJsonValueProcessor.class);
+  }
+
+  @Override
+  public int getOrder() {
+    return Ordered.LOWEST_PRECEDENCE;
+  }
+}

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/spi/DefaultConfigPropertySourcesProcessorHelper.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/spi/DefaultConfigPropertySourcesProcessorHelper.java
@@ -1,0 +1,50 @@
+package com.ctrip.framework.apollo.spring.spi;
+
+import com.ctrip.framework.apollo.core.spi.Ordered;
+import com.ctrip.framework.apollo.spring.annotation.ApolloAnnotationProcessor;
+import com.ctrip.framework.apollo.spring.annotation.ApolloJsonValueProcessor;
+import com.ctrip.framework.apollo.spring.annotation.SpringValueProcessor;
+import com.ctrip.framework.apollo.spring.property.SpringValueDefinitionProcessor;
+import com.ctrip.framework.apollo.spring.util.BeanRegistrationUtil;
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
+
+public class DefaultConfigPropertySourcesProcessorHelper implements ConfigPropertySourcesProcessorHelper {
+
+  @Override
+  public void postProcessBeanDefinitionRegistry(BeanDefinitionRegistry registry) throws BeansException {
+    Map<String, Object> propertySourcesPlaceholderPropertyValues = new HashMap<>();
+    // to make sure the default PropertySourcesPlaceholderConfigurer's priority is higher than PropertyPlaceholderConfigurer
+    propertySourcesPlaceholderPropertyValues.put("order", 0);
+
+    BeanRegistrationUtil.registerBeanDefinitionIfNotExists(registry, PropertySourcesPlaceholderConfigurer.class.getName(),
+        PropertySourcesPlaceholderConfigurer.class, propertySourcesPlaceholderPropertyValues);
+    BeanRegistrationUtil.registerBeanDefinitionIfNotExists(registry, ApolloAnnotationProcessor.class.getName(),
+        ApolloAnnotationProcessor.class);
+    BeanRegistrationUtil.registerBeanDefinitionIfNotExists(registry, SpringValueProcessor.class.getName(),
+        SpringValueProcessor.class);
+    BeanRegistrationUtil.registerBeanDefinitionIfNotExists(registry, ApolloJsonValueProcessor.class.getName(),
+        ApolloJsonValueProcessor.class);
+
+    processSpringValueDefinition(registry);
+  }
+
+  /**
+   * For Spring 3.x versions, the BeanDefinitionRegistryPostProcessor would not be instantiated if
+   * it is added in postProcessBeanDefinitionRegistry phase, so we have to manually call the
+   * postProcessBeanDefinitionRegistry method of SpringValueDefinitionProcessor here...
+   */
+  private void processSpringValueDefinition(BeanDefinitionRegistry registry) {
+    SpringValueDefinitionProcessor springValueDefinitionProcessor = new SpringValueDefinitionProcessor();
+
+    springValueDefinitionProcessor.postProcessBeanDefinitionRegistry(registry);
+  }
+
+  @Override
+  public int getOrder() {
+    return Ordered.LOWEST_PRECEDENCE;
+  }
+}

--- a/apollo-client/src/main/resources/META-INF/services/com.ctrip.framework.apollo.spring.spi.ApolloConfigRegistrarHelper
+++ b/apollo-client/src/main/resources/META-INF/services/com.ctrip.framework.apollo.spring.spi.ApolloConfigRegistrarHelper
@@ -1,0 +1,1 @@
+com.ctrip.framework.apollo.spring.spi.DefaultApolloConfigRegistrarHelper

--- a/apollo-client/src/main/resources/META-INF/services/com.ctrip.framework.apollo.spring.spi.ConfigPropertySourcesProcessorHelper
+++ b/apollo-client/src/main/resources/META-INF/services/com.ctrip.framework.apollo.spring.spi.ConfigPropertySourcesProcessorHelper
@@ -1,0 +1,1 @@
+com.ctrip.framework.apollo.spring.spi.DefaultConfigPropertySourcesProcessorHelper

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/spring/spi/ApolloConfigRegistrarHelperTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/spring/spi/ApolloConfigRegistrarHelperTest.java
@@ -1,0 +1,22 @@
+package com.ctrip.framework.apollo.spring.spi;
+
+import static org.springframework.test.util.AssertionErrors.assertEquals;
+
+import com.ctrip.framework.apollo.spring.annotation.ApolloConfigRegistrar;
+import java.lang.reflect.Field;
+import org.junit.Test;
+import org.springframework.util.ReflectionUtils;
+
+public class ApolloConfigRegistrarHelperTest {
+
+  @Test
+  public void testHelperLoadingOrder() {
+    ApolloConfigRegistrar apolloConfigRegistrar = new ApolloConfigRegistrar();
+
+    Field field = ReflectionUtils.findField(ApolloConfigRegistrar.class, "helper");
+    ReflectionUtils.makeAccessible(field);
+    Object helper = ReflectionUtils.getField(field, apolloConfigRegistrar);
+
+    assertEquals("helper is not TestRegistrarHelper instance", TestRegistrarHelper.class, helper.getClass());
+  }
+}

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/spring/spi/ConfigPropertySourcesProcessorHelperTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/spring/spi/ConfigPropertySourcesProcessorHelperTest.java
@@ -1,0 +1,22 @@
+package com.ctrip.framework.apollo.spring.spi;
+
+import static org.springframework.test.util.AssertionErrors.assertEquals;
+
+import com.ctrip.framework.apollo.spring.config.ConfigPropertySourcesProcessor;
+import java.lang.reflect.Field;
+import org.junit.Test;
+import org.springframework.util.ReflectionUtils;
+
+public class ConfigPropertySourcesProcessorHelperTest {
+
+  @Test
+  public void testHelperLoadingOrder() {
+    ConfigPropertySourcesProcessor processor = new ConfigPropertySourcesProcessor();
+
+    Field field = ReflectionUtils.findField(ConfigPropertySourcesProcessor.class, "helper");
+    ReflectionUtils.makeAccessible(field);
+    Object helper = ReflectionUtils.getField(field, processor);
+
+    assertEquals("helper is not TestProcessorHelper instance", TestProcessorHelper.class, helper.getClass());
+  }
+}

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/spring/spi/TestProcessorHelper.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/spring/spi/TestProcessorHelper.java
@@ -1,0 +1,18 @@
+package com.ctrip.framework.apollo.spring.spi;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+
+public class TestProcessorHelper extends DefaultConfigPropertySourcesProcessorHelper {
+
+  @Override
+  public void postProcessBeanDefinitionRegistry(BeanDefinitionRegistry registry)
+      throws BeansException {
+    super.postProcessBeanDefinitionRegistry(registry);
+  }
+
+  @Override
+  public int getOrder() {
+    return 0;
+  }
+}

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/spring/spi/TestRegistrarHelper.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/spring/spi/TestRegistrarHelper.java
@@ -1,0 +1,18 @@
+package com.ctrip.framework.apollo.spring.spi;
+
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.core.type.AnnotationMetadata;
+
+public class TestRegistrarHelper extends DefaultApolloConfigRegistrarHelper {
+
+  @Override
+  public void registerBeanDefinitions(AnnotationMetadata importingClassMetadata,
+      BeanDefinitionRegistry registry) {
+    super.registerBeanDefinitions(importingClassMetadata, registry);
+  }
+
+  @Override
+  public int getOrder() {
+    return 0;
+  }
+}

--- a/apollo-client/src/test/resources/META-INF/services/com.ctrip.framework.apollo.spring.spi.ApolloConfigRegistrarHelper
+++ b/apollo-client/src/test/resources/META-INF/services/com.ctrip.framework.apollo.spring.spi.ApolloConfigRegistrarHelper
@@ -1,0 +1,1 @@
+com.ctrip.framework.apollo.spring.spi.TestRegistrarHelper

--- a/apollo-client/src/test/resources/META-INF/services/com.ctrip.framework.apollo.spring.spi.ConfigPropertySourcesProcessorHelper
+++ b/apollo-client/src/test/resources/META-INF/services/com.ctrip.framework.apollo.spring.spi.ConfigPropertySourcesProcessorHelper
@@ -1,0 +1,1 @@
+com.ctrip.framework.apollo.spring.spi.TestProcessorHelper

--- a/apollo-core/src/main/java/com/ctrip/framework/foundation/internals/ServiceBootstrap.java
+++ b/apollo-core/src/main/java/com/ctrip/framework/foundation/internals/ServiceBootstrap.java
@@ -1,6 +1,11 @@
 package com.ctrip.framework.foundation.internals;
 
+import com.ctrip.framework.apollo.core.spi.Ordered;
+import com.google.common.collect.Lists;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.Iterator;
+import java.util.List;
 import java.util.ServiceLoader;
 
 public class ServiceBootstrap {
@@ -18,5 +23,32 @@ public class ServiceBootstrap {
     ServiceLoader<S> loader = ServiceLoader.load(clazz);
 
     return loader.iterator();
+  }
+
+  public static <S extends Ordered> List<S> loadAllOrdered(Class<S> clazz) {
+    Iterator<S> iterator = loadAll(clazz);
+
+    if (!iterator.hasNext()) {
+      throw new IllegalStateException(String.format(
+          "No implementation defined in /META-INF/services/%s, please check whether the file exists and has the right implementation class!",
+          clazz.getName()));
+    }
+
+    List<S> candidates = Lists.newArrayList(iterator);
+    Collections.sort(candidates, new Comparator<S>() {
+      @Override
+      public int compare(S o1, S o2) {
+        // the smaller order has higher priority
+        return Integer.compare(o1.getOrder(), o2.getOrder());
+      }
+    });
+
+    return candidates;
+  }
+
+  public static <S extends Ordered> S loadPrimary(Class<S> clazz) {
+    List<S> candidates = loadAllOrdered(clazz);
+
+    return candidates.get(0);
   }
 }

--- a/apollo-core/src/test/java/com/ctrip/framework/foundation/internals/ServiceBootstrapTest.java
+++ b/apollo-core/src/test/java/com/ctrip/framework/foundation/internals/ServiceBootstrapTest.java
@@ -1,5 +1,6 @@
 package com.ctrip.framework.foundation.internals;
 
+import com.ctrip.framework.apollo.core.spi.Ordered;
 import org.junit.Test;
 
 import java.util.ServiceConfigurationError;
@@ -36,6 +37,17 @@ public class ServiceBootstrapTest {
     ServiceBootstrap.loadFirst(Interface5.class);
   }
 
+  @Test
+  public void loadPrimarySuccessfully() {
+    Interface6 service = ServiceBootstrap.loadPrimary(Interface6.class);
+    assertTrue(service instanceof Interface6Impl1);
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void loadPrimaryWithServiceFileButNoServiceImpl() {
+    ServiceBootstrap.loadPrimary(Interface7.class);
+  }
+
   private interface Interface1 {
   }
 
@@ -52,5 +64,25 @@ public class ServiceBootstrapTest {
   }
 
   private interface Interface5 {
+  }
+
+  private interface Interface6 extends Ordered {
+  }
+
+  public static class Interface6Impl1 implements Interface6 {
+    @Override
+    public int getOrder() {
+      return 1;
+    }
+  }
+
+  public static class Interface6Impl2 implements Interface6 {
+    @Override
+    public int getOrder() {
+      return 2;
+    }
+  }
+
+  private interface Interface7 extends Ordered {
   }
 }

--- a/apollo-core/src/test/resources/META-INF/services/com.ctrip.framework.foundation.internals.ServiceBootstrapTest$Interface6
+++ b/apollo-core/src/test/resources/META-INF/services/com.ctrip.framework.foundation.internals.ServiceBootstrapTest$Interface6
@@ -1,0 +1,2 @@
+com.ctrip.framework.foundation.internals.ServiceBootstrapTest$Interface6Impl1
+com.ctrip.framework.foundation.internals.ServiceBootstrapTest$Interface6Impl2


### PR DESCRIPTION
exposing 2 SPIs, ConfigPropertySourcesProcessorHelper and ConfigPropertySourcesProcessorHelper, for customizing spring processors's loading. So users can wrap their own client, and easily add their custom spring processors without modifying apollo-client code.

通过SPI 的方式自定义 spring processor 的加载过程 ，方便用户封装自己的客户端时添加自定义的processor，而不用去修改apollo-client中processor加载的代码。