### PR TITLE
add feature for dynamic log level change under spring project

### DIFF
--- a/apollo-client/pom.xml
+++ b/apollo-client/pom.xml
@@ -11,7 +11,7 @@
 	<artifactId>apollo-client</artifactId>
 	<name>Apollo Client</name>
 	<properties>
-		<java.version>1.7</java.version>
+		<java.version>1.8</java.version>
 		<github.path>${project.artifactId}</github.path>
 	</properties>
 	<dependencyManagement>

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/listener/LogLevelListener.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/listener/LogLevelListener.java
@@ -1,0 +1,60 @@
+package com.ctrip.framework.apollo.listener;
+
+import com.ctrip.framework.apollo.ConfigChangeListener;
+import com.ctrip.framework.apollo.model.ConfigChange;
+import com.ctrip.framework.apollo.model.ConfigChangeEvent;
+import com.ctrip.framework.apollo.spring.annotation.ApolloConfigChangeListener;
+import org.springframework.boot.logging.LogLevel;
+import org.springframework.boot.logging.LoggingSystem;
+import org.springframework.stereotype.Service;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Created by lawrence on 19/12/16.
+ */
+@Service
+public class LogLevelListener implements ConfigChangeListener {
+    private static final String EMPTY = "";
+    private static final String LOG_PACKAGE_PREFIX = "logging.level.";
+    private static final LoggingSystem loggingSystem = LoggingSystem.get(Thread.currentThread().getContextClassLoader());
+
+    @ApolloConfigChangeListener(interestedKeyPrefixes = LOG_PACKAGE_PREFIX)
+    public void onChange(ConfigChangeEvent configChangeEvent) {
+        refeshLogLevel(configChangeEvent);
+    }
+
+    private void refeshLogLevel(ConfigChangeEvent configChangeEvent) {
+        Set<String> keyNames = configChangeEvent.changedKeys();
+        Map<String, ConfigChange> map = configChangeEvent.getChangeValue();
+        for (String key : keyNames) {
+            String logLevel = map.get(key).getNewValue();
+            if(logLevel.isEmpty()) continue;
+            String packageName = key.replace(LOG_PACKAGE_PREFIX, "");
+            changeLevel(packageName, logLevel);
+        }
+    }
+
+    private void changeLevel(String packageName, String strLevel) {
+        final LogLevel level = LogLevel.valueOf(strLevel.toUpperCase());
+        List<String> names = getLoggerConfigurations();
+        if(names.isEmpty()) return;
+        if (EMPTY.equals(packageName)) {
+            loggingSystem.setLogLevel(EMPTY, level);
+        } else {
+            List<String> enableName = names.stream().filter(entry -> entry.startsWith(packageName)).collect(Collectors.toList());
+            if (enableName.isEmpty() || null == enableName) return;
+            enableName.stream().forEach(item -> {
+                loggingSystem.setLogLevel(item, level);
+            });
+        }
+    }
+
+    private List<String> getLoggerConfigurations() {
+        return loggingSystem.getLoggerConfigurations().
+                stream().map(entry -> entry.getName()).collect(Collectors.toList());
+    }
+}
+

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/model/ConfigChangeEvent.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/model/ConfigChangeEvent.java
@@ -55,4 +55,8 @@ public class ConfigChangeEvent {
   public String getNamespace() {
     return m_namespace;
   }
+
+  public Map<String, ConfigChange> getChangeValue(){
+        return m_changes;
+    }
 }


### PR DESCRIPTION
## What's the purpose of this PR

添加了一个能够在spring项目下动态更新日志级别的功能

## Which issue(s) this PR fixes:
Fixes #
https://github.com/ctripcorp/apollo/issues/2798
https://github.com/ctripcorp/apollo/issues/2482

## Brief changelog

增加了继承ConfigChangeListener的监听器
修改了<java.version>1.8</java.version>
