### PR TITLE
use awaitility to stabilize the async tests

### DIFF
--- a/apollo-configservice/src/test/java/com/ctrip/framework/apollo/configservice/controller/NotificationControllerV2Test.java
+++ b/apollo-configservice/src/test/java/com/ctrip/framework/apollo/configservice/controller/NotificationControllerV2Test.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
@@ -334,10 +335,9 @@ public class NotificationControllerV2Test {
     //in batch mode, at most one of them should have result
     assertFalse(deferredResult.hasResult() && anotherDeferredResult.hasResult());
 
-    TimeUnit.MILLISECONDS.sleep(someBatchInterval * 10);
-
     //now both of them should have result
-    assertTrue(deferredResult.hasResult() && anotherDeferredResult.hasResult());
+    await().atMost(someBatchInterval * 500, TimeUnit.MILLISECONDS).untilAsserted(
+        () -> assertTrue(deferredResult.hasResult() && anotherDeferredResult.hasResult()));
   }
 
   @Test

--- a/apollo-configservice/src/test/java/com/ctrip/framework/apollo/configservice/integration/AbstractBaseIntegrationTest.java
+++ b/apollo-configservice/src/test/java/com/ctrip/framework/apollo/configservice/integration/AbstractBaseIntegrationTest.java
@@ -93,7 +93,7 @@ public abstract class AbstractBaseIntegrationTest {
   }
 
   protected void periodicSendMessage(ExecutorService executorService, String message, AtomicBoolean stop) {
-    executorService.submit((Runnable) () -> {
+    executorService.submit(() -> {
       //wait for the request connected to server
       while (!stop.get() && !Thread.currentThread().isInterrupted()) {
         try {

--- a/pom.xml
+++ b/pom.xml
@@ -290,6 +290,13 @@
 				<groupId>com.h2database</groupId>
 				<artifactId>h2</artifactId>
 				<version>1.4.191</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.awaitility</groupId>
+				<artifactId>awaitility</artifactId>
+				<version>4.0.3</version>
+				<scope>test</scope>
 			</dependency>
 			<!-- declare Spring BOMs in order -->
 			<dependency>
@@ -361,6 +368,11 @@
 					<groupId>org.springframework.boot</groupId>
 				</exclusion>
 			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.awaitility</groupId>
+			<artifactId>awaitility</artifactId>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
## What's the purpose of this PR

Use awaitility library to stabilize the async tests

## Brief changelog

replace the usage of java.util.concurrent.TimeUnit#sleep with org.awaitility.Awaitility#await() to stabilize the async tests

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
