### PR TITLE
一个docker包，支持部署无数个环境。不再需要不同环境打不同的包。

### DIFF
--- a/apollo-adminservice/src/main/docker/Dockerfile
+++ b/apollo-adminservice/src/main/docker/Dockerfile
@@ -8,6 +8,10 @@ MAINTAINER ameizi <sxyx2008@163.com>
 
 ENV VERSION 1.5.0-SNAPSHOT
 ENV SERVER_PORT 8090
+# DataSource Info
+ENV DS_URL ""
+ENV DS_USERNAME ""
+ENV DS_PASSWORD ""
 
 RUN echo "http://mirrors.aliyun.com/alpine/v3.8/main" > /etc/apk/repositories \
     && echo "http://mirrors.aliyun.com/alpine/v3.8/community" >> /etc/apk/repositories \

--- a/apollo-adminservice/src/main/docker/Dockerfile
+++ b/apollo-adminservice/src/main/docker/Dockerfile
@@ -7,6 +7,7 @@ FROM openjdk:8-jre-alpine
 MAINTAINER ameizi <sxyx2008@163.com>
 
 ENV VERSION 1.5.0-SNAPSHOT
+ENV SERVER_PORT 8090
 
 RUN echo "http://mirrors.aliyun.com/alpine/v3.8/main" > /etc/apk/repositories \
     && echo "http://mirrors.aliyun.com/alpine/v3.8/community" >> /etc/apk/repositories \
@@ -20,8 +21,9 @@ ADD apollo-adminservice-${VERSION}-github.zip /apollo-adminservice/apollo-admins
 RUN unzip /apollo-adminservice/apollo-adminservice-${VERSION}-github.zip -d /apollo-adminservice \
     && rm -rf /apollo-adminservice/apollo-adminservice-${VERSION}-github.zip \
     && sed -i '$d' /apollo-adminservice/scripts/startup.sh \
+    && chmod +x /apollo-adminservice/scripts/startup.sh \
     && echo "tail -f /dev/null" >> /apollo-adminservice/scripts/startup.sh
 
-EXPOSE 8090
+EXPOSE $SERVER_PORT
 
 CMD ["/apollo-adminservice/scripts/startup.sh"]

--- a/apollo-adminservice/src/main/scripts/startup.sh
+++ b/apollo-adminservice/src/main/scripts/startup.sh
@@ -3,7 +3,8 @@ SERVICE_NAME=apollo-adminservice
 ## Adjust log dir if necessary
 LOG_DIR=/opt/logs/100003172
 ## Adjust server port if necessary
-SERVER_PORT=8090
+#SERVER_PORT=8090
+SERVER_PORT=${SERVER_PORT:=8090}
 
 ## Create log directory if not existed because JDK 8+ won't do that
 mkdir -p $LOG_DIR

--- a/apollo-adminservice/src/main/scripts/startup.sh
+++ b/apollo-adminservice/src/main/scripts/startup.sh
@@ -17,6 +17,11 @@ mkdir -p $LOG_DIR
 
 ########### The following is the same for configservice, adminservice, portal ###########
 export JAVA_OPTS="$JAVA_OPTS -XX:ParallelGCThreads=4 -XX:MaxTenuringThreshold=9 -XX:+DisableExplicitGC -XX:+ScavengeBeforeFullGC -XX:SoftRefLRUPolicyMSPerMB=0 -XX:+ExplicitGCInvokesConcurrent -XX:+HeapDumpOnOutOfMemoryError -XX:-OmitStackTraceInFastThrow -Duser.timezone=Asia/Shanghai -Dclient.encoding.override=UTF-8 -Dfile.encoding=UTF-8 -Djava.security.egd=file:/dev/./urandom"
+# DataSource URL USERNAME PASSWORD
+if [ "$DS_URL"x != x ]
+then
+    export JAVA_OPTS="$JAVA_OPTS -Dspring.datasource.url=$DS_URL -Dspring.datasource.username=$DS_USERNAME -Dspring.datasource.password=$DS_PASSWORD"
+fi
 export JAVA_OPTS="$JAVA_OPTS -Dserver.port=$SERVER_PORT -Dlogging.file=$LOG_DIR/$SERVICE_NAME.log -XX:HeapDumpPath=$LOG_DIR/HeapDumpOnOutOfMemoryError/"
 
 PATH_TO_JAR=$SERVICE_NAME".jar"

