### PR TITLE
Fixed an issue with openapi item comment being too long。#2823

### DIFF
--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/v1/controller/ItemController.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/v1/controller/ItemController.java
@@ -9,6 +9,7 @@ import com.ctrip.framework.apollo.openapi.dto.OpenItemDTO;
 import com.ctrip.framework.apollo.openapi.util.OpenApiBeanUtils;
 import com.ctrip.framework.apollo.portal.service.ItemService;
 import com.ctrip.framework.apollo.portal.spi.UserService;
+import java.util.Objects;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -60,7 +61,7 @@ public class ItemController {
       throw new BadRequestException("User " + item.getDataChangeCreatedBy() + " doesn't exist!");
     }
 
-    if( (item.getComment() == null ? 0 : item.getComment().length())  > 64){
+    if( (Objects.isNull(item.getComment()) ? 0 : item.getComment().length())  > 64){
       throw new BadRequestException("The item comment length is greater than 64");
     }
 
@@ -97,7 +98,7 @@ public class ItemController {
       throw new BadRequestException("user(dataChangeLastModifiedBy) not exists");
     }
 
-    if( (item.getComment() == null ? 0 : item.getComment().length())  > 64){
+    if( (Objects.isNull(item.getComment()) ? 0 : item.getComment().length())  > 64){
       throw new BadRequestException("The item comment length is greater than 64");
     }
 

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/v1/controller/ItemController.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/v1/controller/ItemController.java
@@ -9,7 +9,6 @@ import com.ctrip.framework.apollo.openapi.dto.OpenItemDTO;
 import com.ctrip.framework.apollo.openapi.util.OpenApiBeanUtils;
 import com.ctrip.framework.apollo.portal.service.ItemService;
 import com.ctrip.framework.apollo.portal.spi.UserService;
-import java.util.Objects;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -61,7 +60,7 @@ public class ItemController {
       throw new BadRequestException("User " + item.getDataChangeCreatedBy() + " doesn't exist!");
     }
 
-    if( (Objects.isNull(item.getComment()) ? 0 : item.getComment().length())  > 64){
+    if( (StringUtils.isEmpty(item.getComment()) ? 0 : item.getComment().length())  > 64){
       throw new BadRequestException("The item comment length is greater than 64");
     }
 
@@ -98,7 +97,7 @@ public class ItemController {
       throw new BadRequestException("user(dataChangeLastModifiedBy) not exists");
     }
 
-    if( (Objects.isNull(item.getComment()) ? 0 : item.getComment().length())  > 64){
+    if( (StringUtils.isEmpty(item.getComment()) ? 0 : item.getComment().length())  > 64){
       throw new BadRequestException("The item comment length is greater than 64");
     }
 

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/v1/controller/ItemController.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/v1/controller/ItemController.java
@@ -60,8 +60,8 @@ public class ItemController {
       throw new BadRequestException("User " + item.getDataChangeCreatedBy() + " doesn't exist!");
     }
 
-    if( (StringUtils.isEmpty(item.getComment()) ? 0 : item.getComment().length())  > 64){
-      throw new BadRequestException("The item comment length is greater than 64");
+    if(!StringUtils.isEmpty(item.getComment()) && item.getComment().length() > 64){
+      throw new BadRequestException("Comment length should not exceed 64 characters");
     }
 
     ItemDTO toCreate = OpenApiBeanUtils.transformToItemDTO(item);
@@ -97,8 +97,8 @@ public class ItemController {
       throw new BadRequestException("user(dataChangeLastModifiedBy) not exists");
     }
 
-    if( (StringUtils.isEmpty(item.getComment()) ? 0 : item.getComment().length())  > 64){
-      throw new BadRequestException("The item comment length is greater than 64");
+    if(!StringUtils.isEmpty(item.getComment()) && item.getComment().length() > 64){
+      throw new BadRequestException("Comment length should not exceed 64 characters");
     }
 
     try {

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/v1/controller/ItemController.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/v1/controller/ItemController.java
@@ -60,6 +60,10 @@ public class ItemController {
       throw new BadRequestException("User " + item.getDataChangeCreatedBy() + " doesn't exist!");
     }
 
+    if( (item.getComment() == null ? 0 : item.getComment().length())  > 64){
+      throw new BadRequestException("The item comment length is greater than 64");
+    }
+
     ItemDTO toCreate = OpenApiBeanUtils.transformToItemDTO(item);
 
     //protect
@@ -91,6 +95,10 @@ public class ItemController {
 
     if (userService.findByUserId(item.getDataChangeLastModifiedBy()) == null) {
       throw new BadRequestException("user(dataChangeLastModifiedBy) not exists");
+    }
+
+    if( (item.getComment() == null ? 0 : item.getComment().length())  > 64){
+      throw new BadRequestException("The item comment length is greater than 64");
     }
 
     try {


### PR DESCRIPTION
通过在openapi的接口中限制item comment的长度。

看了下数据库item表下comment字段能放很长。。
https://github.com/ctripcorp/apollo/blob/ec8ed36479202f35edc1ba7cb6d3ac199040f5d6/scripts/db/migration/configdb/V1.0.0__initialization.sql#L215
但是参考前端的长度限制这里就限制64了。

https://github.com/ctripcorp/apollo/issues/2823