### PR TITLE
Refactor/remove redundant else

### DIFF
--- a/apollo-adminservice/src/main/java/com/ctrip/framework/apollo/adminservice/controller/ItemController.java
+++ b/apollo-adminservice/src/main/java/com/ctrip/framework/apollo/adminservice/controller/ItemController.java
@@ -50,10 +50,9 @@ public class ItemController {
     Item managedEntity = itemService.findOne(appId, clusterName, namespaceName, entity.getKey());
     if (managedEntity != null) {
       throw new BadRequestException("item already exists");
-    } else {
-      entity = itemService.save(entity);
-      builder.createItem(entity);
     }
+    entity = itemService.save(entity);
+    builder.createItem(entity);
     dto = BeanUtils.transform(ItemDTO.class, entity);
 
     Commit commit = new Commit();

--- a/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/service/ItemService.java
+++ b/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/service/ItemService.java
@@ -116,9 +116,8 @@ public class ItemService {
     Namespace namespace = namespaceService.findOne(appId, clusterName, namespaceName);
     if (namespace != null) {
       return findItemsWithOrdered(namespace.getId());
-    } else {
-      return Collections.emptyList();
     }
+    return Collections.emptyList();
   }
 
   public List<Item> findItemsModifiedAfterDate(long namespaceId, Date date) {

--- a/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/service/ItemService.java
+++ b/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/service/ItemService.java
@@ -100,9 +100,8 @@ public class ItemService {
     Namespace namespace = namespaceService.findOne(appId, clusterName, namespaceName);
     if (namespace != null) {
       return findItemsWithoutOrdered(namespace.getId());
-    } else {
-      return Collections.emptyList();
     }
+    return Collections.emptyList();
   }
 
   public List<Item> findItemsWithOrdered(Long namespaceId) {

--- a/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/service/ReleaseService.java
+++ b/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/service/ReleaseService.java
@@ -242,9 +242,8 @@ public class ReleaseService {
     if (parentNamespace != null) {
       return publishBranchNamespace(parentNamespace, namespace, operateNamespaceItems,
               releaseName, releaseComment, operator, isEmergencyPublish, grayDelKeys);
-    }else {
-      throw new NotFoundException("Parent namespace not found");
     }
+    throw new NotFoundException("Parent namespace not found");
   }
 
   private void checkLock(Namespace namespace, boolean isEmergencyPublish, String operator) {

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/util/http/HttpUtil.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/util/http/HttpUtil.java
@@ -119,10 +119,9 @@ public class HttpUtil {
         // 200 and 304 should not trigger IOException, thus we must throw the original exception out
         if (statusCode == 200 || statusCode == 304) {
           throw ex;
-        } else {
-          // for status codes like 404, IOException is expected when calling conn.getInputStream()
-          throw new ApolloConfigStatusCodeException(statusCode, ex);
         }
+        // for status codes like 404, IOException is expected when calling conn.getInputStream()
+        throw new ApolloConfigStatusCodeException(statusCode, ex);
       }
 
       if (statusCode == 200) {

--- a/apollo-common/src/main/java/com/ctrip/framework/apollo/common/datasource/TitanCondition.java
+++ b/apollo-common/src/main/java/com/ctrip/framework/apollo/common/datasource/TitanCondition.java
@@ -12,9 +12,11 @@ public class TitanCondition implements Condition {
   public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
     if (!StringUtils.isEmpty(context.getEnvironment().getProperty("fat.titan.url"))) {
       return true;
-    } else if (!StringUtils.isEmpty(context.getEnvironment().getProperty("uat.titan.url"))) {
+    }
+    if (!StringUtils.isEmpty(context.getEnvironment().getProperty("uat.titan.url"))) {
       return true;
-    } else if (!StringUtils.isEmpty(context.getEnvironment().getProperty("pro.titan.url"))) {
+    }
+    if (!StringUtils.isEmpty(context.getEnvironment().getProperty("pro.titan.url"))) {
       return true;
     }
     return false;

--- a/apollo-core/src/main/java/com/ctrip/framework/foundation/internals/DefaultProviderManager.java
+++ b/apollo-core/src/main/java/com/ctrip/framework/foundation/internals/DefaultProviderManager.java
@@ -44,11 +44,10 @@ public class DefaultProviderManager implements ProviderManager {
 
     if (provider != null) {
       return (T) provider;
-    } else {
-      logger.error("No provider [{}] found in DefaultProviderManager, please make sure it is registered in DefaultProviderManager ",
-          clazz.getName());
-      return (T) NullProviderManager.provider;
     }
+    logger.error("No provider [{}] found in DefaultProviderManager, please make sure it is registered in DefaultProviderManager ",
+        clazz.getName());
+    return (T) NullProviderManager.provider;
   }
 
   @Override

--- a/apollo-core/src/main/java/com/ctrip/framework/foundation/internals/provider/DefaultApplicationProvider.java
+++ b/apollo-core/src/main/java/com/ctrip/framework/foundation/internals/provider/DefaultApplicationProvider.java
@@ -66,10 +66,9 @@ public class DefaultApplicationProvider implements ApplicationProvider {
     if ("app.id".equals(name)) {
       String val = getAppId();
       return val == null ? defaultValue : val;
-    } else {
-      String val = m_appProperties.getProperty(name, defaultValue);
-      return val == null ? defaultValue : val;
     }
+    String val = m_appProperties.getProperty(name, defaultValue);
+    return val == null ? defaultValue : val;
   }
 
   @Override

--- a/apollo-core/src/main/java/com/ctrip/framework/foundation/internals/provider/DefaultNetworkProvider.java
+++ b/apollo-core/src/main/java/com/ctrip/framework/foundation/internals/provider/DefaultNetworkProvider.java
@@ -10,7 +10,8 @@ public class DefaultNetworkProvider implements NetworkProvider {
     if ("host.address".equalsIgnoreCase(name)) {
       String val = getHostAddress();
       return val == null ? defaultValue : val;
-    } else if ("host.name".equalsIgnoreCase(name)) {
+    }
+    if ("host.name".equalsIgnoreCase(name)) {
       String val = getHostName();
       return val == null ? defaultValue : val;
     } else {

--- a/apollo-core/src/main/java/com/ctrip/framework/foundation/internals/provider/DefaultNetworkProvider.java
+++ b/apollo-core/src/main/java/com/ctrip/framework/foundation/internals/provider/DefaultNetworkProvider.java
@@ -14,9 +14,8 @@ public class DefaultNetworkProvider implements NetworkProvider {
     if ("host.name".equalsIgnoreCase(name)) {
       String val = getHostName();
       return val == null ? defaultValue : val;
-    } else {
-      return defaultValue;
     }
+    return defaultValue;
   }
 
   @Override

--- a/apollo-core/src/main/java/com/ctrip/framework/foundation/internals/provider/DefaultServerProvider.java
+++ b/apollo-core/src/main/java/com/ctrip/framework/foundation/internals/provider/DefaultServerProvider.java
@@ -86,13 +86,13 @@ public class DefaultServerProvider implements ServerProvider {
     if ("env".equalsIgnoreCase(name)) {
       String val = getEnvType();
       return val == null ? defaultValue : val;
-    } else if ("dc".equalsIgnoreCase(name)) {
+    }
+    if ("dc".equalsIgnoreCase(name)) {
       String val = getDataCenter();
       return val == null ? defaultValue : val;
-    } else {
-      String val = m_serverProperties.getProperty(name, defaultValue);
-      return val == null ? defaultValue : val.trim();
     }
+    String val = m_serverProperties.getProperty(name, defaultValue);
+    return val == null ? defaultValue : val.trim();
   }
 
   @Override

--- a/apollo-mockserver/src/main/java/com/ctrip/framework/apollo/mockserver/EmbeddedApollo.java
+++ b/apollo-mockserver/src/main/java/com/ctrip/framework/apollo/mockserver/EmbeddedApollo.java
@@ -64,7 +64,8 @@ public class EmbeddedApollo extends ExternalResource {
         if (request.getPath().startsWith("/notifications/v2")) {
           String notifications = request.getRequestUrl().queryParameter("notifications");
           return new MockResponse().setResponseCode(200).setBody(mockLongPollBody(notifications));
-        } else if (request.getPath().startsWith("/configs")) {
+        }
+        if (request.getPath().startsWith("/configs")) {
           List<String> pathSegments = request.getRequestUrl().pathSegments();
           // appId and cluster might be used in the future
           String appId = pathSegments.get(1);

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/component/RetryableRestTemplate.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/component/RetryableRestTemplate.java
@@ -219,10 +219,9 @@ public class RetryableRestTemplate {
       return nestedException instanceof SocketTimeoutException
              || nestedException instanceof HttpHostConnectException
              || nestedException instanceof ConnectTimeoutException;
-    } else {
-      return nestedException instanceof HttpHostConnectException
-             || nestedException instanceof ConnectTimeoutException;
     }
+    return nestedException instanceof HttpHostConnectException
+           || nestedException instanceof ConnectTimeoutException;
   }
 
 }

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/component/emailbuilder/GrayPublishEmailBuilder.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/component/emailbuilder/GrayPublishEmailBuilder.java
@@ -56,23 +56,22 @@ public class GrayPublishEmailBuilder extends ConfigPublishEmailBuilder {
 
     if (CollectionUtils.isEmpty(ruleItems)) {
       return bodyTemplate.replaceAll(EMAIL_CONTENT_GRAY_RULES_MODULE, "<br><h4>无灰度规则</h4>");
-    } else {
-      StringBuilder rulesHtmlBuilder = new StringBuilder();
-      for (GrayReleaseRuleItemDTO ruleItem : ruleItems) {
-        String clientAppId = ruleItem.getClientAppId();
-        Set<String> ips = ruleItem.getClientIpList();
-
-        rulesHtmlBuilder.append("<b>AppId:&nbsp;</b>")
-                .append(clientAppId)
-                .append("&nbsp;&nbsp; <b>IP:&nbsp;</b>");
-
-        IP_JOINER.appendTo(rulesHtmlBuilder, ips);
-      }
-      String grayRulesModuleContent = portalConfig.emailGrayRulesModuleTemplate().replaceAll(EMAIL_CONTENT_GRAY_RULES_CONTENT,
-              Matcher.quoteReplacement(rulesHtmlBuilder.toString()));
-
-      return bodyTemplate.replaceAll(EMAIL_CONTENT_GRAY_RULES_MODULE, Matcher.quoteReplacement(grayRulesModuleContent));
     }
+    StringBuilder rulesHtmlBuilder = new StringBuilder();
+    for (GrayReleaseRuleItemDTO ruleItem : ruleItems) {
+      String clientAppId = ruleItem.getClientAppId();
+      Set<String> ips = ruleItem.getClientIpList();
+
+      rulesHtmlBuilder.append("<b>AppId:&nbsp;</b>")
+              .append(clientAppId)
+              .append("&nbsp;&nbsp; <b>IP:&nbsp;</b>");
+
+      IP_JOINER.appendTo(rulesHtmlBuilder, ips);
+    }
+    String grayRulesModuleContent = portalConfig.emailGrayRulesModuleTemplate().replaceAll(EMAIL_CONTENT_GRAY_RULES_CONTENT,
+            Matcher.quoteReplacement(rulesHtmlBuilder.toString()));
+
+    return bodyTemplate.replaceAll(EMAIL_CONTENT_GRAY_RULES_MODULE, Matcher.quoteReplacement(grayRulesModuleContent));
 
   }
 }

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/controller/AppController.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/controller/AppController.java
@@ -75,9 +75,8 @@ public class AppController {
   public List<App> findApps(@RequestParam(value = "appIds", required = false) String appIds) {
     if (StringUtils.isEmpty(appIds)) {
       return appService.findAll();
-    } else {
-      return appService.findByAppIds(Sets.newHashSet(appIds.split(",")));
     }
+    return appService.findByAppIds(Sets.newHashSet(appIds.split(",")));
   }
 
   @GetMapping("/search/by-appid-or-name")
@@ -85,9 +84,8 @@ public class AppController {
       Pageable pageable) {
     if (StringUtils.isEmpty(query)) {
       return appService.findAll(pageable);
-    } else {
-      return appService.searchByAppIdOrAppName(query, pageable);
     }
+    return appService.searchByAppIdOrAppName(query, pageable);
   }
 
   @GetMapping("/by-owner")

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/controller/ConsumerController.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/controller/ConsumerController.java
@@ -86,33 +86,32 @@ public class ConsumerController {
     }
     if (Objects.equals("AppRole", type)) {
       return Collections.singletonList(consumerService.assignAppRoleToConsumer(token, appId));
-    } else {
-      if (StringUtils.isEmpty(namespaceName)) {
-        throw new BadRequestException("Params(NamespaceName) can not be empty.");
-      }
-      if (null != envs){
-        String[] envArray = envs.split(",");
-        List<String> envList = Lists.newArrayList();
-        // validate env parameter
-        for (String env : envArray) {
-          if (Strings.isNullOrEmpty(env)) {
-            continue;
-          }
-          if (Env.UNKNOWN == EnvUtils.transformEnv(env)) {
-            throw new BadRequestException(String.format("env: %s is illegal", env));
-          }
-          envList.add(env);
-        }
-
-        List<ConsumerRole> consumeRoles = new ArrayList<>();
-        for (String env : envList) {
-          consumeRoles.addAll(consumerService.assignNamespaceRoleToConsumer(token, appId, namespaceName, env));
-        }
-        return consumeRoles;
-      }
-
-      return consumerService.assignNamespaceRoleToConsumer(token, appId, namespaceName);
     }
+    if (StringUtils.isEmpty(namespaceName)) {
+      throw new BadRequestException("Params(NamespaceName) can not be empty.");
+    }
+    if (null != envs){
+      String[] envArray = envs.split(",");
+      List<String> envList = Lists.newArrayList();
+      // validate env parameter
+      for (String env : envArray) {
+        if (Strings.isNullOrEmpty(env)) {
+          continue;
+        }
+        if (Env.UNKNOWN == EnvUtils.transformEnv(env)) {
+          throw new BadRequestException(String.format("env: %s is illegal", env));
+        }
+        envList.add(env);
+      }
+
+      List<ConsumerRole> consumeRoles = new ArrayList<>();
+      for (String env : envList) {
+        consumeRoles.addAll(consumerService.assignNamespaceRoleToConsumer(token, appId, namespaceName, env));
+      }
+      return consumeRoles;
+    }
+
+    return consumerService.assignNamespaceRoleToConsumer(token, appId, namespaceName);
   }
 
 

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/controller/ItemController.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/controller/ItemController.java
@@ -194,8 +194,7 @@ public class ItemController {
       configService.syncItems(model.getSyncToNamespaces(), model.getSyncItems());
       return ResponseEntity.status(HttpStatus.OK).build();
     }
-    else
-      throw new AccessDeniedException(String.format("You don't have the permission to modify environment: %s", envNoPermission));
+    throw new AccessDeniedException(String.format("You don't have the permission to modify environment: %s", envNoPermission));
   }
 
   @PreAuthorize(value = "@permissionValidator.hasModifyNamespacePermission(#appId, #namespaceName, #env)")

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/controller/ServerConfigController.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/controller/ServerConfigController.java
@@ -40,11 +40,11 @@ public class ServerConfigController {
       serverConfig.setDataChangeLastModifiedBy(modifiedBy);
       serverConfig.setId(0L);//为空，设置ID 为0，jpa执行新增操作
       return serverConfigRepository.save(serverConfig);
-    } else {//update
-      BeanUtils.copyEntityProperties(serverConfig, storedConfig);
-      storedConfig.setDataChangeLastModifiedBy(modifiedBy);
-      return serverConfigRepository.save(storedConfig);
     }
+    //update
+    BeanUtils.copyEntityProperties(serverConfig, storedConfig);
+    storedConfig.setDataChangeLastModifiedBy(modifiedBy);
+    return serverConfigRepository.save(storedConfig);
   }
 
   @PreAuthorize(value = "@permissionValidator.isSuperAdmin()")

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/entity/bo/UserInfo.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/entity/bo/UserInfo.java
@@ -48,9 +48,8 @@ public class UserInfo {
 
       UserInfo anotherUser = (UserInfo) o;
       return userId.equals(anotherUser.userId);
-    } else {
-      return false;
     }
+    return false;
 
   }
 }

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/listener/ConfigPublishListener.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/listener/ConfigPublishListener.java
@@ -101,9 +101,8 @@ public class ConfigPublishListener {
       if (publishInfo.isRollbackEvent()) {
         return releaseHistoryService
             .findLatestByPreviousReleaseIdAndOperation(env, publishInfo.getPreviousReleaseId(), operation);
-      } else {
-        return releaseHistoryService.findLatestByReleaseIdAndOperation(env, publishInfo.getReleaseId(), operation);
       }
+      return releaseHistoryService.findLatestByReleaseIdAndOperation(env, publishInfo.getReleaseId(), operation);
 
     }
 

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/service/ItemService.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/service/ItemService.java
@@ -239,10 +239,10 @@ public class ItemService {
 
     if (sourceComment == null) {
       return !StringUtils.isEmpty(targetComment);
-    } else if (targetComment != null) {
-      return !sourceComment.equals(targetComment);
-    } else {
-      return false;
     }
+    if (targetComment != null) {
+      return !sourceComment.equals(targetComment);
+    }
+    return false;
   }
 }

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/service/ReleaseService.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/service/ReleaseService.java
@@ -126,9 +126,8 @@ public class ReleaseService {
     List<ReleaseDTO> releases = findReleaseByIds(env, releaseIds);
     if (CollectionUtils.isEmpty(releases)) {
       return null;
-    } else {
-      return releases.get(0);
     }
+    return releases.get(0);
 
   }
 

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/configuration/AuthConfiguration.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/configuration/AuthConfiguration.java
@@ -373,15 +373,15 @@ public class AuthConfiguration {
             ldapProperties.getSearchFilter(), ldapContextSource);
         filterBasedLdapUserSearch.setSearchSubtree(true);
         return filterBasedLdapUserSearch;
-      } else {
-        FilterLdapByGroupUserSearch filterLdapByGroupUserSearch = new FilterLdapByGroupUserSearch(
-            ldapProperties.getBase(), ldapProperties.getSearchFilter(), ldapExtendProperties.getGroup().getGroupBase(),
-            ldapContextSource, ldapExtendProperties.getGroup().getGroupSearch(),
-            ldapExtendProperties.getMapping().getRdnKey(),
-            ldapExtendProperties.getGroup().getGroupMembership(),ldapExtendProperties.getMapping().getLoginId());
-        filterLdapByGroupUserSearch.setSearchSubtree(true);
-        return filterLdapByGroupUserSearch;
       }
+
+      FilterLdapByGroupUserSearch filterLdapByGroupUserSearch = new FilterLdapByGroupUserSearch(
+          ldapProperties.getBase(), ldapProperties.getSearchFilter(), ldapExtendProperties.getGroup().getGroupBase(),
+          ldapContextSource, ldapExtendProperties.getGroup().getGroupSearch(),
+          ldapExtendProperties.getMapping().getRdnKey(),
+          ldapExtendProperties.getGroup().getGroupMembership(),ldapExtendProperties.getMapping().getLoginId());
+      filterLdapByGroupUserSearch.setSearchSubtree(true);
+      return filterLdapByGroupUserSearch;
     }
 
     @Bean

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/ldap/ApolloLdapAuthenticationProvider.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/ldap/ApolloLdapAuthenticationProvider.java
@@ -70,13 +70,12 @@ public class ApolloLdapAuthenticationProvider extends LdapAuthenticationProvider
     } else if (!StringUtils.hasLength(password)) {
       throw new BadCredentialsException(this.messages
           .getMessage("AbstractLdapAuthenticationProvider.emptyPassword", "Empty Password"));
-    } else {
-      Assert.notNull(password, "Null password was supplied in authentication token");
-      DirContextOperations userData = this.doAuthentication(userToken);
-      String loginId = userData.getStringAttribute(properties.getMapping().getLoginId());
-      UserDetails user = this.userDetailsContextMapper.mapUserFromContext(userData, loginId,
-          this.loadUserAuthorities(userData, loginId, (String) authentication.getCredentials()));
-      return this.createSuccessfulAuthentication(userToken, user);
     }
