### PR TITLE
优化kubernetes部署去掉nodeSelector改为POD反亲和性(podAntiAffinity)

### DIFF
--- a/scripts/apollo-on-kubernetes/README.md
+++ b/scripts/apollo-on-kubernetes/README.md
@@ -94,7 +94,8 @@ kubectl apply -f apollo-env-prod/service-apollo-admin-server-prod.yaml --record
 kubectl apply -f service-apollo-portal-server.yaml --record
 ```
 
-你需要注意的是, 应当尽量让同一个 server 的不同 pod 在不同 node 上, 这个通过 kubernetes nodeSelector 实现
+~~你需要注意的是, 应当尽量让同一个 server 的不同 pod 在不同 node 上, 这个通过 kubernetes nodeSelector 实现
+~~ 已经优化去掉nodeSelector使用kubernetes的pod反亲和性[podAntiAffinity](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/)
 
 ### 2.3 验证所有 pod 处于 Running 并且 READY 状态
 

--- a/scripts/apollo-on-kubernetes/README.md
+++ b/scripts/apollo-on-kubernetes/README.md
@@ -95,6 +95,7 @@ kubectl apply -f service-apollo-portal-server.yaml --record
 ```
 
 ~~你需要注意的是, 应当尽量让同一个 server 的不同 pod 在不同 node 上, 这个通过 kubernetes nodeSelector 实现~~ 
+
 已经优化去掉nodeSelector使用kubernetes的pod反亲和性[podAntiAffinity](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/)
 
 ### 2.3 验证所有 pod 处于 Running 并且 READY 状态

