### PR TITLE
Allow repeatable deletions and enhance thread safety

### DIFF
--- a/apollo-mockserver/src/main/java/com/ctrip/framework/apollo/mockserver/EmbeddedApollo.java
+++ b/apollo-mockserver/src/main/java/com/ctrip/framework/apollo/mockserver/EmbeddedApollo.java
@@ -5,14 +5,13 @@ import com.ctrip.framework.apollo.core.dto.ApolloConfig;
 import com.ctrip.framework.apollo.core.dto.ApolloConfigNotification;
 import com.ctrip.framework.apollo.core.utils.ResourceUtils;
 import com.ctrip.framework.apollo.internals.ConfigServiceLocator;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -38,8 +37,8 @@ public class EmbeddedApollo extends ExternalResource {
   private static ConfigServiceLocator CONFIG_SERVICE_LOCATOR;
 
   private final Gson gson = new Gson();
-  private final Map<String, Map<String, String>> addedOrModifiedPropertiesOfNamespace = new HashMap<>();
-  private final Map<String, Set<String>> deletedKeysOfNamespace = new HashMap<>();
+  private final Map<String, Map<String, String>> addedOrModifiedPropertiesOfNamespace = Maps.newConcurrentMap();
+  private final Map<String, Set<String>> deletedKeysOfNamespace = Maps.newConcurrentMap();
 
   private MockWebServer server;
 
@@ -151,7 +150,7 @@ public class EmbeddedApollo extends ExternalResource {
     if (addedOrModifiedPropertiesOfNamespace.containsKey(namespace)) {
       addedOrModifiedPropertiesOfNamespace.get(namespace).put(someKey, someValue);
     } else {
-      Map<String, String> m = new HashMap<>();
+      Map<String, String> m = Maps.newConcurrentMap();
       m.put(someKey, someValue);
       addedOrModifiedPropertiesOfNamespace.put(namespace, m);
     }
@@ -164,7 +163,9 @@ public class EmbeddedApollo extends ExternalResource {
     if (deletedKeysOfNamespace.containsKey(namespace)) {
       deletedKeysOfNamespace.get(namespace).add(someKey);
     } else {
-      deletedKeysOfNamespace.put(namespace, ImmutableSet.of(someKey));
+      Set<String> m = Sets.newConcurrentHashSet();
+      m.add(someKey);
+      deletedKeysOfNamespace.put(namespace, m);
     }
   }
 

--- a/apollo-mockserver/src/test/java/com/ctrip/framework/apollo/mockserver/ApolloMockServerApiTest.java
+++ b/apollo-mockserver/src/test/java/com/ctrip/framework/apollo/mockserver/ApolloMockServerApiTest.java
@@ -12,6 +12,7 @@ import com.google.common.util.concurrent.SettableFuture;
 
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
+
 import org.junit.ClassRule;
 import org.junit.Test;
 
@@ -54,7 +55,6 @@ public class ApolloMockServerApiTest {
 
     assertEquals(someNewValue, otherConfig.getProperty("key1", null));
     assertEquals("otherValue2", otherConfig.getProperty("key2", null));
-
     assertTrue(changeEvent.isChanged("key1"));
   }
 
@@ -73,14 +73,13 @@ public class ApolloMockServerApiTest {
       }
     });
 
-    assertEquals("otherValue1", otherConfig.getProperty("key1", null));
-    assertEquals("otherValue2", otherConfig.getProperty("key2", null));
+    assertEquals("otherValue3", otherConfig.getProperty("key3", null));
 
-    embeddedApollo.addOrModifyProperty(anotherNamespace, "key1", someNewValue);
-    embeddedApollo.addOrModifyProperty(anotherNamespace, "key1", someNewValue);
+    embeddedApollo.addOrModifyProperty(anotherNamespace, "key3", someNewValue);
+    embeddedApollo.addOrModifyProperty(anotherNamespace, "key3", someNewValue);
 
     assertTrue(changes.tryAcquire(5, TimeUnit.SECONDS));
-    assertEquals(someNewValue, otherConfig.getProperty("key1", null));
+    assertEquals(someNewValue, otherConfig.getProperty("key3", null));
     assertEquals(0, changes.availablePermits());
   }
 
@@ -97,15 +96,16 @@ public class ApolloMockServerApiTest {
       }
     });
 
-    assertEquals("otherValue1", otherConfig.getProperty("key1", null));
-    assertEquals("otherValue2", otherConfig.getProperty("key2", null));
+    assertEquals("otherValue4", otherConfig.getProperty("key4", null));
+    assertEquals("otherValue5", otherConfig.getProperty("key5", null));
 
-    embeddedApollo.deleteProperty(anotherNamespace, "key1");
+    embeddedApollo.deleteProperty(anotherNamespace, "key4");
 
     ConfigChangeEvent changeEvent = future.get(5, TimeUnit.SECONDS);
 
-    assertNull(otherConfig.getProperty("key1", null));
-    assertTrue(changeEvent.isChanged("key1"));
+    assertNull(otherConfig.getProperty("key4", null));
+    assertEquals("otherValue5", otherConfig.getProperty("key5", null));
+    assertTrue(changeEvent.isChanged("key4"));
   }
 
   @Test
@@ -121,14 +121,13 @@ public class ApolloMockServerApiTest {
       }
     });
 
-    assertEquals("otherValue1", otherConfig.getProperty("key1", null));
-    assertEquals("otherValue2", otherConfig.getProperty("key2", null));
+    assertEquals("otherValue6", otherConfig.getProperty("key6", null));
 
-    embeddedApollo.deleteProperty(anotherNamespace, "key1");
-    embeddedApollo.deleteProperty(anotherNamespace, "key1");
+    embeddedApollo.deleteProperty(anotherNamespace, "key6");
+    embeddedApollo.deleteProperty(anotherNamespace, "key6");
 
     assertTrue(changes.tryAcquire(5, TimeUnit.SECONDS));
-    assertNull(otherConfig.getProperty("key1", null));
+    assertNull(otherConfig.getProperty("key6", null));
     assertEquals(0, changes.availablePermits());
   }
 }

--- a/apollo-mockserver/src/test/resources/mockdata-anotherNamespace.properties
+++ b/apollo-mockserver/src/test/resources/mockdata-anotherNamespace.properties
@@ -1,2 +1,6 @@
 key1=otherValue1
 key2=otherValue2
+key3=otherValue3
+key4=otherValue4
+key5=otherValue5
+key6=otherValue6


### PR DESCRIPTION
## What's the purpose of this PR

fix two bugs in mockserver
* repeatable deletion of properties is erroneous
* there would be race condition issue on override properties

## Which issue(s) this PR fixes:

Fixes #3064 

## Brief changelog

* change immutable set to concurrent hash set
* change plain hash map to concurrent map