+    Assert.notNull(password, "Null password was supplied in authentication token");
+    DirContextOperations userData = this.doAuthentication(userToken);
+    String loginId = userData.getStringAttribute(properties.getMapping().getLoginId());
+    UserDetails user = this.userDetailsContextMapper.mapUserFromContext(userData, loginId,
+        this.loadUserAuthorities(userData, loginId, (String) authentication.getCredentials()));
+    return this.createSuccessfulAuthentication(userToken, user);
   }
 }

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/ldap/ApolloLdapAuthenticationProvider.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/ldap/ApolloLdapAuthenticationProvider.java
@@ -67,7 +67,8 @@ public class ApolloLdapAuthenticationProvider extends LdapAuthenticationProvider
     if (!StringUtils.hasLength(username)) {
       throw new BadCredentialsException(
           this.messages.getMessage("LdapAuthenticationProvider.emptyUsername", "Empty Username"));
-    } else if (!StringUtils.hasLength(password)) {
+    }
+    if (!StringUtils.hasLength(password)) {
       throw new BadCredentialsException(this.messages
           .getMessage("AbstractLdapAuthenticationProvider.emptyPassword", "Empty Password"));
     }

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/ldap/FilterLdapByGroupUserSearch.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/ldap/FilterLdapByGroupUserSearch.java
@@ -81,17 +81,16 @@ public class FilterLdapByGroupUserSearch extends FilterBasedLdapUserSearch {
               }
             }
             throw new UsernameNotFoundException("User " + username + " not found in directory.");
