### PR TITLE
各服务的端口号提取到build.sh中配置

### DIFF
--- a/apollo-adminservice/src/main/resources/application.yml
+++ b/apollo-adminservice/src/main/resources/application.yml
@@ -8,7 +8,7 @@ ctrip:
   appid: 100003172
   
 server:
-  port: 8090
+  port: ${admin_server_port}
   
 logging:
   file: /opt/logs/100003172/apollo-adminservice.log

--- a/apollo-adminservice/src/main/resources/application.yml
+++ b/apollo-adminservice/src/main/resources/application.yml
@@ -8,7 +8,7 @@ ctrip:
   appid: 100003172
   
 server:
-  port: ${admin_server_port}
+  port: ${admin_server_port:8090}
   
 logging:
   file: /opt/logs/100003172/apollo-adminservice.log

--- a/apollo-adminservice/src/main/resources/bootstrap.yml
+++ b/apollo-adminservice/src/main/resources/bootstrap.yml
@@ -8,7 +8,7 @@ eureka:
     serviceUrl:
       # This setting will be overridden by eureka.service.url setting from ApolloConfigDB.ServerConfig or System Property
       # see com.ctrip.framework.apollo.biz.eureka.ApolloEurekaClientConfig
-      defaultZone: http://${eureka.instance.hostname}:8080/eureka/
+      defaultZone: http://${eureka.instance.hostname}:${config_server_port}/eureka/
     healthcheck:
       enabled: true
     eurekaServiceUrlPollIntervalSeconds: 60

--- a/apollo-adminservice/src/main/resources/bootstrap.yml
+++ b/apollo-adminservice/src/main/resources/bootstrap.yml
@@ -8,7 +8,7 @@ eureka:
     serviceUrl:
       # This setting will be overridden by eureka.service.url setting from ApolloConfigDB.ServerConfig or System Property
       # see com.ctrip.framework.apollo.biz.eureka.ApolloEurekaClientConfig
-      defaultZone: http://${eureka.instance.hostname}:${config_server_port}/eureka/
+      defaultZone: http://${eureka.instance.hostname}:${config_server_port:8080}/eureka/
     healthcheck:
       enabled: true
     eurekaServiceUrlPollIntervalSeconds: 60

--- a/apollo-adminservice/src/main/scripts/startup.sh
+++ b/apollo-adminservice/src/main/scripts/startup.sh
@@ -4,7 +4,7 @@ SERVICE_NAME=apollo-adminservice
 LOG_DIR=/opt/logs/100003172
 ## Adjust server port if necessary
 #SERVER_PORT=8090
-SERVER_PORT=${SERVER_PORT:=8090}
+SERVER_PORT=${SERVER_PORT:=-1}
 
 ## Create log directory if not existed because JDK 8+ won't do that
 mkdir -p $LOG_DIR
@@ -17,12 +17,17 @@ mkdir -p $LOG_DIR
 
 ########### The following is the same for configservice, adminservice, portal ###########
 export JAVA_OPTS="$JAVA_OPTS -XX:ParallelGCThreads=4 -XX:MaxTenuringThreshold=9 -XX:+DisableExplicitGC -XX:+ScavengeBeforeFullGC -XX:SoftRefLRUPolicyMSPerMB=0 -XX:+ExplicitGCInvokesConcurrent -XX:+HeapDumpOnOutOfMemoryError -XX:-OmitStackTraceInFastThrow -Duser.timezone=Asia/Shanghai -Dclient.encoding.override=UTF-8 -Dfile.encoding=UTF-8 -Djava.security.egd=file:/dev/./urandom"
+# SERVER_PORT
+if [ $SERVER_PORT != -1 ]
+then
+    export JAVA_OPTS="$JAVA_OPTS -Dserver.port=$SERVER_PORT"
+fi
 # DataSource URL USERNAME PASSWORD
 if [ "$DS_URL"x != x ]
 then
     export JAVA_OPTS="$JAVA_OPTS -Dspring.datasource.url=$DS_URL -Dspring.datasource.username=$DS_USERNAME -Dspring.datasource.password=$DS_PASSWORD"
 fi
-export JAVA_OPTS="$JAVA_OPTS -Dserver.port=$SERVER_PORT -Dlogging.file=$LOG_DIR/$SERVICE_NAME.log -XX:HeapDumpPath=$LOG_DIR/HeapDumpOnOutOfMemoryError/"
+export JAVA_OPTS="$JAVA_OPTS -Dlogging.file=$LOG_DIR/$SERVICE_NAME.log -XX:HeapDumpPath=$LOG_DIR/HeapDumpOnOutOfMemoryError/"
 
 PATH_TO_JAR=$SERVICE_NAME".jar"
 SERVER_URL="http://localhost:$SERVER_PORT"
