### PR TITLE
spring集成方式appid等配置支持application.properties文件

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,8 @@ The project is licensed under the [Apache 2 license](https://github.com/ctripcor
 ![实习僧](https://raw.githubusercontent.com/ctripcorp/apollo-community/master/images/known-users/xiaoyuanzhao.png) 
 ![达令家](https://raw.githubusercontent.com/ctripcorp/apollo-community/master/images/known-users/dalingjia.png) 
 ![寺库](https://raw.githubusercontent.com/ctripcorp/apollo-community/master/images/known-users/secoo.png) 
+![连连支付](https://raw.githubusercontent.com/ctripcorp/apollo-community/master/images/known-users/lianlianpay.png) 
+![众安保险](https://raw.githubusercontent.com/ctripcorp/apollo-community/master/images/known-users/zhongan.png) 
 
 # Awards
 

--- a/apollo-core/src/test/java/com/ctrip/framework/apollo/core/utils/ByteUtilTest.java
+++ b/apollo-core/src/test/java/com/ctrip/framework/apollo/core/utils/ByteUtilTest.java
@@ -1,0 +1,38 @@
+package com.ctrip.framework.apollo.core.utils;
+
+import com.ctrip.framework.apollo.core.utils.ByteUtil;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ByteUtilTest {
+
+  @Test
+  public void testInt3() {
+    Assert.assertEquals((byte)0, ByteUtil.int3(0));
+    Assert.assertEquals((byte)0, ByteUtil.int3(1));
+  }
+
+  @Test
+  public void testInt2() {
+    Assert.assertEquals((byte)0, ByteUtil.int2(0));
+    Assert.assertEquals((byte)0, ByteUtil.int2(1));
+  }
+
+  @Test
+  public void testInt1() {
+    Assert.assertEquals((byte)0, ByteUtil.int1(0));
+    Assert.assertEquals((byte)0, ByteUtil.int1(1));
+  }
+
+  @Test
+  public void testInt0() {
+    Assert.assertEquals((byte)0, ByteUtil.int0(0));
+    Assert.assertEquals((byte)1, ByteUtil.int0(1));
+  }
+
+  @Test
+  public void testToHexString() {
+    Assert.assertEquals("", ByteUtil.toHexString(new byte[] {}));
+    Assert.assertEquals("98", ByteUtil.toHexString(new byte[] {(byte)-104}));
+  }
+}


### PR DESCRIPTION
和springboot一样支持application.properties配置文件，在原有app.properties和server.properties基础上文件中的配置也可以放在项目常用的application.properties配置文件