-          } else {
-            String[] memberUids = ((DirContextAdapter) ctx)
-                .getStringAttributes(groupMembershipAttrName);
-            for (String memberUid : memberUids) {
-              if (memberUid.equalsIgnoreCase(username)) {
-                Name name = searchUserById(memberUid);
-                LdapName ldapName = LdapUtils.newLdapName(name);
-                LdapName ldapRdn = LdapUtils
-                    .removeFirst(ldapName, LdapUtils.newLdapName(searchBase));
-                return new DirContextAdapter(ldapRdn);
-              }
+          }
+          String[] memberUids = ((DirContextAdapter) ctx)
+              .getStringAttributes(groupMembershipAttrName);
+          for (String memberUid : memberUids) {
+            if (memberUid.equalsIgnoreCase(username)) {
+              Name name = searchUserById(memberUid);
+              LdapName ldapName = LdapUtils.newLdapName(name);
+              LdapName ldapRdn = LdapUtils
+                  .removeFirst(ldapName, LdapUtils.newLdapName(searchBase));
+              return new DirContextAdapter(ldapRdn);
             }
           }
           throw new UsernameNotFoundException("User " + username + " not found in directory.");

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/ldap/LdapUserService.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/ldap/LdapUserService.java
@@ -167,12 +167,10 @@ public class LdapUserService implements UserService {
       if (userIds != null) {
         if (userIds.stream().anyMatch(c -> c.equals(tmp.getUserId()))) {
           return tmp;
-        } else {
-          return null;
         }
-      } else {
-        return tmp;
+        return null;
       }
+      return tmp;
 
     });
   }