@@ -43,6 +48,18 @@ function checkPidAlive {
 
     printf "\nNo pid file found, startup may failed. Please check logs under $LOG_DIR and /tmp for more information!\n"
     exit 1;
+}
+
+function freshPortAndServerUrl {
+    if [[ $SERVER_PORT == -1 ]]
+    then
+        port=$(lsof -n -i -P | grep LISTEN | grep $pid | awk '{ print $9 }' | awk -F: '{ print $2 }')
+        if [[ $port != "" ]]
+        then
+            SERVER_PORT=$port
+            SERVER_URL="http://localhost:$SERVER_PORT"
+        fi
+    fi
 }
 
 if [ "$(uname)" == "Darwin" ]; then
@@ -137,13 +154,14 @@ declare -i max_counter=48 # 48*5=240s
 declare -i total_time=0
 
 printf "Waiting for server startup"
-until [[ (( counter -ge max_counter )) || "$(curl -X GET --silent --connect-timeout 1 --max-time 2 --head $SERVER_URL | grep "HTTP")" != "" ]];
+until [[ (( counter -ge max_counter )) || ($SERVER_PORT != -1 && "$(curl -X GET --silent --connect-timeout 1 --max-time 2 --head $SERVER_URL | grep "HTTP")" != "") ]];
 do
     printf "."
     counter+=1
     sleep 5
 
     checkPidAlive
+    freshPortAndServerUrl
 done
 
 total_time=counter*5

--- a/apollo-configservice/src/main/resources/application.yml
+++ b/apollo-configservice/src/main/resources/application.yml
@@ -8,7 +8,7 @@ ctrip:
   appid: 100003171
 
 server:
-  port: 8080
+  port: ${config_server_port}
 
 logging:
   file: /opt/logs/100003171/apollo-configservice.log

--- a/apollo-configservice/src/main/resources/application.yml
+++ b/apollo-configservice/src/main/resources/application.yml
@@ -8,7 +8,7 @@ ctrip:
   appid: 100003171
 
 server:
-  port: ${config_server_port}
+  port: ${config_server_port:8080}
 
 logging:
   file: /opt/logs/100003171/apollo-configservice.log

--- a/apollo-configservice/src/main/resources/bootstrap.yml
+++ b/apollo-configservice/src/main/resources/bootstrap.yml
@@ -11,7 +11,7 @@ eureka:
     serviceUrl:
       # This setting will be overridden by eureka.service.url setting from ApolloConfigDB.ServerConfig or System Property
       # see com.ctrip.framework.apollo.biz.eureka.ApolloEurekaClientConfig
-      defaultZone: http://${eureka.instance.hostname}:8080/eureka/
+      defaultZone: http://${eureka.instance.hostname}:${config_server_port}/eureka/
     healthcheck:
       enabled: true
     eurekaServiceUrlPollIntervalSeconds: 60

--- a/apollo-configservice/src/main/resources/bootstrap.yml
+++ b/apollo-configservice/src/main/resources/bootstrap.yml
@@ -11,7 +11,7 @@ eureka:
     serviceUrl:
       # This setting will be overridden by eureka.service.url setting from ApolloConfigDB.ServerConfig or System Property
       # see com.ctrip.framework.apollo.biz.eureka.ApolloEurekaClientConfig
-      defaultZone: http://${eureka.instance.hostname}:${config_server_port}/eureka/
+      defaultZone: http://${eureka.instance.hostname}:${config_server_port:8080}/eureka/
     healthcheck:
       enabled: true
     eurekaServiceUrlPollIntervalSeconds: 60

--- a/apollo-portal/src/main/resources/application.yml
+++ b/apollo-portal/src/main/resources/application.yml
@@ -10,7 +10,7 @@ spring:
           plan_cache_max_size: 192 # limit query plan cache max size
 
 server:
-  port: ${server_port}
+  port: ${server_port:8070}
   compression:
     enabled: true
   tomcat:

--- a/apollo-portal/src/main/resources/application.yml
+++ b/apollo-portal/src/main/resources/application.yml
@@ -10,7 +10,7 @@ spring:
           plan_cache_max_size: 192 # limit query plan cache max size
 
 server:
-  port: 8070
+  port: ${server_port}
   compression:
     enabled: true
   tomcat:

--- a/apollo-portal/src/main/scripts/startup.sh
+++ b/apollo-portal/src/main/scripts/startup.sh
@@ -4,7 +4,7 @@ SERVICE_NAME=apollo-portal
 LOG_DIR=/opt/logs/100003173
 ## Adjust server port if necessary
 #SERVER_PORT=8070
-SERVER_PORT=${SERVER_PORT:=8070}
+SERVER_PORT=${SERVER_PORT:=-1}
 
 ## Create log directory if not existed because JDK 8+ won't do that
 mkdir -p $LOG_DIR
