### PR TITLE
Fix maven build WARNING

### DIFF
--- a/apollo-portal/pom.xml
+++ b/apollo-portal/pom.xml
@@ -113,7 +113,7 @@
 					</execution>
 				</executions>
 				<configuration>
-					<basedir>${build.directory}</basedir>
+					<basedir>${project.build.directory}</basedir>
 					<includes>
 						<include>classes/static/*.html</include>
 						<include>classes/static/**/*.html</include>


### PR DESCRIPTION
## Environment
- Apache Maven 3.6.1 
- Java version: 1.8.0_181, vendor: Oracle Corporation,

## Problem

When I used `mvn clean compile` to compile source code, there was some WARNING occur.
It is highly recommended to fix these problems because they threaten the stability of your build.
```bash
➜  apollo git:(master) mvn clean compile 
[INFO] Scanning for projects...
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for com.ctrip.framework.apollo:apollo-portal:jar:1.6.0-SNAPSHOT
[WARNING] The expression ${build.directory} is deprecated. Please use ${project.build.directory} instead.
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Build Order:
[INFO] 
[INFO] Apollo                                                             [pom]
[INFO] Apollo BuildTools                                                  [jar]
[INFO] Apollo Core                                                        [jar]
[INFO] Apollo Client                                                      [jar]
[INFO] Apollo Common                                                      [jar]
[INFO] Apollo Biz                                                         [jar]
[INFO] Apollo ConfigService                                               [jar]
[INFO] Apollo AdminService                                                [jar]
[INFO] Apollo Open Api                                                    [jar]
[INFO] Apollo Portal                                                      [jar]
[INFO] Apollo Assembly                                                    [jar]
[INFO] Apollo Demo                                                        [jar]
[INFO] Apollo Mock Server                                                 [jar]
[INFO] 
...

```