@@ -224,24 +222,23 @@ public class LdapUserService implements UserService {
 
             }
             return userInfos;
-          } else {
-            List<UserInfo> userInfos = new ArrayList<>();
-            String[] memberUids = ((DirContextAdapter) ctx)
-                .getStringAttributes(groupMembershipAttrName);
-            for (String memberUid : memberUids) {
-              UserInfo userInfo = searchUserById(memberUid);
-              if (userInfo != null) {
-                if (keyword != null) {
-                  if (userInfo.getUserId().toLowerCase().contains(keyword.toLowerCase())) {
-                    userInfos.add(userInfo);
-                  }
-                } else {
+          }
+          List<UserInfo> userInfos = new ArrayList<>();
+          String[] memberUids = ((DirContextAdapter) ctx)
+              .getStringAttributes(groupMembershipAttrName);
+          for (String memberUid : memberUids) {
+            UserInfo userInfo = searchUserById(memberUid);
+            if (userInfo != null) {
+              if (keyword != null) {
+                if (userInfo.getUserId().toLowerCase().contains(keyword.toLowerCase())) {
                   userInfos.add(userInfo);
                 }
+              } else {
+                userInfos.add(userInfo);
               }
             }
-            return userInfos;
           }
+          return userInfos;
         });
   }
 
