### PR TITLE
Update NotificationControllerV2.java

### DIFF
--- a/apollo-configservice/src/main/java/com/ctrip/framework/apollo/configservice/controller/NotificationControllerV2.java
+++ b/apollo-configservice/src/main/java/com/ctrip/framework/apollo/configservice/controller/NotificationControllerV2.java
@@ -117,8 +117,8 @@ public class NotificationControllerV2 implements ReleaseMessageListener {
     }
     
     DeferredResultWrapper deferredResultWrapper = new DeferredResultWrapper(bizConfig.longPollingTimeoutInMilli());
-    Set<String> namespaces = Sets.newHashSet();
-    Map<String, Long> clientSideNotifications = Maps.newHashMap();
+    Set<String> namespaces = Sets.newHashSetWithExpectedSize(filteredNotifications.size());
+    Map<String, Long> clientSideNotifications = Maps.newHashMapWithExpectedSize(filteredNotifications.size());
     
     for (Map.Entry<String, ApolloConfigNotification> notificationEntry : filteredNotifications.entrySet()) {
       String normalizedNamespace = notificationEntry.getKey();

--- a/apollo-configservice/src/main/java/com/ctrip/framework/apollo/configservice/controller/NotificationControllerV2.java
+++ b/apollo-configservice/src/main/java/com/ctrip/framework/apollo/configservice/controller/NotificationControllerV2.java
@@ -109,12 +109,17 @@ public class NotificationControllerV2 implements ReleaseMessageListener {
     if (CollectionUtils.isEmpty(notifications)) {
       throw new BadRequestException("Invalid format of notifications: " + notificationsAsString);
     }
+    
+    Map<String, ApolloConfigNotification> filteredNotifications = filterNotifications(appId, notifications);
 
+    if (CollectionUtils.isEmpty(filteredNotifications)) {
+      throw new BadRequestException("Invalid format of notifications: " + notificationsAsString);
+    }
+    
     DeferredResultWrapper deferredResultWrapper = new DeferredResultWrapper(bizConfig.longPollingTimeoutInMilli());
     Set<String> namespaces = Sets.newHashSet();
     Map<String, Long> clientSideNotifications = Maps.newHashMap();
-    Map<String, ApolloConfigNotification> filteredNotifications = filterNotifications(appId, notifications);
-
+    
     for (Map.Entry<String, ApolloConfigNotification> notificationEntry : filteredNotifications.entrySet()) {
       String normalizedNamespace = notificationEntry.getKey();
       ApolloConfigNotification notification = notificationEntry.getValue();
@@ -123,10 +128,6 @@ public class NotificationControllerV2 implements ReleaseMessageListener {
       if (!Objects.equals(notification.getNamespaceName(), normalizedNamespace)) {
         deferredResultWrapper.recordNamespaceNameNormalizedResult(notification.getNamespaceName(), normalizedNamespace);
       }
-    }
-
-    if (CollectionUtils.isEmpty(namespaces)) {
-      throw new BadRequestException("Invalid format of notifications: " + notificationsAsString);
     }
 
     Multimap<String, String> watchedKeysMap =


### PR DESCRIPTION
##  What's the purpose of this PR

Adjust the order of check。

if `filteredNotifications` is not empty, then  `namespaces` will not empty。 so check  `filteredNotifications` before  `namespaces ` Initialized ， will avoid create useless object

