### PR TITLE
修复App创建时没有分配ManageAppMaster权限

### DIFF
--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/controller/PermissionController.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/controller/PermissionController.java
@@ -322,7 +322,7 @@ public class PermissionController {
     roleInitializationService.initManageAppMasterRole(appId, userInfoHolder.getUser().getUserId());
     Set<String> userIds = new HashSet<>();
     userIds.add(userId);
-    rolePermissionService.assignRoleToUsers(RoleUtils.buildManageAppMasterRoleName(PermissionType.MANAGE_APP_MASTER, appId),
+    rolePermissionService.assignRoleToUsers(RoleUtils.buildCreateApplicationRoleName(PermissionType.MANAGE_APP_MASTER, appId),
             userIds, userInfoHolder.getUser().getUserId());
     return ResponseEntity.ok().build();
   }
@@ -334,7 +334,7 @@ public class PermissionController {
     roleInitializationService.initManageAppMasterRole(appId, userInfoHolder.getUser().getUserId());
     Set<String> userIds = new HashSet<>();
     userIds.add(userId);
-    rolePermissionService.removeRoleFromUsers(RoleUtils.buildManageAppMasterRoleName(PermissionType.MANAGE_APP_MASTER, appId),
+    rolePermissionService.removeRoleFromUsers(RoleUtils.buildCreateApplicationRoleName(PermissionType.MANAGE_APP_MASTER, appId),
             userIds, userInfoHolder.getUser().getUserId());
     return ResponseEntity.ok().build();
   }

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/defaultimpl/DefaultRoleInitializationService.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/defaultimpl/DefaultRoleInitializationService.java
@@ -56,6 +56,9 @@ public class DefaultRoleInitializationService implements RoleInitializationServi
     rolePermissionService
         .assignRoleToUsers(RoleUtils.buildAppMasterRoleName(appId), Sets.newHashSet(app.getOwnerName()),
             operator);
+    rolePermissionService
+        .assignRoleToUsers(RoleUtils.buildCreateApplicationRoleName(PermissionType.MANAGE_APP_MASTER, appId), Sets.newHashSet(app.getOwnerName()),
+            operator);
 
     initNamespaceRoles(appId, ConfigConsts.NAMESPACE_APPLICATION, operator);
     initNamespaceEnvRoles(appId, ConfigConsts.NAMESPACE_APPLICATION, operator);
@@ -130,7 +133,7 @@ public class DefaultRoleInitializationService implements RoleInitializationServi
   private void createManageAppMasterRole(String appId, String operator) {
     Permission permission = createPermission(appId, PermissionType.MANAGE_APP_MASTER, operator);
     rolePermissionService.createPermission(permission);
-    Role role = createRole(RoleUtils.buildManageAppMasterRoleName(PermissionType.MANAGE_APP_MASTER, appId), operator);
+    Role role = createRole(RoleUtils.buildCreateApplicationRoleName(PermissionType.MANAGE_APP_MASTER, appId), operator);
     Set<Long> permissionIds = new HashSet<>();
     permissionIds.add(permission.getId());
     rolePermissionService.createRoleWithPermissions(role, permissionIds);
@@ -139,7 +142,7 @@ public class DefaultRoleInitializationService implements RoleInitializationServi
   // fix historical data
   @Transactional
   public void initManageAppMasterRole(String appId, String operator) {
-    String manageAppMasterRoleName = RoleUtils.buildManageAppMasterRoleName(PermissionType.MANAGE_APP_MASTER, appId);
+    String manageAppMasterRoleName = RoleUtils.buildCreateApplicationRoleName(PermissionType.MANAGE_APP_MASTER, appId);
     if (rolePermissionService.findRoleByRoleName(manageAppMasterRoleName) != null) {
       return;
     }

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/util/RoleUtils.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/util/RoleUtils.java
@@ -89,8 +89,4 @@ public class RoleUtils {
   public static String buildCreateApplicationRoleName(String permissionType, String permissionTargetId) {
     return STRING_JOINER.join(permissionType, permissionTargetId);
   }
-
-  public static String buildManageAppMasterRoleName(String permissionType, String permissionTargetId) {
-    return STRING_JOINER.join(permissionType, permissionTargetId);
-  }
 }


### PR DESCRIPTION
修复 https://github.com/ctripcorp/apollo/pull/2309 的bug

创建App后Owner不属于ManageAppMaster角色，造成人员不能管理项目管理员

随便删除重复方法，buildManageAppMasterRoleName和buildCreateApplicationRoleName重复了

![image](https://user-images.githubusercontent.com/3982826/65592320-f3e38580-dfc0-11e9-8800-7b6ada199fb5.png)
