### PR TITLE
public namespaces only allow properties format

### DIFF
--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/service/AppNamespaceService.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/service/AppNamespaceService.java
@@ -111,6 +111,11 @@ public class AppNamespaceService {
       throw new BadRequestException("App not exist. AppId = " + appId);
     }
 
+    // public namespaces only allow properties format
+    if (appNamespace.isPublic()) {
+      appNamespace.setFormat(ConfigFileFormat.Properties.getValue());
+    }
+
     StringBuilder appNamespaceName = new StringBuilder();
     //add prefix postfix
     appNamespaceName

--- a/apollo-portal/src/main/resources/static/scripts/controller/NamespaceController.js
+++ b/apollo-portal/src/main/resources/static/scripts/controller/NamespaceController.js
@@ -133,6 +133,11 @@ namespace_module.controller("LinkNamespaceController",
                         return;
                     }
 
+                    // public namespaces only allow properties format
+                    if ($scope.appNamespace.isPublic) {
+                        $scope.appNamespace.format = 'properties';
+                    }
+
                     $scope.submitBtnDisabled = true;
                     //only append namespace prefix for public app namespace
                     var appendNamespacePrefix = shouldAppendNamespacePrefix();

--- a/apollo-portal/src/test/java/com/ctrip/framework/apollo/portal/service/AppNamespaceServiceTest.java
+++ b/apollo-portal/src/test/java/com/ctrip/framework/apollo/portal/service/AppNamespaceServiceTest.java
@@ -72,6 +72,7 @@ public class AppNamespaceServiceTest extends AbstractIntegrationTest {
     AppNamespace appNamespace = assembleBaseAppNamespace();
     appNamespace.setPublic(true);
     appNamespace.setName("old");
+    appNamespace.setFormat(ConfigFileFormat.Properties.getValue());
 
     appNamespaceService.createAppNamespaceInLocal(appNamespace);
   }
@@ -95,6 +96,7 @@ public class AppNamespaceServiceTest extends AbstractIntegrationTest {
     AppNamespace appNamespace = assembleBaseAppNamespace();
     appNamespace.setPublic(true);
     appNamespace.setName("old");
+    appNamespace.setFormat(ConfigFileFormat.Properties.getValue());
 
     AppNamespace createdAppNamespace = appNamespaceService.createAppNamespaceInLocal(appNamespace, false);
 
@@ -109,6 +111,7 @@ public class AppNamespaceServiceTest extends AbstractIntegrationTest {
     AppNamespace appNamespace = assembleBaseAppNamespace();
     appNamespace.setPublic(true);
     appNamespace.setName("datasource");
+    appNamespace.setFormat(ConfigFileFormat.Properties.getValue());
 
     appNamespaceService.createAppNamespaceInLocal(appNamespace, false);
   }
@@ -127,6 +130,24 @@ public class AppNamespaceServiceTest extends AbstractIntegrationTest {
     Assert.assertNotNull(createdAppNamespace);
     Assert.assertEquals(appNamespace.getName(), createdAppNamespace.getName());
   }
+
+  @Test
+  @Sql(scripts = "/sql/appnamespaceservice/init-appnamespace.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+  @Sql(scripts = "/sql/cleanup.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
+  public void testCreatePublicAppNamespaceWithWrongFormatNotExisted() {
+    AppNamespace appNamespace = assembleBaseAppNamespace();
+    appNamespace.setPublic(true);
+    appNamespace.setFormat(ConfigFileFormat.YAML.getValue());
+
+    appNamespaceService.createAppNamespaceInLocal(appNamespace);
+
+    AppNamespace createdAppNamespace = appNamespaceService.findPublicAppNamespace(appNamespace.getName());
+
+    Assert.assertNotNull(createdAppNamespace);
+    Assert.assertEquals(appNamespace.getName(), createdAppNamespace.getName());
+    Assert.assertEquals(ConfigFileFormat.Properties.getValue(), createdAppNamespace.getFormat());
+  }
+
 
   @Test(expected = BadRequestException.class)
   @Sql(scripts = "/sql/appnamespaceservice/init-appnamespace.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)

--- a/apollo-portal/src/test/resources/sql/appnamespaceservice/init-appnamespace.sql
+++ b/apollo-portal/src/test/resources/sql/appnamespaceservice/init-appnamespace.sql
@@ -1,13 +1,14 @@
 INSERT INTO `appnamespace` (`Id`, `Name`, `AppId`, `Format`, `IsPublic`, `Comment`, `IsDeleted`, `DataChange_CreatedBy`, `DataChange_CreatedTime`, `DataChange_LastModifiedBy`, `DataChange_LastTime`)
 VALUES
-	(139, 'FX.old.xml', '100003173', 'properties', 1, '', 0, 'zhanglea', '2016-07-11 10:00:58', 'zhanglea', '2016-07-11 10:00:58'),
+	(139, 'FX.old', '100003173', 'properties', 1, '', 0, 'zhanglea', '2016-07-11 10:00:58', 'zhanglea', '2016-07-11 10:00:58'),
 	(140, 'SCC.song0711-03', 'song0711-01', 'properties', 1, '', 0, 'song_s', '2016-07-11 10:04:09', 'song_s', '2016-07-11 10:04:09'),
 	(141, 'SCC.song0711-04', 'song0711-01', 'properties', 1, '', 0, 'song_s', '2016-07-11 10:06:29', 'song_s', '2016-07-11 10:06:29'),
 	(142, 'application', 'song0711-02', 'properties', 1, 'default app namespace', 0, 'song_s', '2016-07-11 11:18:24', 'song_s', '2016-07-11 11:18:24'),
 	(143, 'TFF.song0711-02', 'song0711-02', 'properties', 0, '', 0, 'song_s', '2016-07-11 11:15:11', 'song_s', '2016-07-11 11:15:11'),
-	(144, 'datasourcexml', '100003173', 'xml', 1, '', 0, 'apollo', '2016-07-11 12:08:29', 'apollo', '2016-07-11 12:08:29'),
+	(144, 'datasourcexml', '100003173', 'properties', 1, '', 0, 'apollo', '2016-07-11 12:08:29', 'apollo', '2016-07-11 12:08:29'),
 	(145, 'datasource.xml', '100003173', 'xml', 0, '', 0, 'apollo', '2016-07-11 12:09:30', 'apollo', '2016-07-11 12:09:30'),
-	(146, 'FX.private-01', '100003173', 'properties', 0, '', 0, 'apollo', '2016-07-11 12:09:30', 'apollo', '2016-07-11 12:09:30');;
+	(146, 'FX.private-01', '100003173', 'properties', 0, '', 0, 'apollo', '2016-07-11 12:09:30', 'apollo', '2016-07-11 12:09:30'),
+	(147, 'datasource', '100003173', 'properties', 0, '', 0, 'apollo', '2016-07-11 12:09:30', 'apollo', '2016-07-11 12:09:30');
 
 INSERT INTO `app` (`AppId`, `Name`, `OrgId`, `OrgName`, `OwnerName`, `OwnerEmail`, `IsDeleted`, `DataChange_CreatedBy`, `DataChange_LastModifiedBy`)
 VALUES


### PR DESCRIPTION
## What's the purpose of this PR

public namespaces only allow properties format

## Which issue(s) this PR fixes:
Fixes #3119

## Brief changelog

check the namespace's isPublic property and set the format to properties if isPublic is true.

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