--- a/apollo-configservice/src/main/docker/Dockerfile
+++ b/apollo-configservice/src/main/docker/Dockerfile
@@ -8,6 +8,10 @@ MAINTAINER ameizi <sxyx2008@163.com>
 
 ENV VERSION 1.5.0-SNAPSHOT
 ENV SERVER_PORT 8080
+# DataSource Info
+ENV DS_URL ""
+ENV DS_USERNAME ""
+ENV DS_PASSWORD ""
 
 RUN echo "http://mirrors.aliyun.com/alpine/v3.8/main" > /etc/apk/repositories \
     && echo "http://mirrors.aliyun.com/alpine/v3.8/community" >> /etc/apk/repositories \

--- a/apollo-configservice/src/main/docker/Dockerfile
+++ b/apollo-configservice/src/main/docker/Dockerfile
@@ -7,6 +7,7 @@ FROM openjdk:8-jre-alpine
 MAINTAINER ameizi <sxyx2008@163.com>
 
 ENV VERSION 1.5.0-SNAPSHOT
+ENV SERVER_PORT 8080
 
 RUN echo "http://mirrors.aliyun.com/alpine/v3.8/main" > /etc/apk/repositories \
     && echo "http://mirrors.aliyun.com/alpine/v3.8/community" >> /etc/apk/repositories \
@@ -20,8 +21,9 @@ ADD apollo-configservice-${VERSION}-github.zip /apollo-configservice/apollo-conf
 RUN unzip /apollo-configservice/apollo-configservice-${VERSION}-github.zip -d /apollo-configservice \
     && rm -rf /apollo-configservice/apollo-configservice-${VERSION}-github.zip \
     && sed -i '$d' /apollo-configservice/scripts/startup.sh \
+    && chmod +x /apollo-configservice/scripts/startup.sh \
     && echo "tail -f /dev/null" >> /apollo-configservice/scripts/startup.sh
 
-EXPOSE 8080
+EXPOSE $SERVER_PORT
 
 CMD ["/apollo-configservice/scripts/startup.sh"]

--- a/apollo-configservice/src/main/scripts/startup.sh
+++ b/apollo-configservice/src/main/scripts/startup.sh
@@ -17,6 +17,11 @@ mkdir -p $LOG_DIR
 
 ########### The following is the same for configservice, adminservice, portal ###########
 export JAVA_OPTS="$JAVA_OPTS -XX:ParallelGCThreads=4 -XX:MaxTenuringThreshold=9 -XX:+DisableExplicitGC -XX:+ScavengeBeforeFullGC -XX:SoftRefLRUPolicyMSPerMB=0 -XX:+ExplicitGCInvokesConcurrent -XX:+HeapDumpOnOutOfMemoryError -XX:-OmitStackTraceInFastThrow -Duser.timezone=Asia/Shanghai -Dclient.encoding.override=UTF-8 -Dfile.encoding=UTF-8 -Djava.security.egd=file:/dev/./urandom"
+# DataSource URL USERNAME PASSWORD
+if [ "$DS_URL"x != x ]
+then
+    export JAVA_OPTS="$JAVA_OPTS -Dspring.datasource.url=$DS_URL -Dspring.datasource.username=$DS_USERNAME -Dspring.datasource.password=$DS_PASSWORD"
+fi
 export JAVA_OPTS="$JAVA_OPTS -Dserver.port=$SERVER_PORT -Dlogging.file=$LOG_DIR/$SERVICE_NAME.log -XX:HeapDumpPath=$LOG_DIR/HeapDumpOnOutOfMemoryError/"
 
 PATH_TO_JAR=$SERVICE_NAME".jar"