@@ -258,15 +255,14 @@ public class LdapUserService implements UserService {
         }
         return -1;
       })), ArrayList::new));
-    } else {
-      ContainerCriteria criteria = ldapQueryCriteria();
-      if (!Strings.isNullOrEmpty(keyword)) {
-        criteria.and(query().where(loginIdAttrName).like(keyword + "*").or(userDisplayNameAttrName)
-            .like(keyword + "*"));
-      }
-      users = ldapTemplate.search(criteria, ldapUserInfoMapper);
-      return users;
     }
+    ContainerCriteria criteria = ldapQueryCriteria();
+    if (!Strings.isNullOrEmpty(keyword)) {
+      criteria.and(query().where(loginIdAttrName).like(keyword + "*").or(userDisplayNameAttrName)
+          .like(keyword + "*"));
+    }
+    users = ldapTemplate.search(criteria, ldapUserInfoMapper);
+    return users;
   }
 
   @Override
@@ -278,29 +274,27 @@ public class LdapUserService implements UserService {
         return lists.get(0);
       }
       return null;
-    } else {
-      return ldapTemplate
-          .searchForObject(ldapQueryCriteria().and(loginIdAttrName).is(userId), ldapUserInfoMapper);
-
     }
+    return ldapTemplate
+        .searchForObject(ldapQueryCriteria().and(loginIdAttrName).is(userId), ldapUserInfoMapper);
+
   }
 
   @Override
   public List<UserInfo> findByUserIds(List<String> userIds) {
     if (CollectionUtils.isEmpty(userIds)) {
       return Collections.emptyList();
+    }
+    List<UserInfo> userList = new ArrayList<>();
+    if (StringUtils.isNotBlank(groupSearch)) {
+      List<UserInfo> userListByGroup = searchUserInfoByGroup(groupBase, groupSearch, null,
+          userIds);
+      userList.addAll(userListByGroup);
+      return userList;
     } else {
-      List<UserInfo> userList = new ArrayList<>();
-      if (StringUtils.isNotBlank(groupSearch)) {
-        List<UserInfo> userListByGroup = searchUserInfoByGroup(groupBase, groupSearch, null,
-            userIds);
-        userList.addAll(userListByGroup);
-        return userList;
-      } else {
-        ContainerCriteria criteria = query().where(loginIdAttrName).is(userIds.get(0));
-        userIds.stream().skip(1).forEach(userId -> criteria.or(loginIdAttrName).is(userId));
-        return ldapTemplate.search(ldapQueryCriteria().and(criteria), ldapUserInfoMapper);
-      }
+      ContainerCriteria criteria = query().where(loginIdAttrName).is(userIds.get(0));
+      userIds.stream().skip(1).forEach(userId -> criteria.or(loginIdAttrName).is(userId));
+      return ldapTemplate.search(ldapQueryCriteria().and(criteria), ldapUserInfoMapper);
     }
   }
 

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/ldap/LdapUserService.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/ldap/LdapUserService.java
@@ -291,11 +291,10 @@ public class LdapUserService implements UserService {
           userIds);
       userList.addAll(userListByGroup);
       return userList;
