### PR TITLE
将程序服务的端口提取到docker run中可指定，不指定默认原有端口。用于避免docker host网络的端口冲突。

### DIFF
--- a/apollo-adminservice/src/main/docker/Dockerfile
+++ b/apollo-adminservice/src/main/docker/Dockerfile
@@ -7,6 +7,7 @@ FROM openjdk:8-jre-alpine
 MAINTAINER ameizi <sxyx2008@163.com>
 
 ENV VERSION 1.5.0-SNAPSHOT
+ENV SERVER_PORT 8090
 
 RUN echo "http://mirrors.aliyun.com/alpine/v3.8/main" > /etc/apk/repositories \
     && echo "http://mirrors.aliyun.com/alpine/v3.8/community" >> /etc/apk/repositories \
@@ -20,8 +21,9 @@ ADD apollo-adminservice-${VERSION}-github.zip /apollo-adminservice/apollo-admins
 RUN unzip /apollo-adminservice/apollo-adminservice-${VERSION}-github.zip -d /apollo-adminservice \
     && rm -rf /apollo-adminservice/apollo-adminservice-${VERSION}-github.zip \
     && sed -i '$d' /apollo-adminservice/scripts/startup.sh \
+    && chmod +x /apollo-adminservice/scripts/startup.sh \
     && echo "tail -f /dev/null" >> /apollo-adminservice/scripts/startup.sh
 
-EXPOSE 8090
+EXPOSE $SERVER_PORT
 
 CMD ["/apollo-adminservice/scripts/startup.sh"]

--- a/apollo-adminservice/src/main/scripts/startup.sh
+++ b/apollo-adminservice/src/main/scripts/startup.sh
@@ -3,7 +3,8 @@ SERVICE_NAME=apollo-adminservice
 ## Adjust log dir if necessary
 LOG_DIR=/opt/logs/100003172
 ## Adjust server port if necessary
-SERVER_PORT=8090
+#SERVER_PORT=8090
+SERVER_PORT=${SERVER_PORT:=8090}
 
 ## Create log directory if not existed because JDK 8+ won't do that
 mkdir -p $LOG_DIR

--- a/apollo-configservice/src/main/docker/Dockerfile
+++ b/apollo-configservice/src/main/docker/Dockerfile
@@ -7,6 +7,7 @@ FROM openjdk:8-jre-alpine
 MAINTAINER ameizi <sxyx2008@163.com>
 
 ENV VERSION 1.5.0-SNAPSHOT
+ENV SERVER_PORT 8080
 
 RUN echo "http://mirrors.aliyun.com/alpine/v3.8/main" > /etc/apk/repositories \
     && echo "http://mirrors.aliyun.com/alpine/v3.8/community" >> /etc/apk/repositories \
@@ -20,8 +21,9 @@ ADD apollo-configservice-${VERSION}-github.zip /apollo-configservice/apollo-conf
 RUN unzip /apollo-configservice/apollo-configservice-${VERSION}-github.zip -d /apollo-configservice \
     && rm -rf /apollo-configservice/apollo-configservice-${VERSION}-github.zip \
     && sed -i '$d' /apollo-configservice/scripts/startup.sh \
+    && chmod +x /apollo-configservice/scripts/startup.sh \
     && echo "tail -f /dev/null" >> /apollo-configservice/scripts/startup.sh
 
-EXPOSE 8080
+EXPOSE $SERVER_PORT
 
 CMD ["/apollo-configservice/scripts/startup.sh"]

--- a/apollo-configservice/src/main/scripts/startup.sh
+++ b/apollo-configservice/src/main/scripts/startup.sh
@@ -3,7 +3,8 @@ SERVICE_NAME=apollo-configservice
 ## Adjust log dir if necessary
 LOG_DIR=/opt/logs/100003171
 ## Adjust server port if necessary
-SERVER_PORT=8080
+#SERVER_PORT=8080
+SERVER_PORT=${SERVER_PORT:=8080}
 
 ## Create log directory if not existed because JDK 8+ won't do that
 mkdir -p $LOG_DIR

--- a/apollo-portal/src/main/docker/Dockerfile
+++ b/apollo-portal/src/main/docker/Dockerfile
@@ -7,6 +7,7 @@ FROM openjdk:8-jre-alpine
 MAINTAINER ameizi <sxyx2008@163.com>
 
 ENV VERSION 1.5.0-SNAPSHOT
+ENV SERVER_PORT 8070
 
 RUN echo "http://mirrors.aliyun.com/alpine/v3.8/main" > /etc/apk/repositories \
     && echo "http://mirrors.aliyun.com/alpine/v3.8/community" >> /etc/apk/repositories \
@@ -20,8 +21,9 @@ ADD apollo-portal-${VERSION}-github.zip /apollo-portal/apollo-portal-${VERSION}-
 RUN unzip /apollo-portal/apollo-portal-${VERSION}-github.zip -d /apollo-portal \
     && rm -rf /apollo-portal/apollo-portal-${VERSION}-github.zip \
     && sed -i '$d' /apollo-portal/scripts/startup.sh \
+    && chmod +x /apollo-portal/scripts/startup.sh \
     && echo "tail -f /dev/null" >> /apollo-portal/scripts/startup.sh
 
-EXPOSE 8070
+EXPOSE $SERVER_PORT
 
 CMD ["/apollo-portal/scripts/startup.sh"]

--- a/apollo-portal/src/main/scripts/startup.sh
+++ b/apollo-portal/src/main/scripts/startup.sh
@@ -3,7 +3,8 @@ SERVICE_NAME=apollo-portal
 ## Adjust log dir if necessary
 LOG_DIR=/opt/logs/100003173
 ## Adjust server port if necessary
-SERVER_PORT=8070
+#SERVER_PORT=8070
+SERVER_PORT=${SERVER_PORT:=8070}
 
 ## Create log directory if not existed because JDK 8+ won't do that
 mkdir -p $LOG_DIR


### PR DESCRIPTION
1.将服务端口提取到docker run的 -e SERVER_PORT 可指定，在docker需要使用host网络时，可以不用修改代码指定端口，避免与宿主机上的原有端口占用冲突
2.对docker CMD入口的startup.sh文件，增加可执行授权指令，防止在某些时候该文件被打包进入后没有执行权限的麻烦（已实际遇到，又回头重新打包）