--- a/apollo-configservice/src/main/scripts/startup.sh
+++ b/apollo-configservice/src/main/scripts/startup.sh
@@ -3,7 +3,8 @@ SERVICE_NAME=apollo-configservice
 ## Adjust log dir if necessary
 LOG_DIR=/opt/logs/100003171
 ## Adjust server port if necessary
-SERVER_PORT=8080
+#SERVER_PORT=8080
+SERVER_PORT=${SERVER_PORT:=8080}
 
 ## Create log directory if not existed because JDK 8+ won't do that
 mkdir -p $LOG_DIR

--- a/apollo-portal/src/main/docker/Dockerfile
+++ b/apollo-portal/src/main/docker/Dockerfile
@@ -7,6 +7,7 @@ FROM openjdk:8-jre-alpine
 MAINTAINER ameizi <sxyx2008@163.com>
 
 ENV VERSION 1.5.0-SNAPSHOT
+ENV SERVER_PORT 8070
 
 RUN echo "http://mirrors.aliyun.com/alpine/v3.8/main" > /etc/apk/repositories \
     && echo "http://mirrors.aliyun.com/alpine/v3.8/community" >> /etc/apk/repositories \
@@ -20,8 +21,9 @@ ADD apollo-portal-${VERSION}-github.zip /apollo-portal/apollo-portal-${VERSION}-
 RUN unzip /apollo-portal/apollo-portal-${VERSION}-github.zip -d /apollo-portal \
     && rm -rf /apollo-portal/apollo-portal-${VERSION}-github.zip \
     && sed -i '$d' /apollo-portal/scripts/startup.sh \
+    && chmod +x /apollo-portal/scripts/startup.sh \
     && echo "tail -f /dev/null" >> /apollo-portal/scripts/startup.sh
 
-EXPOSE 8070
+EXPOSE $SERVER_PORT
 
 CMD ["/apollo-portal/scripts/startup.sh"]

--- a/apollo-portal/src/main/docker/Dockerfile
+++ b/apollo-portal/src/main/docker/Dockerfile
@@ -8,7 +8,7 @@ MAINTAINER ameizi <sxyx2008@163.com>
 
 ENV VERSION 1.5.0-SNAPSHOT
 ENV SERVER_PORT 8070
-# DataSource Info
+# DataSource Info 
 ENV DS_URL ""
 ENV DS_USERNAME ""
 ENV DS_PASSWORD ""

--- a/apollo-portal/src/main/docker/Dockerfile
+++ b/apollo-portal/src/main/docker/Dockerfile
@@ -8,6 +8,16 @@ MAINTAINER ameizi <sxyx2008@163.com>
 
 ENV VERSION 1.5.0-SNAPSHOT
 ENV SERVER_PORT 8070
+# DataSource Info
+ENV DS_URL ""
+ENV DS_USERNAME ""
+ENV DS_PASSWORD ""
+# Environmental variable declaration (meta server url, different environments should have different meta server addresses)
+ENV DEV_META ""
+ENV FAT_META ""
+ENV UAT_META ""
+ENV LPT_META ""
+ENV PRO_META ""
 
 RUN echo "http://mirrors.aliyun.com/alpine/v3.8/main" > /etc/apk/repositories \
     && echo "http://mirrors.aliyun.com/alpine/v3.8/community" >> /etc/apk/repositories \

--- a/apollo-portal/src/main/scripts/startup.sh
+++ b/apollo-portal/src/main/scripts/startup.sh
@@ -17,6 +17,10 @@ mkdir -p $LOG_DIR
 
 ########### The following is the same for configservice, adminservice, portal ###########
 export JAVA_OPTS="$JAVA_OPTS -XX:ParallelGCThreads=4 -XX:MaxTenuringThreshold=9 -XX:+DisableExplicitGC -XX:+ScavengeBeforeFullGC -XX:SoftRefLRUPolicyMSPerMB=0 -XX:+ExplicitGCInvokesConcurrent -XX:+HeapDumpOnOutOfMemoryError -XX:-OmitStackTraceInFastThrow -Duser.timezone=Asia/Shanghai -Dclient.encoding.override=UTF-8 -Dfile.encoding=UTF-8 -Djava.security.egd=file:/dev/./urandom"