@@ -17,11 +17,18 @@ mkdir -p $LOG_DIR
 
 ########### The following is the same for configservice, adminservice, portal ###########
 export JAVA_OPTS="$JAVA_OPTS -XX:ParallelGCThreads=4 -XX:MaxTenuringThreshold=9 -XX:+DisableExplicitGC -XX:+ScavengeBeforeFullGC -XX:SoftRefLRUPolicyMSPerMB=0 -XX:+ExplicitGCInvokesConcurrent -XX:+HeapDumpOnOutOfMemoryError -XX:-OmitStackTraceInFastThrow -Duser.timezone=Asia/Shanghai -Dclient.encoding.override=UTF-8 -Dfile.encoding=UTF-8 -Djava.security.egd=file:/dev/./urandom"
+
+# SERVER_PORT
+if [ $SERVER_PORT != -1 ]
+then
+    export JAVA_OPTS="$JAVA_OPTS -Dserver.port=$SERVER_PORT"
+fi
+
 if [ "$DS_URL"x != x ]
 then
     export JAVA_OPTS="$JAVA_OPTS -Dspring.datasource.url=$DS_URL -Dspring.datasource.username=$DS_USERNAME -Dspring.datasource.password=$DS_PASSWORD"
 fi
-export JAVA_OPTS="$JAVA_OPTS -Dserver.port=$SERVER_PORT -Dlogging.file=$LOG_DIR/$SERVICE_NAME.log -XX:HeapDumpPath=$LOG_DIR/HeapDumpOnOutOfMemoryError/"
+export JAVA_OPTS="$JAVA_OPTS -Dlogging.file=$LOG_DIR/$SERVICE_NAME.log -XX:HeapDumpPath=$LOG_DIR/HeapDumpOnOutOfMemoryError/"
 
 PATH_TO_JAR=$SERVICE_NAME".jar"
 SERVER_URL="http://localhost:$SERVER_PORT"
@@ -42,6 +49,18 @@ function checkPidAlive {
 
     printf "\nNo pid file found, startup may failed. Please check logs under $LOG_DIR and /tmp for more information!\n"
     exit 1;
+}
+
+function freshPortAndServerUrl {
+    if [[ $SERVER_PORT == -1 ]]
+    then
+        port=$(lsof -n -i -P | grep LISTEN | grep $pid | awk '{ print $9 }' | awk -F: '{ print $2 }')
+        if [[ $port != "" ]]
+        then
+            SERVER_PORT=$port
+            SERVER_URL="http://localhost:$SERVER_PORT"
+        fi
+    fi
 }
 
 if [ "$(uname)" == "Darwin" ]; then
@@ -136,13 +155,14 @@ declare -i max_counter=48 # 48*5=240s
 declare -i total_time=0
 
 printf "Waiting for server startup"
-until [[ (( counter -ge max_counter )) || "$(curl -X GET --silent --connect-timeout 1 --max-time 2 --head $SERVER_URL | grep "HTTP")" != "" ]];
+until [[ (( counter -ge max_counter )) || ($SERVER_PORT != -1 && "$(curl -X GET --silent --connect-timeout 1 --max-time 2 --head $SERVER_URL | grep "HTTP")" != "") ]];
 do
     printf "."
     counter+=1
     sleep 5
 
     checkPidAlive
+    freshPortAndServerUrl
 done
 
 total_time=counter*5

--- a/scripts/build.bat
+++ b/scripts/build.bat
@@ -10,6 +10,12 @@ set apollo_portal_db_url="jdbc:mysql://localhost:3306/ApolloPortalDB?characterEn
 set apollo_portal_db_username="root"
 set apollo_portal_db_password=""
 
+
+# apollo services and portal port
+set config_server_port=8080
+set admin_server_port=8090
+set portal_server_port=8070
+
 rem meta server url, different environments should have different meta server addresses
 set dev_meta="http://localhost:8080"
 set fat_meta="http://someIp:8080"
@@ -27,13 +33,13 @@ cd ..
 rem package config-service and admin-service
 echo "==== starting to build config-service and admin-service ===="
 
-call mvn clean package -DskipTests -pl apollo-configservice,apollo-adminservice -am -Dapollo_profile=github -Dspring_datasource_url=%apollo_config_db_url% -Dspring_datasource_username=%apollo_config_db_username% -Dspring_datasource_password=%apollo_config_db_password%
+call mvn clean package -DskipTests -pl apollo-configservice,apollo-adminservice -am -Dconfig_server_port=$config_server_port -Dadmin_server_port=$admin_server_port -Dapollo_profile=github -Dspring_datasource_url=%apollo_config_db_url% -Dspring_datasource_username=%apollo_config_db_username% -Dspring_datasource_password=%apollo_config_db_password%
 
 echo "==== building config-service and admin-service finished ===="
 
 echo "==== starting to build portal ===="
 
