### PR TITLE
关联公共配置时未发布配置表格表头乱序调整

### DIFF
--- a/apollo-portal/src/main/resources/static/views/component/namespace-panel-master-tab.html
+++ b/apollo-portal/src/main/resources/static/views/component/namespace-panel-master-tab.html
@@ -592,13 +592,13 @@
 
                                     </th>
                                     <th>
-                                        {{'Component.Namespace.Master.Items.Body.ItemComment' | translate }}
-                                    </th>
-                                    <th>
                                         {{'Component.Namespace.Master.Items.Body.NoPublished.PublishedValue' | translate }}
                                     </th>
                                     <th>
                                         {{'Component.Namespace.Master.Items.Body.NoPublished.NoPublishedValue' | translate }}
+                                    </th>
+                                    <th>
+                                        {{'Component.Namespace.Master.Items.Body.ItemComment' | translate }}
                                     </th>
                                     <th class="hover"
                                         title="{{'Component.Namespace.Master.Items.Body.Sort' | translate }}"


### PR DESCRIPTION
## What's the purpose of this PR

关联公共配置时未发布配置表格表头乱序调整

## Which issue(s) this PR fixes:
Fixes #
apollo-portal/src/main/resources/static/views/component/namespace-panel-master-tab.html
关联功能配置时，未发布配置的表头与内容乱序调整

## Brief changelog

XXXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
