### PR TITLE
fix the issue that access key function doesn't work when prefix path is configured

### DIFF
--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/controller/PrefixPathController.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/controller/PrefixPathController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class PrefixPathController {
 
-  @Value("${prefixPath:}")
+  @Value("${prefix.path:}")
   private String prefixPath;
 
   @GetMapping("/prefix-path")

--- a/apollo-portal/src/main/resources/static/app/access_key.html
+++ b/apollo-portal/src/main/resources/static/app/access_key.html
@@ -28,7 +28,7 @@
                     </div>
                     <div class="col-md-5 text-right">
                         <a type="button" class="btn btn-info" data-dismiss="modal"
-                            href="/config.html?#appid={{pageContext.appId}}">{{'Common.ReturnToIndex' | translate }}
+                            href="{{ '/config.html' | prefixPath }}?#appid={{pageContext.appId}}">{{'Common.ReturnToIndex' | translate }}
                         </a>
                     </div>
                 </div>

--- a/apollo-portal/src/main/resources/static/config.html
+++ b/apollo-portal/src/main/resources/static/config.html
@@ -122,7 +122,7 @@
 
                         <apolloentrance apollo-title="'Config.AccessKeyManage' | translate"
                                         apollo-img-src="'accesskey-manage'"
-                                        apollo-href="'/app/access_key.html?#/appid=' + pageContext.appId"></apolloentrance>
+                                        apollo-href="'app/access_key.html?#/appid=' + pageContext.appId"></apolloentrance>
 
                         <a class="list-group-item" ng-show="missEnvs.length > 0" ng-click="createAppInMissEnv()">
                             <div class="row icon-text icon-plus-orange">

--- a/apollo-portal/src/main/resources/static/scripts/services/AccessKeyService.js
+++ b/apollo-portal/src/main/resources/static/scripts/services/AccessKeyService.js
@@ -1,25 +1,25 @@
-appService.service('AccessKeyService', ['$resource', '$q', function ($resource, $q) {
+appService.service('AccessKeyService', ['$resource', '$q', 'AppUtil', function ($resource, $q, AppUtil) {
     var access_key_resource = $resource('', {}, {
         load_access_keys: {
             method: 'GET',
             isArray: true,
-            url: '/apps/:appId/envs/:env/accesskeys'
+            url: AppUtil.prefixPath() + '/apps/:appId/envs/:env/accesskeys'
         },
         create_access_key: {
             method: 'POST',
-            url: '/apps/:appId/envs/:env/accesskeys'
+            url: AppUtil.prefixPath() + '/apps/:appId/envs/:env/accesskeys'
         },
         remove_access_key: {
             method: 'DELETE',
-            url: '/apps/:appId/envs/:env/accesskeys/:id'
+            url: AppUtil.prefixPath() + '/apps/:appId/envs/:env/accesskeys/:id'
         },
         enable_access_key: {
             method: 'PUT',
-            url: '/apps/:appId/envs/:env/accesskeys/:id/enable'
+            url: AppUtil.prefixPath() + '/apps/:appId/envs/:env/accesskeys/:id/enable'
         },
         disable_access_key: {
             method: 'PUT',
-            url: '/apps/:appId/envs/:env/accesskeys/:id/disable'
+            url: AppUtil.prefixPath() + '/apps/:appId/envs/:env/accesskeys/:id/disable'
         }
     });
     return {


### PR DESCRIPTION
## What's the purpose of this PR

fix the issue that access key function doesn't work when prefix path is configured

## Brief changelog

1. change prefix path key from `prefixPath` to `prefix.path`
2. fix the incompatible path in access key pages

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