-call mvn clean package -DskipTests -pl apollo-portal -am -Dapollo_profile=github,auth -Dspring_datasource_url=%apollo_portal_db_url% -Dspring_datasource_username=%apollo_portal_db_username% -Dspring_datasource_password=%apollo_portal_db_password% %META_SERVERS_OPTS%
+call mvn clean package -DskipTests -pl apollo-portal -am -Dserver_port=$portal_server_port -Dapollo_profile=github,auth -Dspring_datasource_url=%apollo_portal_db_url% -Dspring_datasource_username=%apollo_portal_db_username% -Dspring_datasource_password=%apollo_portal_db_password% %META_SERVERS_OPTS%
 
 echo "==== building portal finished ===="
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -10,11 +10,16 @@ apollo_portal_db_url=jdbc:mysql://fill-in-the-correct-server:3306/ApolloPortalDB
 apollo_portal_db_username=FillInCorrectUser
 apollo_portal_db_password=FillInCorrectPassword
 
+# apollo services and portal port
+config_server_port=8080
+admin_server_port=8090
+portal_server_port=8070
+
 # meta server url, different environments should have different meta server addresses
-dev_meta=http://fill-in-dev-meta-server:8080
-fat_meta=http://fill-in-fat-meta-server:8080
-uat_meta=http://fill-in-uat-meta-server:8080
-pro_meta=http://fill-in-pro-meta-server:8080
+dev_meta=http://fill-in-dev-meta-server:$config_server_port
+fat_meta=http://fill-in-fat-meta-server:$config_server_port
+uat_meta=http://fill-in-uat-meta-server:$config_server_port
+pro_meta=http://fill-in-pro-meta-server:$config_server_port
 
 META_SERVERS_OPTS="-Ddev_meta=$dev_meta -Dfat_meta=$fat_meta -Duat_meta=$uat_meta -Dpro_meta=$pro_meta"
 
@@ -27,12 +32,12 @@ cd ..
 # package config-service and admin-service
 echo "==== starting to build config-service and admin-service ===="
 
-mvn clean package -DskipTests -pl apollo-configservice,apollo-adminservice -am -Dapollo_profile=github -Dspring_datasource_url=$apollo_config_db_url -Dspring_datasource_username=$apollo_config_db_username -Dspring_datasource_password=$apollo_config_db_password
+mvn clean package -DskipTests -pl apollo-configservice,apollo-adminservice -am -Dconfig_server_port=$config_server_port -Dadmin_server_port=$admin_server_port -Dapollo_profile=github -Dspring_datasource_url=$apollo_config_db_url -Dspring_datasource_username=$apollo_config_db_username -Dspring_datasource_password=$apollo_config_db_password
 
 echo "==== building config-service and admin-service finished ===="
 
 echo "==== starting to build portal ===="
 
-mvn clean package -DskipTests -pl apollo-portal -am -Dapollo_profile=github,auth -Dspring_datasource_url=$apollo_portal_db_url -Dspring_datasource_username=$apollo_portal_db_username -Dspring_datasource_password=$apollo_portal_db_password $META_SERVERS_OPTS
+mvn clean package -DskipTests -pl apollo-portal -am -Dserver_port=$portal_server_port -Dapollo_profile=github,auth -Dspring_datasource_url=$apollo_portal_db_url -Dspring_datasource_username=$apollo_portal_db_username -Dspring_datasource_password=$apollo_portal_db_password $META_SERVERS_OPTS
 
 echo "==== building portal finished ===="


### PR DESCRIPTION
个人愚见：觉得port放在各个项目的startup.sh里，改起来不方便，要改3个startup.sh和build.sh几个文件，并且要相互对应
我的做法：
1. build.sh/build.bat里加上3个端口配置参数，并在package命令上加上-Dxxx_server_port参数
2. application.yml里的server.port改为${xxx_server_port}
3. startup.sh里的SERVER_PORT参数的默认值改为-1。启动时如果SERVER_PORT=-1，不拼接-Dserver.port=$SERVER_PORT参数，此时启动端口即用到build.sh里设置的-Dxxx_server_port参数；如果有，则拼接，即以环境变量SERVER_PORT启动服务
4. 如果SERVER_PORT来源于build.sh中设置参数，服务检测SERVER_URL中要用到的端口由pid获取

PS:
1. build.sh中端口设置端口，打包，启动服务，已测试可以按配置端口启动服务
2. 环境变量SERVER_PORT优先级高于build.sh中的端口设置，已通过设置环境变量测试。改动应该对docker启动也有影响，未测（docker初学，见谅）。
3. shell脚本实在不熟，都是依葫芦画瓢，反复重试才测通，如见非常写法请轻批。
4. 想常年浪迹github，第一次pull request。