### PR TITLE
Use LinkedHashSet for deterministic iterations

### DIFF
--- a/apollo-configservice/src/test/java/com/ctrip/framework/apollo/configservice/service/ReleaseMessageServiceWithCacheTest.java
+++ b/apollo-configservice/src/test/java/com/ctrip/framework/apollo/configservice/service/ReleaseMessageServiceWithCacheTest.java
@@ -94,13 +94,15 @@ public class ReleaseMessageServiceWithCacheTest {
 
     List<ReleaseMessage> latestReleaseMsgGroupByMsgContent =
         releaseMessageServiceWithCache
-            .findLatestReleaseMessagesGroupByMessages(Sets.newHashSet(someMsgContent, anotherMsgContent));
+            .findLatestReleaseMessagesGroupByMessages(Sets.newLinkedHashSet(
+                    Arrays.asList(someMsgContent, anotherMsgContent))
+            );
 
     assertEquals(2, latestReleaseMsgGroupByMsgContent.size());
-    assertEquals(1, latestReleaseMsgGroupByMsgContent.get(1).getId());
-    assertEquals(someMsgContent, latestReleaseMsgGroupByMsgContent.get(1).getMessage());
-    assertEquals(3, latestReleaseMsgGroupByMsgContent.get(0).getId());
-    assertEquals(anotherMsgContent, latestReleaseMsgGroupByMsgContent.get(0).getMessage());
+    assertEquals(3, latestReleaseMsgGroupByMsgContent.get(1).getId());
+    assertEquals(anotherMsgContent, latestReleaseMsgGroupByMsgContent.get(1).getMessage());
+    assertEquals(1, latestReleaseMsgGroupByMsgContent.get(0).getId());
+    assertEquals(someMsgContent, latestReleaseMsgGroupByMsgContent.get(0).getMessage());
 
   }
 


### PR DESCRIPTION
## What's the purpose of this PR
Test `testWhenHasReleaseMsgAndHasRepeatMsg` may fail or pass without changes made to source code, due to HashSet's  non deterministic iteration order.

This PR proposes to use a LinkedHashSet for deterministic iteration order. This will make the test more stable.

## Which issue(s) this PR fixes:
Fixes #2917 



Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
