### PR TITLE
completing the remaining predefined environment

### DIFF
--- a/apollo-core/src/main/java/com/ctrip/framework/apollo/core/internals/LegacyMetaServerProvider.java
+++ b/apollo-core/src/main/java/com/ctrip/framework/apollo/core/internals/LegacyMetaServerProvider.java
@@ -27,10 +27,12 @@ public class LegacyMetaServerProvider implements MetaServerProvider {
 
     domains.put(Env.LOCAL, getMetaServerAddress(prop, "local_meta", "local.meta"));
     domains.put(Env.DEV, getMetaServerAddress(prop, "dev_meta", "dev.meta"));
+    domains.put(Env.FWS, getMetaServerAddress(prop, "fws_meta", "fws.meta"));
     domains.put(Env.FAT, getMetaServerAddress(prop, "fat_meta", "fat.meta"));
     domains.put(Env.UAT, getMetaServerAddress(prop, "uat_meta", "uat.meta"));
     domains.put(Env.LPT, getMetaServerAddress(prop, "lpt_meta", "lpt.meta"));
     domains.put(Env.PRO, getMetaServerAddress(prop, "pro_meta", "pro.meta"));
+    domains.put(Env.TOOLS, getMetaServerAddress(prop, "tools_meta", "tools.meta"));
   }
 
   private String getMetaServerAddress(Properties prop, String sourceName, String propName) {


### PR DESCRIPTION
## What's the purpose of this PR

FWS and TOOLS environments cannot be used in the portal.
预定义环境（FWS，TOOLS），portal中默认无法使用。


## Brief changelog
update *com.ctrip.framework.apollo.core.internals.LegacyMetaServerProvider#initialize*

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
