### PR TITLE
Revert "Modify the logic to add ApolloPropertySources to env, add list empty check logic"

### DIFF
--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/config/PropertySourcesProcessor.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/config/PropertySourcesProcessor.java
@@ -29,7 +29,6 @@ import java.util.Collection;
 import java.util.Iterator;
 import org.springframework.core.env.MutablePropertySources;
 import org.springframework.core.env.PropertySource;
-import org.springframework.util.CollectionUtils;
 
 /**
  * Apollo Property Sources processor for Spring Annotation Based Application. <br /> <br />
@@ -83,21 +82,18 @@ public class PropertySourcesProcessor implements BeanFactoryPostProcessor, Envir
     // clean up
     NAMESPACE_NAMES.clear();
 
-    // ensure ApolloBootstrapPropertySources is still the first
-    ensureBootstrapPropertyPrecedence(environment);
-
-    if (CollectionUtils.isEmpty(composite.getPropertySources())) {
-      return;
-    }
     // add after the bootstrap property source or to the first
     if (environment.getPropertySources()
         .contains(PropertySourcesConstants.APOLLO_BOOTSTRAP_PROPERTY_SOURCE_NAME)) {
+
+      // ensure ApolloBootstrapPropertySources is still the first
+      ensureBootstrapPropertyPrecedence(environment);
+
       environment.getPropertySources()
           .addAfter(PropertySourcesConstants.APOLLO_BOOTSTRAP_PROPERTY_SOURCE_NAME, composite);
     } else {
       environment.getPropertySources().addFirst(composite);
     }
-
   }
 
   private void ensureBootstrapPropertyPrecedence(ConfigurableEnvironment environment) {


### PR DESCRIPTION
Reverts ctripcorp/apollo#2733 since `org.springframework.core.env.CompositePropertySource#getPropertySources` only exists for Spring 4.1.1+ and apollo-client needs to support Spring 3.1.1+