--- a/scripts/apollo-on-kubernetes/README.md
+++ b/scripts/apollo-on-kubernetes/README.md
@@ -94,8 +94,8 @@ kubectl apply -f apollo-env-prod/service-apollo-admin-server-prod.yaml --record
 kubectl apply -f service-apollo-portal-server.yaml --record
 ```
 
-~~你需要注意的是, 应当尽量让同一个 server 的不同 pod 在不同 node 上, 这个通过 kubernetes nodeSelector 实现
-~~ 已经优化去掉nodeSelector使用kubernetes的pod反亲和性[podAntiAffinity](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/)
+~~你需要注意的是, 应当尽量让同一个 server 的不同 pod 在不同 node 上, 这个通过 kubernetes nodeSelector 实现~~ 
+已经优化去掉nodeSelector使用kubernetes的pod反亲和性[podAntiAffinity](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/)
 
 ### 2.3 验证所有 pod 处于 Running 并且 READY 状态
 

--- a/scripts/apollo-on-kubernetes/kubernetes/apollo-env-dev/service-apollo-admin-server-dev.yaml
+++ b/scripts/apollo-on-kubernetes/kubernetes/apollo-env-dev/service-apollo-admin-server-dev.yaml
@@ -54,8 +54,18 @@ spec:
       labels:
         app: pod-apollo-admin-server-dev
     spec:
-      nodeSelector:
-        node: "apollo"
+      affinity:
+        podAntiAffinity:
+          PreferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - pod-apollo-admin-server-dev
+              topologyKey: kubernetes.io/hostname
       
       volumes:
         - name: volume-configmap-apollo-admin-server-dev

--- a/scripts/apollo-on-kubernetes/kubernetes/apollo-env-dev/service-apollo-config-server-dev.yaml
+++ b/scripts/apollo-on-kubernetes/kubernetes/apollo-env-dev/service-apollo-config-server-dev.yaml
@@ -72,8 +72,18 @@ spec:
       labels:
         app: pod-apollo-config-server-dev
     spec:
-      nodeSelector:
-        node: "apollo"
+      affinity:
+        podAntiAffinity:
+          PreferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - pod-apollo-config-server-dev
+              topologyKey: kubernetes.io/hostname
 
       volumes:
         - name: volume-configmap-apollo-config-server-dev

--- a/scripts/apollo-on-kubernetes/kubernetes/apollo-env-prod/service-apollo-admin-server-prod.yaml
+++ b/scripts/apollo-on-kubernetes/kubernetes/apollo-env-prod/service-apollo-admin-server-prod.yaml
@@ -54,8 +54,18 @@ spec:
       labels:
         app: pod-apollo-admin-server-prod
     spec:
-      nodeSelector:
-        node: "apollo"
+      affinity:
+        podAntiAffinity:
+          PreferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - pod-apollo-admin-server-prod
+              topologyKey: kubernetes.io/hostname
       
       volumes:
         - name: volume-configmap-apollo-admin-server-prod

--- a/scripts/apollo-on-kubernetes/kubernetes/apollo-env-prod/service-apollo-config-server-prod.yaml
+++ b/scripts/apollo-on-kubernetes/kubernetes/apollo-env-prod/service-apollo-config-server-prod.yaml
@@ -72,8 +72,18 @@ spec:
       labels:
         app: pod-apollo-config-server-prod
     spec:
-      nodeSelector:
-        node: "apollo"
+      affinity:
+        podAntiAffinity:
+          PreferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - pod-apollo-config-server-prod
+              topologyKey: kubernetes.io/hostname
       
       volumes:
         - name: volume-configmap-apollo-config-server-prod

--- a/scripts/apollo-on-kubernetes/kubernetes/apollo-env-test-alpha/service-apollo-admin-server-test-alpha.yaml
+++ b/scripts/apollo-on-kubernetes/kubernetes/apollo-env-test-alpha/service-apollo-admin-server-test-alpha.yaml
@@ -54,8 +54,18 @@ spec:
       labels:
         app: pod-apollo-admin-server-test-alpha
     spec:
-      nodeSelector:
-        node: "apollo"
+      affinity:
+        podAntiAffinity:
+          PreferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - pod-apollo-admin-server-test-alpha
+              topologyKey: kubernetes.io/hostname
       
       volumes:
         - name: volume-configmap-apollo-admin-server-test-alpha

--- a/scripts/apollo-on-kubernetes/kubernetes/apollo-env-test-alpha/service-apollo-config-server-test-alpha.yaml
+++ b/scripts/apollo-on-kubernetes/kubernetes/apollo-env-test-alpha/service-apollo-config-server-test-alpha.yaml
@@ -72,8 +72,18 @@ spec:
       labels:
         app: pod-apollo-config-server-test-alpha
     spec:
-      nodeSelector:
-        node: "apollo"
+      affinity:
+        podAntiAffinity:
+          PreferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - pod-apollo-config-server-test-alpha
+              topologyKey: kubernetes.io/hostname
       
       volumes:
         - name: volume-configmap-apollo-config-server-test-alpha

--- a/scripts/apollo-on-kubernetes/kubernetes/apollo-env-test-beta/service-apollo-admin-server-test-beta.yaml
+++ b/scripts/apollo-on-kubernetes/kubernetes/apollo-env-test-beta/service-apollo-admin-server-test-beta.yaml
@@ -54,8 +54,18 @@ spec:
       labels:
         app: pod-apollo-admin-server-test-beta
     spec:
-      nodeSelector:
-        node: "apollo"
+      affinity:
+        podAntiAffinity:
+          PreferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - pod-apollo-admin-server-test-beta
+              topologyKey: kubernetes.io/hostname
       
       volumes:
         - name: volume-configmap-apollo-admin-server-test-beta

--- a/scripts/apollo-on-kubernetes/kubernetes/apollo-env-test-beta/service-apollo-config-server-test-beta.yaml
+++ b/scripts/apollo-on-kubernetes/kubernetes/apollo-env-test-beta/service-apollo-config-server-test-beta.yaml
@@ -72,8 +72,18 @@ spec:
       labels:
         app: pod-apollo-config-server-test-beta
     spec:
-      nodeSelector:
-        node: "apollo"
+      affinity:
+        podAntiAffinity:
+          PreferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - pod-apollo-config-server-test-beta
+              topologyKey: kubernetes.io/hostname
       
       volumes:
         - name: volume-configmap-apollo-config-server-test-beta

--- a/scripts/apollo-on-kubernetes/kubernetes/service-apollo-portal-server.yaml
+++ b/scripts/apollo-on-kubernetes/kubernetes/service-apollo-portal-server.yaml
@@ -93,8 +93,18 @@ spec:
       labels:
         app: pod-apollo-portal-server
     spec:
-      nodeSelector:
-        node: "apollo"
+      affinity:
+        podAntiAffinity:
+          PreferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - pod-apollo-portal-server
+              topologyKey: kubernetes.io/hostname
       
       volumes:
         - name: volume-configmap-apollo-portal-server


### PR DESCRIPTION
nodeSelector只能提供简单的将pod限制为具有特定标签的节点,而podAntiAffinity将一个服务的POD分散在不同的主机或者拓扑域中，提高服务本身的稳定性。
官方文档：https://kubernetes.io/docs/concepts/configuration/assign-pod-node/