### PR TITLE
use linked hash map to keep server side config order and do some refactoring to apollo-client

### DIFF
--- a/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/service/ReleaseService.java
+++ b/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/service/ReleaseService.java
@@ -31,14 +31,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.CollectionUtils;
 
 import java.lang.reflect.Type;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 
 /**
  * @author Jason Song(song_s@ctrip.com)
@@ -153,7 +146,7 @@ public class ReleaseService {
 
     Map<String, String> operateNamespaceItems = getNamespaceItems(namespace);
 
-    Map<String, Object> operationContext = Maps.newHashMap();
+    Map<String, Object> operationContext = Maps.newLinkedHashMap();
     operationContext.put(ReleaseOperationContext.SOURCE_BRANCH, branchName);
     operationContext.put(ReleaseOperationContext.BASE_RELEASE_ID, branchReleaseId);
     operationContext.put(ReleaseOperationContext.IS_EMERGENCY_PUBLISH, isEmergencyPublish);
@@ -188,7 +181,7 @@ public class ReleaseService {
     }
 
     //master release
-    Map<String, Object> operationContext = Maps.newHashMap();
+    Map<String, Object> operationContext = Maps.newLinkedHashMap();
     operationContext.put(ReleaseOperationContext.IS_EMERGENCY_PUBLISH, isEmergencyPublish);
 
     Release release = masterRelease(namespace, releaseName, releaseComment, operateNamespaceItems,
@@ -211,7 +204,7 @@ public class ReleaseService {
     Release parentLatestRelease = findLatestActiveRelease(parentNamespace);
     Map<String, String> parentConfigurations = parentLatestRelease != null ?
             gson.fromJson(parentLatestRelease.getConfigurations(),
-                    GsonType.CONFIG) : new HashMap<>();
+                    GsonType.CONFIG) : new LinkedHashMap<>();
     long baseReleaseId = parentLatestRelease == null ? 0 : parentLatestRelease.getId();
 
     Map<String, String> configsToPublish = mergeConfiguration(parentConfigurations, childNamespaceItems);
@@ -342,7 +335,7 @@ public class ReleaseService {
                                                       childNamespace.getNamespaceName());
     long previousReleaseId = previousRelease == null ? 0 : previousRelease.getId();
 
-    Map<String, Object> releaseOperationContext = Maps.newHashMap();
+    Map<String, Object> releaseOperationContext = Maps.newLinkedHashMap();
     releaseOperationContext.put(ReleaseOperationContext.BASE_RELEASE_ID, baseReleaseId);
     releaseOperationContext.put(ReleaseOperationContext.IS_EMERGENCY_PUBLISH, isEmergencyPublish);
     releaseOperationContext.put(ReleaseOperationContext.BRANCH_RELEASE_KEYS, branchReleaseKeys);
@@ -372,7 +365,7 @@ public class ReleaseService {
 
   private Map<String, String> mergeConfiguration(Map<String, String> baseConfigurations,
                                                  Map<String, String> coverConfigurations) {
-    Map<String, String> result = new HashMap<>();
+    Map<String, String> result = new LinkedHashMap<>();
     //copy base configuration
     for (Map.Entry<String, String> entry : baseConfigurations.entrySet()) {
       result.put(entry.getKey(), entry.getValue());
@@ -388,8 +381,8 @@ public class ReleaseService {
 
 
   private Map<String, String> getNamespaceItems(Namespace namespace) {
-    List<Item> items = itemService.findItemsWithoutOrdered(namespace.getId());
-    Map<String, String> configurations = new HashMap<>();
+    List<Item> items = itemService.findItemsWithOrdered(namespace.getId());
+    Map<String, String> configurations = new LinkedHashMap<>();
     for (Item item : items) {
       if (StringUtils.isEmpty(item.getKey())) {
         continue;
@@ -520,7 +513,7 @@ public class ReleaseService {
       Map<String, String> masterReleaseConfigs, Map<String, String> branchReleaseConfigs,
       Collection<String> branchReleaseKeys) {
 
-    Map<String, String> modifiedConfigs = new HashMap<>();
+    Map<String, String> modifiedConfigs = new LinkedHashMap<>();
 
     if (CollectionUtils.isEmpty(branchReleaseConfigs)) {
       return modifiedConfigs;

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/DefaultConfig.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/DefaultConfig.java
@@ -88,7 +88,7 @@ public class DefaultConfig extends AbstractConfig implements RepositoryChangeLis
 
     // step 4: check properties file from classpath
     if (value == null && m_resourceProperties != null) {
-      value = (String) m_resourceProperties.getProperty(key);
+      value = m_resourceProperties.getProperty(key);
     }
 
     if (value == null && m_configProperties.get() == null && m_warnLogRateLimiter.tryAcquire()) {

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/util/OrderedProperties.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/util/OrderedProperties.java
@@ -107,7 +107,9 @@ public class OrderedProperties extends Properties {
 
   @Override
   public synchronized Object remove(Object key) {
-    this.propertyNames.remove(key);
+    if (key instanceof String) {
+      this.propertyNames.remove(key);
+    }
     return super.remove(key);
   }
 

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/util/factory/DefaultPropertiesFactory.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/util/factory/DefaultPropertiesFactory.java
@@ -3,10 +3,7 @@ package com.ctrip.framework.apollo.util.factory;
 import com.ctrip.framework.apollo.build.ApolloInjector;
 import com.ctrip.framework.apollo.util.ConfigUtil;
 import com.ctrip.framework.apollo.util.OrderedProperties;
-import com.google.common.base.Strings;
 import java.util.Properties;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Default PropertiesFactory implementation.
@@ -14,8 +11,6 @@ import org.slf4j.LoggerFactory;
  * @author songdragon@zts.io
  */
 public class DefaultPropertiesFactory implements PropertiesFactory {
-
-  private static final Logger logger = LoggerFactory.getLogger(DefaultPropertiesFactory.class);
 
   private ConfigUtil m_configUtil;
 

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/util/factory/PropertiesFactory.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/util/factory/PropertiesFactory.java
@@ -12,7 +12,7 @@ public interface PropertiesFactory {
   /**
    * Configuration to keep properties order as same as line order in .yml/.yaml/.properties file.
    */
-  public static final String APOLLO_PROPERTY_ORDER_ENABLE = "apollo.property.order.enable";
+  String APOLLO_PROPERTY_ORDER_ENABLE = "apollo.property.order.enable";
 
   /**
    * <pre>

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/BaseIntegrationTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/BaseIntegrationTest.java
@@ -44,6 +44,7 @@ public abstract class BaseIntegrationTest {
   protected static String someDataCenter;
   protected static int refreshInterval;
   protected static TimeUnit refreshTimeUnit;
+  protected static boolean propertiesOrderEnabled;
   private Server server;
   protected Gson gson = new Gson();
 
@@ -64,6 +65,7 @@ public abstract class BaseIntegrationTest {
     someDataCenter = "someDC";
     refreshInterval = 5;
     refreshTimeUnit = TimeUnit.MINUTES;
+    propertiesOrderEnabled = false;
 
     //as ConfigService is singleton, so we must manually clear its container
     ConfigService.reset();
@@ -140,6 +142,10 @@ public abstract class BaseIntegrationTest {
     BaseIntegrationTest.refreshTimeUnit = refreshTimeUnit;
   }
 
+  protected void setPropertiesOrderEnabled(boolean propertiesOrderEnabled) {
+    BaseIntegrationTest.propertiesOrderEnabled = propertiesOrderEnabled;
+  }
+
   public static class MockConfigUtil extends ConfigUtil {
 
     @Override
@@ -204,7 +210,7 @@ public abstract class BaseIntegrationTest {
 
     @Override
     public boolean isPropertiesOrderEnabled() {
-      return true;
+      return propertiesOrderEnabled;
     }
   }
 

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/integration/ConfigIntegrationTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/integration/ConfigIntegrationTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
+import com.ctrip.framework.apollo.util.OrderedProperties;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -17,7 +18,6 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import com.ctrip.framework.apollo.util.factory.PropertiesFactory;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.eclipse.jetty.server.handler.ContextHandler;
@@ -53,7 +53,6 @@ public class ConfigIntegrationTest extends BaseIntegrationTest {
   private String defaultNamespace;
   private String someOtherNamespace;
   private RemoteConfigLongPollService remoteConfigLongPollService;
-  private PropertiesFactory propertiesFactory;
 
   @Before
   public void setUp() throws Exception {
@@ -68,9 +67,6 @@ public class ConfigIntegrationTest extends BaseIntegrationTest {
     }
     configDir.mkdirs();
     remoteConfigLongPollService = ApolloInjector.getInstance(RemoteConfigLongPollService.class);
-
-    System.setProperty(PropertiesFactory.APOLLO_PROPERTY_ORDER_ENABLE, "true");
-    propertiesFactory = ApolloInjector.getInstance(PropertiesFactory.class);
   }
 
   @Override
@@ -78,7 +74,6 @@ public class ConfigIntegrationTest extends BaseIntegrationTest {
   public void tearDown() throws Exception {
     ReflectionTestUtils.invokeMethod(remoteConfigLongPollService, "stopLongPollingRefresh");
     recursiveDelete(configDir);
-    System.clearProperty(PropertiesFactory.APOLLO_PROPERTY_ORDER_ENABLE);
     super.tearDown();
   }
 
@@ -117,6 +112,8 @@ public class ConfigIntegrationTest extends BaseIntegrationTest {
 
   @Test
   public void testOrderGetConfigWithNoLocalFileButWithRemoteConfig() throws Exception {
+    setPropertiesOrderEnabled(true);
+
     String someKey1 = "someKey1";
     String someValue1 = "someValue1";
     String someKey2 = "someKey2";
@@ -167,7 +164,9 @@ public class ConfigIntegrationTest extends BaseIntegrationTest {
     String someKey2 = "someKey2";
     String someValue2 = "someValue2";
 
-    Properties properties = propertiesFactory.getPropertiesInstance();
+    setPropertiesOrderEnabled(true);
+
+    Properties properties = new OrderedProperties();
     properties.put(someKey, someValue);
     properties.put(someKey1, someValue1);
     properties.put(someKey2, someValue2);
@@ -230,7 +229,10 @@ public class ConfigIntegrationTest extends BaseIntegrationTest {
     String someValue1 = "someValue1";
     String someKey2 = "someKey2";
     String someValue2 = "someValue2";
-    Properties properties = propertiesFactory.getPropertiesInstance();
+
+    setPropertiesOrderEnabled(true);
+
+    Properties properties = new OrderedProperties();
     properties.put(someKey1, someValue1);
     properties.put(someKey2, someValue2);
     createLocalCachePropertyFile(properties);

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/internals/PropertiesConfigFileTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/internals/PropertiesConfigFileTest.java
@@ -10,8 +10,6 @@ import com.ctrip.framework.apollo.ConfigFileChangeListener;
 import com.ctrip.framework.apollo.build.MockInjector;
 import com.ctrip.framework.apollo.enums.PropertyChangeType;
 import com.ctrip.framework.apollo.model.ConfigFileChangeEvent;
-import com.ctrip.framework.apollo.util.ConfigUtil;
-import com.ctrip.framework.apollo.util.factory.DefaultPropertiesFactory;
 import com.ctrip.framework.apollo.util.factory.PropertiesFactory;
 import com.google.common.util.concurrent.SettableFuture;
 import java.util.Properties;
@@ -21,9 +19,11 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import com.ctrip.framework.apollo.core.enums.ConfigFileFormat;
+import org.mockito.stubbing.Answer;
 
 /**
  * @author Jason Song(song_s@ctrip.com)
@@ -34,13 +34,20 @@ public class PropertiesConfigFileTest {
   private String someNamespace;
   @Mock
   private ConfigRepository configRepository;
+  @Mock
+  private PropertiesFactory propertiesFactory;
 
   @Before
   public void setUp() throws Exception {
     someNamespace = "someName";
     MockInjector.reset();
-    MockInjector.setInstance(ConfigUtil.class, new ConfigUtil());
-    MockInjector.setInstance(PropertiesFactory.class, new DefaultPropertiesFactory());
+    when(propertiesFactory.getPropertiesInstance()).thenAnswer(new Answer<Properties>() {
+      @Override
+      public Properties answer(InvocationOnMock invocation) {
+        return new Properties();
+      }
+    });
+    MockInjector.setInstance(PropertiesFactory.class, propertiesFactory);
   }
 
   @Test

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/internals/SimpleConfigTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/internals/SimpleConfigTest.java
@@ -6,16 +6,15 @@ import static org.mockito.Mockito.when;
 
 import com.ctrip.framework.apollo.build.MockInjector;
 import com.ctrip.framework.apollo.enums.ConfigSourceType;
-import com.ctrip.framework.apollo.util.factory.DefaultPropertiesFactory;
 import com.ctrip.framework.apollo.util.factory.PropertiesFactory;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import com.ctrip.framework.apollo.Config;
@@ -25,6 +24,7 @@ import com.ctrip.framework.apollo.model.ConfigChange;
 import com.ctrip.framework.apollo.model.ConfigChangeEvent;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.SettableFuture;
+import org.mockito.stubbing.Answer;
 
 /**
  * @author Jason Song(song_s@ctrip.com)
@@ -35,20 +35,21 @@ public class SimpleConfigTest {
   private String someNamespace;
   @Mock
   private ConfigRepository configRepository;
+  @Mock
+  private PropertiesFactory propertiesFactory;
   private ConfigSourceType someSourceType;
 
   @Before
   public void setUp() throws Exception {
     someNamespace = "someName";
 
-    System.setProperty(PropertiesFactory.APOLLO_PROPERTY_ORDER_ENABLE, "true");
-    PropertiesFactory propertiesFactory = new DefaultPropertiesFactory();
+    when(propertiesFactory.getPropertiesInstance()).thenAnswer(new Answer<Properties>() {
+      @Override
+      public Properties answer(InvocationOnMock invocation) {
+        return new Properties();
+      }
+    });
     MockInjector.setInstance(PropertiesFactory.class, propertiesFactory);
-  }
-
-  @After
-  public void tearDown() throws Exception {
-    System.clearProperty(PropertiesFactory.APOLLO_PROPERTY_ORDER_ENABLE);
   }
 
   @Test

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/internals/XmlConfigFileTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/internals/XmlConfigFileTest.java
@@ -10,7 +10,6 @@ import com.ctrip.framework.apollo.ConfigFileChangeListener;
 import com.ctrip.framework.apollo.build.MockInjector;
 import com.ctrip.framework.apollo.enums.PropertyChangeType;
 import com.ctrip.framework.apollo.model.ConfigFileChangeEvent;
-import com.ctrip.framework.apollo.util.factory.DefaultPropertiesFactory;
 import com.ctrip.framework.apollo.util.factory.PropertiesFactory;
 import com.google.common.util.concurrent.SettableFuture;
 import java.util.Properties;
@@ -21,10 +20,12 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import com.ctrip.framework.apollo.core.ConfigConsts;
 import com.ctrip.framework.apollo.core.enums.ConfigFileFormat;
+import org.mockito.stubbing.Answer;
 
 /**
  * @author Jason Song(song_s@ctrip.com)
@@ -35,13 +36,19 @@ public class XmlConfigFileTest {
   private String someNamespace;
   @Mock
   private ConfigRepository configRepository;
+  @Mock
+  private PropertiesFactory propertiesFactory;
 
   @Before
   public void setUp() throws Exception {
     someNamespace = "someName";
 
-    System.setProperty(PropertiesFactory.APOLLO_PROPERTY_ORDER_ENABLE, "true");
-    PropertiesFactory propertiesFactory = new DefaultPropertiesFactory();
+    when(propertiesFactory.getPropertiesInstance()).thenAnswer(new Answer<Properties>() {
+      @Override
+      public Properties answer(InvocationOnMock invocation) {
+        return new Properties();
+      }
+    });
     MockInjector.setInstance(PropertiesFactory.class, propertiesFactory);
   }
 

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/util/ConfigUtilTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/util/ConfigUtilTest.java
@@ -10,7 +10,6 @@ import org.junit.Test;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
 
 /**
  * @author Jason Song(song_s@ctrip.com)

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/util/OrderedPropertiesTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/util/OrderedPropertiesTest.java
@@ -6,13 +6,11 @@ import java.util.Collection;
 import java.util.Enumeration;
 import java.util.Properties;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class OrderedPropertiesTest {
 
   private OrderedProperties orderedProperties;
-  private Properties legacyProperties;
 
   @Before
   public void setUp() {
@@ -23,7 +21,7 @@ public class OrderedPropertiesTest {
 
   @Test
   public void testOrderedPropertiesInvokedAsLegacyProperties() {
-    legacyProperties = orderedProperties;
+    Properties legacyProperties = orderedProperties;
     assertEquals(orderedProperties.size(), legacyProperties.size());
 
     legacyProperties.put("key3", "value3");
@@ -85,10 +83,9 @@ public class OrderedPropertiesTest {
 
   @Test
   public void testPropertyNames() {
-    Enumeration<String> propertyNames = (Enumeration<String>) orderedProperties.propertyNames();
-    assertTrue(propertyNames.nextElement().equals("key1"));
-    assertTrue(propertyNames.nextElement().equals("key2"));
-
+    Enumeration<?> propertyNames = orderedProperties.propertyNames();
+    assertEquals("key1", propertyNames.nextElement());
+    assertEquals("key2", propertyNames.nextElement());
   }
 
 

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/util/yaml/YamlParserTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/util/yaml/YamlParserTest.java
@@ -1,17 +1,24 @@
 package com.ctrip.framework.apollo.util.yaml;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import com.ctrip.framework.apollo.build.MockInjector;
+import com.ctrip.framework.apollo.util.OrderedProperties;
+import com.ctrip.framework.apollo.util.factory.PropertiesFactory;
+import com.google.common.base.Charsets;
+import com.google.common.io.Files;
 import java.io.File;
+import java.io.IOException;
 import java.util.Properties;
-
 import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 import org.springframework.beans.factory.config.YamlPropertiesFactoryBean;
 import org.springframework.core.io.ByteArrayResource;
 import org.yaml.snakeyaml.parser.ParserException;
-
-import com.google.common.base.Charsets;
-import com.google.common.io.Files;
 
 public class YamlParserTest {
 
@@ -37,12 +44,48 @@ public class YamlParserTest {
     testInvalid("case8.yaml");
   }
 
-  private void test(String caseName) throws Exception {
-    File file = new File("src/test/resources/yaml/" + caseName);
+  @Test
+  public void testOrderProperties() throws IOException {
+    String yamlContent = loadYaml("orderedcase.yaml");
 
-    String yamlContent = Files.toString(file, Charsets.UTF_8);
+    Properties nonOrderedProperties = parser.yamlToProperties(yamlContent);
+
+    MockInjector.reset();
+
+    PropertiesFactory propertiesFactory = mock(PropertiesFactory.class);;
+    when(propertiesFactory.getPropertiesInstance()).thenAnswer(new Answer<Properties>() {
+      @Override
+      public Properties answer(InvocationOnMock invocation) {
+        return new OrderedProperties();
+      }
+    });
+    MockInjector.setInstance(PropertiesFactory.class, propertiesFactory);
+
+    parser = new YamlParser();
+
+    Properties orderedProperties = parser.yamlToProperties(yamlContent);
+
+    assertTrue(orderedProperties instanceof OrderedProperties);
+
+    checkPropertiesEquals(nonOrderedProperties, orderedProperties);
+
+    String[] propertyNames = orderedProperties.stringPropertyNames().toArray(new String[0]);
+
+    assertEquals("k2", propertyNames[0]);
+    assertEquals("k4", propertyNames[1]);
+    assertEquals("k1", propertyNames[2]);
+  }
+
+  private void test(String caseName) throws Exception {
+    String yamlContent = loadYaml(caseName);
 
     check(yamlContent);
+  }
+
+  private String loadYaml(String caseName) throws IOException {
+    File file = new File("src/test/resources/yaml/" + caseName);
+
+    return Files.toString(file, Charsets.UTF_8);
   }
 
   private void testInvalid(String caseName) throws Exception {

--- a/apollo-client/src/test/resources/yaml/orderedcase.yaml
+++ b/apollo-client/src/test/resources/yaml/orderedcase.yaml
@@ -1,0 +1,3 @@
+k2: "someValue"
+k4: "anotherValue"
+k1: "yetAnotherValue"

--- a/apollo-configservice/src/main/java/com/ctrip/framework/apollo/configservice/controller/ConfigController.java
+++ b/apollo-configservice/src/main/java/com/ctrip/framework/apollo/configservice/controller/ConfigController.java
@@ -177,7 +177,7 @@ public class ConfigController {
    * Release in lower index override those in higher index
    */
   Map<String, String> mergeReleaseConfigurations(List<Release> releases) {
-    Map<String, String> result = Maps.newHashMap();
+    Map<String, String> result = Maps.newLinkedHashMap();
     for (Release release : Lists.reverse(releases)) {
       result.putAll(gson.fromJson(release.getConfigurations(), configurationTypeReference));
     }


### PR DESCRIPTION
## What's the purpose of this PR

To make sure the configurations return from server side is in the same order as what user sees in apollo-portal.

## Brief changelog

1. use linked hash map to keep server side config order
2. do some refactoring to #2861

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
