### PR TITLE
add prometheus integration.

### DIFF
--- a/apollo-common/pom.xml
+++ b/apollo-common/pom.xml
@@ -61,12 +61,7 @@
             <artifactId>commons-lang</artifactId>
         </dependency>
 
-        <!-- Spring boot actuator to expose metrics endpoint -->
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-actuator</artifactId>
-        </dependency>
-        <!-- Micormeter core dependecy -->
+        <!-- Micrometer core dependecy -->
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-core</artifactId>

--- a/apollo-common/pom.xml
+++ b/apollo-common/pom.xml
@@ -60,5 +60,20 @@
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
         </dependency>
+
+        <!-- Spring boot actuator to expose metrics endpoint -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <!-- Micormeter core dependecy -->
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/apollo-common/src/main/java/com/ctrip/framework/apollo/common/controller/WebMvcConfig.java
+++ b/apollo-common/src/main/java/com/ctrip/framework/apollo/common/controller/WebMvcConfig.java
@@ -27,7 +27,6 @@ public class WebMvcConfig implements WebMvcConfigurer, WebServerFactoryCustomize
   @Override
   public void configureContentNegotiation(ContentNegotiationConfigurer configurer) {
     configurer.favorPathExtension(false);
-    //configurer.ignoreAcceptHeader(true).defaultContentType(MediaType.APPLICATION_JSON_UTF8);
   }
 
   @Override

--- a/apollo-common/src/main/java/com/ctrip/framework/apollo/common/controller/WebMvcConfig.java
+++ b/apollo-common/src/main/java/com/ctrip/framework/apollo/common/controller/WebMvcConfig.java
@@ -1,18 +1,16 @@
 package com.ctrip.framework.apollo.common.controller;
 
+import java.util.List;
 import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
 import org.springframework.boot.web.server.MimeMappings;
 import org.springframework.boot.web.server.WebServerFactoryCustomizer;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
-import org.springframework.http.MediaType;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.ContentNegotiationConfigurer;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-
-import java.util.List;
 
 @Configuration
 public class WebMvcConfig implements WebMvcConfigurer, WebServerFactoryCustomizer<TomcatServletWebServerFactory> {
@@ -29,7 +27,7 @@ public class WebMvcConfig implements WebMvcConfigurer, WebServerFactoryCustomize
   @Override
   public void configureContentNegotiation(ContentNegotiationConfigurer configurer) {
     configurer.favorPathExtension(false);
-    configurer.ignoreAcceptHeader(true).defaultContentType(MediaType.APPLICATION_JSON_UTF8);
+    //configurer.ignoreAcceptHeader(true).defaultContentType(MediaType.APPLICATION_JSON_UTF8);
   }
 
   @Override

--- a/apollo-common/src/main/resources/application.properties
+++ b/apollo-common/src/main/resources/application.properties
@@ -19,5 +19,3 @@ logging.file.max-size=50MB
 logging.file.max-history=10
 
 management.endpoints.web.exposure.include=info,health,metrics,prometheus
-management.endpoint.metrics.enabled=true
-management.endpoint.prometheus.enabled=true

--- a/apollo-common/src/main/resources/application.properties
+++ b/apollo-common/src/main/resources/application.properties
@@ -18,4 +18,6 @@ management.endpoints.web.base-path=/
 logging.file.max-size=50MB
 logging.file.max-history=10
 
-management.endpoints.web.exposure.include=*
+management.endpoints.web.exposure.include=info,health,metrics,prometheus
+management.endpoint.metrics.enabled=true
+management.endpoint.prometheus.enabled=true

--- a/apollo-common/src/main/resources/application.properties
+++ b/apollo-common/src/main/resources/application.properties
@@ -17,3 +17,5 @@ server.max-http-header-size=10240
 management.endpoints.web.base-path=/
 logging.file.max-size=50MB
 logging.file.max-history=10
+
+management.endpoints.web.exposure.include=*

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/configuration/AuthConfiguration.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/configuration/AuthConfiguration.java
@@ -271,7 +271,7 @@ public class AuthConfiguration {
       http.csrf().disable();
       http.headers().frameOptions().sameOrigin();
       http.authorizeRequests()
-          .antMatchers("/openapi/**", "/vendor/**", "/styles/**", "/scripts/**", "/views/**", "/img/**").permitAll()
+          .antMatchers("/prometheus/**","/metrics/**","/openapi/**", "/vendor/**", "/styles/**", "/scripts/**", "/views/**", "/img/**").permitAll()
           .antMatchers("/**").hasAnyRole(USER_ROLE);
       http.formLogin().loginPage("/signin").permitAll().failureUrl("/signin?#/error").and().httpBasic();
       SimpleUrlLogoutSuccessHandler urlLogoutHandler = new SimpleUrlLogoutSuccessHandler();

--- a/apollo-portal/src/main/resources/application.yml
+++ b/apollo-portal/src/main/resources/application.yml
@@ -22,6 +22,6 @@ logging:
 management:
   health:
     status:
-      order: DOWN, OUT_OF_SERVICE, UNKNOWN, UP 
+      order: DOWN, OUT_OF_SERVICE, UNKNOWN, UP
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -362,21 +362,6 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
-
-		<!-- Spring boot actuator to expose metrics endpoint -->
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-actuator</artifactId>
-		</dependency>
-		<!-- Micormeter core dependecy -->
-		<dependency>
-			<groupId>io.micrometer</groupId>
-			<artifactId>micrometer-core</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>io.micrometer</groupId>
-			<artifactId>micrometer-registry-prometheus</artifactId>
-		</dependency>
 	</dependencies>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -362,6 +362,21 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
+
+		<!-- Spring boot actuator to expose metrics endpoint -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+		<!-- Micormeter core dependecy -->
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-registry-prometheus</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
support https://github.com/ctripcorp/apollo/issues/2489

- Exposed prometheus API: `/prometheus`  in Apollo-ConfigService, Apollo-Adminservice,Apollo-Portal modules.
  e.g.
  - localhost:8080/prometheus
  - localhost:8090/prometheus
  - localhost:8070/prometheus

- How to use: https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#production-ready-metrics-export-prometheus