### PR TITLE
:sparkles: add order config change listener

### DIFF
--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/ConfigOrderedChangeListener.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/ConfigOrderedChangeListener.java
@@ -1,0 +1,6 @@
+package com.ctrip.framework.apollo;
+
+public interface ConfigOrderedChangeListener extends ConfigChangeListener {
+
+    int order();
+}

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/AbstractConfig.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/AbstractConfig.java
@@ -2,6 +2,7 @@ package com.ctrip.framework.apollo.internals;
 
 import com.ctrip.framework.apollo.Config;
 import com.ctrip.framework.apollo.ConfigChangeListener;
+import com.ctrip.framework.apollo.ConfigOrderedChangeListener;
 import com.ctrip.framework.apollo.build.ApolloInjector;
 import com.ctrip.framework.apollo.core.utils.ApolloThreadFactory;
 import com.ctrip.framework.apollo.enums.PropertyChangeType;
@@ -23,12 +24,7 @@ import com.google.common.collect.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Date;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicLong;
@@ -84,6 +80,17 @@ public abstract class AbstractConfig implements Config {
   public void addChangeListener(ConfigChangeListener listener, Set<String> interestedKeys, Set<String> interestedKeyPrefixes) {
     if (!m_listeners.contains(listener)) {
       m_listeners.add(listener);
+      Collections.sort(m_listeners, new Comparator<ConfigChangeListener>() {
+        @Override
+        public int compare(ConfigChangeListener o1, ConfigChangeListener o2) {
+          if (o1 instanceof ConfigOrderedChangeListener && o2 instanceof ConfigOrderedChangeListener){
+            ConfigOrderedChangeListener configOrderedChangeListener1 = (ConfigOrderedChangeListener) o1;
+            ConfigOrderedChangeListener configOrderedChangeListener2 = (ConfigOrderedChangeListener) o2;
+            return Integer.compare(configOrderedChangeListener1.order(),configOrderedChangeListener2.order());
+          }
+          return 0;
+        }
+      });
       if (interestedKeys != null && !interestedKeys.isEmpty()) {
         m_interestedKeys.put(listener, Sets.newHashSet(interestedKeys));
       }

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/annotation/ApolloConfigChangeListener.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/annotation/ApolloConfigChangeListener.java
@@ -52,4 +52,10 @@ public @interface ApolloConfigChangeListener {
    * If neither of {@code interestedKeys} and {@code interestedKeyPrefixes} is specified then the {@code listener} will be notified when whatever key is changed.
    */
   String[] interestedKeyPrefixes() default {};
+
+  /**
+   * the listener invoked order,lowest is Integer.MAX_VALUE,highest is Integer.MIN_VALUE
+   * @return
+   */
+  int order() default 0;
 }


### PR DESCRIPTION
[issues2671](https://github.com/ctripcorp/apollo/issues/2671) 功能开发
`ApolloConfigChangeListener` 支持 `order` 排序

