### PR TITLE
Spring集成支持application.properties 修复gson解析时间报错 ConfigService支持获取有序Config

### DIFF
--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/ConfigService.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/ConfigService.java
@@ -6,6 +6,8 @@ import com.ctrip.framework.apollo.core.enums.ConfigFileFormat;
 import com.ctrip.framework.apollo.internals.ConfigManager;
 import com.ctrip.framework.apollo.spi.ConfigFactory;
 import com.ctrip.framework.apollo.spi.ConfigRegistry;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Entry point for client config use
@@ -17,6 +19,16 @@ public class ConfigService {
 
   private volatile ConfigManager m_configManager;
   private volatile ConfigRegistry m_configRegistry;
+
+  private static List<Config> configs = new ArrayList<>();
+
+  /**
+   * get namespaces
+   * @return
+   */
+  public static List<Config>  getConfigs(){
+    return configs;
+  }
 
   private ConfigManager getManager() {
     if (m_configManager == null) {
@@ -50,6 +62,23 @@ public class ConfigService {
   public static Config getAppConfig() {
     return getConfig(ConfigConsts.NAMESPACE_APPLICATION);
   }
+
+  /**
+   * Get the config instance for the namespace.
+   * add namespace to list in order
+   *
+   * @param namespace the namespace of the config
+   * @return config instance
+   */
+  public static Config getConfig2(String namespace) {
+
+    Config config = s_instance.getManager().getConfig(namespace);
+    if(config != null){
+      configs.add(config);
+    }
+    return config;
+  }
+
 
   /**
    * Get the config instance for the namespace.

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/boot/ApolloApplicationContextInitializer.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/boot/ApolloApplicationContextInitializer.java
@@ -101,7 +101,7 @@ public class ApolloApplicationContextInitializer implements
 
     CompositePropertySource composite = new CompositePropertySource(PropertySourcesConstants.APOLLO_BOOTSTRAP_PROPERTY_SOURCE_NAME);
     for (String namespace : namespaceList) {
-      Config config = ConfigService.getConfig(namespace);
+      Config config = ConfigService.getConfig2(namespace);
 
       composite.addPropertySource(configPropertySourceFactory.getConfigPropertySource(namespace, config));
     }

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/config/PropertySourcesProcessor.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/config/PropertySourcesProcessor.java
@@ -73,7 +73,7 @@ public class PropertySourcesProcessor implements BeanFactoryPostProcessor, Envir
     while (iterator.hasNext()) {
       int order = iterator.next();
       for (String namespace : NAMESPACE_NAMES.get(order)) {
-        Config config = ConfigService.getConfig(namespace);
+        Config config = ConfigService.getConfig2(namespace);
 
         composite.addPropertySource(configPropertySourceFactory.getConfigPropertySource(namespace, config));
       }

--- a/apollo-core/src/main/java/com/ctrip/framework/apollo/core/ConfigConsts.java
+++ b/apollo-core/src/main/java/com/ctrip/framework/apollo/core/ConfigConsts.java
@@ -9,4 +9,5 @@ public interface ConfigConsts {
   String CONFIG_FILE_CONTENT_KEY = "content";
   String NO_APPID_PLACEHOLDER = "ApolloNoAppIdPlaceHolder";
   long NOTIFICATION_ID_PLACEHOLDER = -1;
+  String APPLICATION_CLASSPATH = "/application.properties";
 }

--- a/apollo-core/src/main/java/com/ctrip/framework/foundation/internals/provider/DefaultApplicationProvider.java
+++ b/apollo-core/src/main/java/com/ctrip/framework/foundation/internals/provider/DefaultApplicationProvider.java
@@ -1,5 +1,6 @@
 package com.ctrip.framework.foundation.internals.provider;
 
+import com.ctrip.framework.apollo.core.ConfigConsts;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
@@ -16,6 +17,9 @@ import com.ctrip.framework.foundation.spi.provider.Provider;
 public class DefaultApplicationProvider implements ApplicationProvider {
   private static final Logger logger = LoggerFactory.getLogger(DefaultApplicationProvider.class);
   public static final String APP_PROPERTIES_CLASSPATH = "/META-INF/app.properties";
+
+  private static String PROPERTIES_PATH = APP_PROPERTIES_CLASSPATH;
+
   private Properties m_appProperties = new Properties();
 
   private String m_appId;
@@ -26,6 +30,13 @@ public class DefaultApplicationProvider implements ApplicationProvider {
       InputStream in = Thread.currentThread().getContextClassLoader().getResourceAsStream(APP_PROPERTIES_CLASSPATH);
       if (in == null) {
         in = DefaultApplicationProvider.class.getResourceAsStream(APP_PROPERTIES_CLASSPATH);
+      }
+      if(in == null){
+        in = Thread.currentThread().getContextClassLoader().getResourceAsStream(ConfigConsts.APPLICATION_CLASSPATH);
+        if (in == null) {
+          in = DefaultApplicationProvider.class.getResourceAsStream(ConfigConsts.APPLICATION_CLASSPATH);
+        }
+        PROPERTIES_PATH = ConfigConsts.APPLICATION_CLASSPATH;
       }
 
       initialize(in);
@@ -98,12 +109,12 @@ public class DefaultApplicationProvider implements ApplicationProvider {
     m_appId = m_appProperties.getProperty("app.id");
     if (!Utils.isBlank(m_appId)) {
       m_appId = m_appId.trim();
-      logger.info("App ID is set to {} by app.id property from {}", m_appId, APP_PROPERTIES_CLASSPATH);
+      logger.info("App ID is set to {} by app.id property from {}", m_appId, PROPERTIES_PATH);
       return;
     }
 
     m_appId = null;
-    logger.warn("app.id is not available from System Property and {}. It is set to null", APP_PROPERTIES_CLASSPATH);
+    logger.warn("app.id is not available from System Property and {}. It is set to null", PROPERTIES_PATH);
   }
 
   @Override

--- a/apollo-core/src/main/java/com/ctrip/framework/foundation/internals/provider/DefaultServerProvider.java
+++ b/apollo-core/src/main/java/com/ctrip/framework/foundation/internals/provider/DefaultServerProvider.java
@@ -1,5 +1,6 @@
 package com.ctrip.framework.foundation.internals.provider;
 
+import com.ctrip.framework.apollo.core.ConfigConsts;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
@@ -18,6 +19,7 @@ public class DefaultServerProvider implements ServerProvider {
   private static final Logger logger = LoggerFactory.getLogger(DefaultServerProvider.class);
   private static final String SERVER_PROPERTIES_LINUX = "/opt/settings/server.properties";
   private static final String SERVER_PROPERTIES_WINDOWS = "C:/opt/settings/server.properties";
+  private static String PROPERTIES_PATH = "";
 
   private String m_env;
   private String m_dc;
@@ -28,6 +30,7 @@ public class DefaultServerProvider implements ServerProvider {
   public void initialize() {
     try {
       String path = Utils.isOSWindows() ? SERVER_PROPERTIES_WINDOWS : SERVER_PROPERTIES_LINUX;
+      PROPERTIES_PATH = path;
 
       File file = new File(path);
       if (file.exists() && file.canRead()) {
@@ -36,8 +39,13 @@ public class DefaultServerProvider implements ServerProvider {
         initialize(fis);
         return;
       }
-
-      initialize(null);
+      InputStream in = Thread.currentThread().getContextClassLoader().getResourceAsStream(
+              ConfigConsts.APPLICATION_CLASSPATH);
+      if (in == null) {
+        in = DefaultServerProvider.class.getResourceAsStream(ConfigConsts.APPLICATION_CLASSPATH);
+      }
+      PROPERTIES_PATH = ConfigConsts.APPLICATION_CLASSPATH;
+      initialize(in);
     } catch (Throwable ex) {
       logger.error("Initialize DefaultServerProvider failed.", ex);
     }
@@ -151,7 +159,7 @@ public class DefaultServerProvider implements ServerProvider {
     m_dc = m_serverProperties.getProperty("idc");
     if (!Utils.isBlank(m_dc)) {
       m_dc = m_dc.trim();
-      logger.info("Data Center is set to [{}] by property 'idc' in server.properties.", m_dc);
+      logger.info("Data Center is set to [{}] by property 'idc' in {}.", m_dc, PROPERTIES_PATH);
       return;
     }
 

--- a/apollo-openapi/src/main/java/com/ctrip/framework/apollo/openapi/client/constant/ApolloOpenApiConstants.java
+++ b/apollo-openapi/src/main/java/com/ctrip/framework/apollo/openapi/client/constant/ApolloOpenApiConstants.java
@@ -4,6 +4,6 @@ public interface ApolloOpenApiConstants {
   int DEFAULT_CONNECT_TIMEOUT = 1000; //1 second
   int DEFAULT_READ_TIMEOUT = 5000; //5 seconds
   String OPEN_API_V1_PREFIX = "/openapi/v1";
-  String JSON_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ssZ";
+  String JSON_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
 
 }


### PR DESCRIPTION
1、优化配置文件读取，app和server配置支持application.properties
2、修改openApi gson解析时间格式报异常问题
3、ConfigService可以获取全部Configs，并按序排列