+if [ "$DS_URL"x != x ]
+then
+    export JAVA_OPTS="$JAVA_OPTS -Dspring.datasource.url=$DS_URL -Dspring.datasource.username=$DS_USERNAME -Dspring.datasource.password=$DS_PASSWORD"
+fi
 export JAVA_OPTS="$JAVA_OPTS -Dserver.port=$SERVER_PORT -Dlogging.file=$LOG_DIR/$SERVICE_NAME.log -XX:HeapDumpPath=$LOG_DIR/HeapDumpOnOutOfMemoryError/"
 
 PATH_TO_JAR=$SERVICE_NAME".jar"

--- a/apollo-portal/src/main/scripts/startup.sh
+++ b/apollo-portal/src/main/scripts/startup.sh
@@ -3,7 +3,8 @@ SERVICE_NAME=apollo-portal
 ## Adjust log dir if necessary
 LOG_DIR=/opt/logs/100003173
 ## Adjust server port if necessary
-SERVER_PORT=8070
+#SERVER_PORT=8070
+SERVER_PORT=${SERVER_PORT:=8070}
 
 ## Create log directory if not existed because JDK 8+ won't do that
 mkdir -p $LOG_DIR


### PR DESCRIPTION
1、maven编译，不再需要为每个config环境都修改build.sh(bat)，只需要进行一次maven编译。一次docker打包。
2、原本需要再build.sh(bat)中配置的参数 portal 的数据库连接信息、config和admin的数据库连接信息、metaserver信息，都将不需要了。
3、这些信息，都提取到环境变量中来配置。不管你是普通部署还是docker部署，都可以通过环境变量来配置信息。
完全杜绝同环境不同包的问题。一次编译，多次运行！
---------------------------------------------------------------------
下面是一个完全通过env配置的docker-compose.yml示例，包括了数据库和MetaServer的配置：
---------------------------------------------------------------------

```
version: '3'
services:
  apollo-portal:
    image: docker.io/xzxiaoshan/apollo-portal:1.4.0
    container_name: apollo-portal
    network_mode: "host"
    environment: 
      SERVER_PORT: 5555
      # DataSource Info
      DS_URL: "jdbc:mysql://pro.shanhy.com:3306/ApolloPortalDB?characterEncoding=utf8"
      DS_USERNAME: "shanhy"
      DS_PASSWORD: "xzxiaoshan@123"
      # Environmental variable declaration (meta server url, different environments should have different meta server addresses)
      DEV_META: "http://dev.shanhy.com:6666"
      FAT_META: ""
      UAT_META: ""
      LPT_META: ""
      PRO_META: "http://pro.shanhy.com:6666"
    depends_on:
      - apollo-adminservice
    logging:
      driver: "json-file"
      options:
        max-size: "200k"
        max-file: "10"
        
  apollo-configservice:
    image: docker.io/xzxiaoshan/apollo-configservice:1.4.0
    container_name: apollo-configservice
    network_mode: "host"
    environment:
      SERVER_PORT: 6666
      # DataSource Info
      DS_URL: "jdbc:mysql://pro.shanhy.com:3306/ApolloConfigDB?characterEncoding=utf8"
      DS_USERNAME: "shanhy"
      DS_PASSWORD: "xzxiaoshan@123"
    logging:
      driver: "json-file"
      options:
        max-size: "200k"
        max-file: "10"
        
  apollo-adminservice:
    image: docker.io/xzxiaoshan/apollo-adminservice:1.4.0
    container_name: apollo-adminservice
    network_mode: "host"
    environment:
      SERVER_PORT: 6667
      # DataSource Info
      DS_URL: "jdbc:mysql://pro.shanhy.com:3306/ApolloConfigDB?characterEncoding=utf8"
      DS_USERNAME: "shanhy"
      DS_PASSWORD: "xzxiaoshan@123"
    depends_on:
      - apollo-configservice
    logging:
      driver: "json-file"
      options:
        max-size: "200k"
        max-file: "10"
```