### PR TITLE
fix for java 11

### DIFF
--- a/apollo-core/src/main/java/com/ctrip/framework/apollo/core/signature/HmacSha1Utils.java
+++ b/apollo-core/src/main/java/com/ctrip/framework/apollo/core/signature/HmacSha1Utils.java
@@ -1,11 +1,11 @@
 package com.ctrip.framework.apollo.core.signature;
 
-import javax.crypto.Mac;
-import javax.crypto.spec.SecretKeySpec;
-import javax.xml.bind.DatatypeConverter;
+import com.google.common.io.BaseEncoding;
 import java.io.UnsupportedEncodingException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
 
 /**
  * @author nisiyong
@@ -23,7 +23,7 @@ public class HmacSha1Utils {
           ALGORITHM_NAME
       ));
       byte[] signData = mac.doFinal(stringToSign.getBytes(ENCODING));
-      return DatatypeConverter.printBase64Binary(signData);
+      return BaseEncoding.base64().encode(signData);
     } catch (NoSuchAlgorithmException | UnsupportedEncodingException | InvalidKeyException e) {
       throw new IllegalArgumentException(e.toString());
     }


### PR DESCRIPTION
## What's the purpose of this PR

Fix the java 11 compatibility issue brought by #2828

## Brief changelog

use guava base64 instead of javax.xml.bind.DatatypeConverter to support java 11

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