-    } else {
-      ContainerCriteria criteria = query().where(loginIdAttrName).is(userIds.get(0));
-      userIds.stream().skip(1).forEach(userId -> criteria.or(loginIdAttrName).is(userId));
-      return ldapTemplate.search(ldapQueryCriteria().and(criteria), ldapUserInfoMapper);
     }
+    ContainerCriteria criteria = query().where(loginIdAttrName).is(userIds.get(0));
+    userIds.stream().skip(1).forEach(userId -> criteria.or(loginIdAttrName).is(userId));
+    return ldapTemplate.search(ldapQueryCriteria().and(criteria), ldapUserInfoMapper);
   }
 
 }

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/util/RelativeDateFormat.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/util/RelativeDateFormat.java
@@ -53,9 +53,8 @@ public class RelativeDateFormat {
     long months = toMonths(delta);
     if (months <= 3) {
       return (months <= 0 ? 1 : months) + ONE_MONTH_AGO;
-    } else {
-      return TIMESTAMP_FORMAT.format(date);
     }
+    return TIMESTAMP_FORMAT.format(date);
   }
 
   private static long toSeconds(long date) {


### PR DESCRIPTION
## What's the purpose of this PR

remove redundant else.
If an if block contains a return/throw statement, the else block becomes unnecessary. Its contents can be placed outside of the block.

## Which issue(s) this PR fixes:
Fixes #

## Brief changelog

refactor code.

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
