### PR TITLE
DefaultApplicationProvider 在加载/META-INF/app.properties 文件时代码优化

### DIFF
--- a/apollo-core/src/main/java/com/ctrip/framework/foundation/internals/provider/DefaultApplicationProvider.java
+++ b/apollo-core/src/main/java/com/ctrip/framework/foundation/internals/provider/DefaultApplicationProvider.java
@@ -23,7 +23,7 @@ public class DefaultApplicationProvider implements ApplicationProvider {
   @Override
   public void initialize() {
     try {
-      InputStream in = Thread.currentThread().getContextClassLoader().getResourceAsStream(APP_PROPERTIES_CLASSPATH);
+      InputStream in = Thread.currentThread().getContextClassLoader().getResourceAsStream(APP_PROPERTIES_CLASSPATH.substring(1));
       if (in == null) {
         in = DefaultApplicationProvider.class.getResourceAsStream(APP_PROPERTIES_CLASSPATH);
       }


### PR DESCRIPTION
` InputStream in = Thread.currentThread().getContextClassLoader().getResourceAsStream(APP_PROPERTIES_CLASSPATH);
      if (in == null) {
        in = DefaultApplicationProvider.class.getResourceAsStream(APP_PROPERTIES_CLASSPATH);
      }`

DefaultApplicationProvider 在加载/META-INF/app.properties ,在使用contextClassLoader加载时，应该讲前缀"/"去除，否则加载到的结果为null，只能使用DefaultApplicationProvider.class.进行加载。

修改完成后，运行：
com.ctrip.framework.foundation.internals.provider.DefaultApplicationProviderTest#testLoadAppProperties ，结果OK

具体issue:
https://github.com/ctripcorp/apollo/issues/2508