### PR TITLE
fix delete children clusters twice.

### DIFF
--- a/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/service/AdminService.java
+++ b/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/service/AdminService.java
@@ -54,7 +54,7 @@ public class AdminService {
 
     logger.info("{} is deleting App:{}", operator, appId);
 
-    List<Cluster> managedClusters = clusterService.findClusters(appId);
+    List<Cluster> managedClusters = clusterService.findParentClusters(appId);
 
     // 1. delete clusters
     if (Objects.nonNull(managedClusters)) {

--- a/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/service/ClusterService.java
+++ b/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/service/ClusterService.java
@@ -148,9 +148,6 @@ public class ClusterService {
       return Collections.emptyList();
     }
 
-    // to make sure parent cluster is ahead of branch cluster
-    Collections.sort(clusters);
-
     return clusters;
   }
 }

--- a/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/service/ClusterService.java
+++ b/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/service/ClusterService.java
@@ -148,6 +148,9 @@ public class ClusterService {
       return Collections.emptyList();
     }
 
+    // to make sure parent cluster is ahead of branch cluster
+    Collections.sort(clusters);
+
     return clusters;
   }
 }


### PR DESCRIPTION
原因: 当parent cluster在列表最前面的时候，循环删除Cluster
      for (Cluster cluster : managedClusters) {
        clusterService.delete(cluster.getId(), operator);
      }
会先删除父Cluster，但是由于删除父Cluster的时候会一起删除子Cluster。导致循环到删除子Cluster的时候会多删除一次。

解决方法: AdminService#deleteApp() 中的 clusterService.findClusters 只在 AdminService中用到 所以我直接把排序去掉了。

tips: ClusterService#delete() 中的 clusterRepository.findById(id).orElse(null);这个方法能查出 isDelete=true 的数据。不知道是数据库问题还是JPA的问题。