### PR TITLE
fix setting null value of property in xml throws NullPointerException

### DIFF
--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/property/PlaceholderHelper.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/property/PlaceholderHelper.java
@@ -4,6 +4,7 @@ import com.google.common.base.Strings;
 import com.google.common.collect.Sets;
 import java.util.Set;
 import java.util.Stack;
+import java.util.Objects;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.BeanExpressionContext;
@@ -65,7 +66,7 @@ public class PlaceholderHelper {
   public Set<String> extractPlaceholderKeys(String propertyString) {
     Set<String> placeholderKeys = Sets.newHashSet();
 
-    if (propertyString == null || (!isNormalizedPlaceholder(propertyString) && !isExpressionWithPlaceholder(propertyString))) {
+    if (Objects.isNull(propertyString) || (!isNormalizedPlaceholder(propertyString) && !isExpressionWithPlaceholder(propertyString))) {
       return placeholderKeys;
     }
 

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/property/PlaceholderHelper.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/property/PlaceholderHelper.java
@@ -65,7 +65,7 @@ public class PlaceholderHelper {
   public Set<String> extractPlaceholderKeys(String propertyString) {
     Set<String> placeholderKeys = Sets.newHashSet();
 
-    if (!isNormalizedPlaceholder(propertyString) && !isExpressionWithPlaceholder(propertyString)) {
+    if (propertyString == null || (!isNormalizedPlaceholder(propertyString) && !isExpressionWithPlaceholder(propertyString))) {
       return placeholderKeys;
     }
 


### PR DESCRIPTION
解决如下问题：
当propertyString==null时，会抛空指针异常NullPointerException。例如：在xml的配置中，如果设置属性值为null， `<property name="manager"></null></property>`，即发生propertyString==null
