### PR TITLE
Add unit tests for com.ctrip.framework.apollo.core.utils.ByteUtil

### DIFF
--- a/apollo-core/src/test/java/com/ctrip/framework/apollo/core/utils/ByteUtilTest.java
+++ b/apollo-core/src/test/java/com/ctrip/framework/apollo/core/utils/ByteUtilTest.java
@@ -1,0 +1,38 @@
+package com.ctrip.framework.apollo.core.utils;
+
+import com.ctrip.framework.apollo.core.utils.ByteUtil;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ByteUtilTest {
+
+  @Test
+  public void testInt3() {
+    Assert.assertEquals((byte)0, ByteUtil.int3(0));
+    Assert.assertEquals((byte)0, ByteUtil.int3(1));
+  }
+
+  @Test
+  public void testInt2() {
+    Assert.assertEquals((byte)0, ByteUtil.int2(0));
+    Assert.assertEquals((byte)0, ByteUtil.int2(1));
+  }
+
+  @Test
+  public void testInt1() {
+    Assert.assertEquals((byte)0, ByteUtil.int1(0));
+    Assert.assertEquals((byte)0, ByteUtil.int1(1));
+  }
+
+  @Test
+  public void testInt0() {
+    Assert.assertEquals((byte)0, ByteUtil.int0(0));
+    Assert.assertEquals((byte)1, ByteUtil.int0(1));
+  }
+
+  @Test
+  public void testToHexString() {
+    Assert.assertEquals("", ByteUtil.toHexString(new byte[] {}));
+    Assert.assertEquals("98", ByteUtil.toHexString(new byte[] {(byte)-104}));
+  }
+}


### PR DESCRIPTION
Further to my PR at https://github.com/ctripcorp/apollo/pull/2366, here are some tests for `com.ctrip.framework.apollo.core.utils.ByteUtil`, also written with the help of [Diffblue Cover](https://www.diffblue.com/opensource).