### PR TITLE
change static version number to ${revision} variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,5 @@ target
 
 # git
 *.orig
+.flattened-pom.xml
 

--- a/apollo-adminservice/pom.xml
+++ b/apollo-adminservice/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.ctrip.framework.apollo</groupId>
 		<artifactId>apollo</artifactId>
-		<version>1.7.0-SNAPSHOT</version>
+		<version>${revision}</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/apollo-assembly/pom.xml
+++ b/apollo-assembly/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.ctrip.framework.apollo</groupId>
 		<artifactId>apollo</artifactId>
-		<version>1.7.0-SNAPSHOT</version>
+		<version>${revision}</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/apollo-biz/pom.xml
+++ b/apollo-biz/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.ctrip.framework.apollo</groupId>
 		<artifactId>apollo</artifactId>
-		<version>1.7.0-SNAPSHOT</version>
+		<version>${revision}</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>apollo-biz</artifactId>

--- a/apollo-buildtools/pom.xml
+++ b/apollo-buildtools/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.ctrip.framework.apollo</groupId>
 		<artifactId>apollo</artifactId>
-		<version>1.7.0-SNAPSHOT</version>
+		<version>${revision}</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/apollo-client/pom.xml
+++ b/apollo-client/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.ctrip.framework.apollo</groupId>
 		<artifactId>apollo</artifactId>
-		<version>1.7.0-SNAPSHOT</version>
+		<version>${revision}</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/apollo-common/pom.xml
+++ b/apollo-common/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.ctrip.framework.apollo</groupId>
         <artifactId>apollo</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/apollo-configservice/pom.xml
+++ b/apollo-configservice/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.ctrip.framework.apollo</groupId>
 		<artifactId>apollo</artifactId>
-		<version>1.7.0-SNAPSHOT</version>
+		<version>${revision}</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/apollo-core/pom.xml
+++ b/apollo-core/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.ctrip.framework.apollo</groupId>
 		<artifactId>apollo</artifactId>
-		<version>1.7.0-SNAPSHOT</version>
+		<version>${revision}</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/apollo-demo/pom.xml
+++ b/apollo-demo/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>apollo</artifactId>
 		<groupId>com.ctrip.framework.apollo</groupId>
-		<version>1.7.0-SNAPSHOT</version>
+		<version>${revision}</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>apollo-demo</artifactId>

--- a/apollo-mockserver/pom.xml
+++ b/apollo-mockserver/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>apollo</artifactId>
     <groupId>com.ctrip.framework.apollo</groupId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/apollo-openapi/pom.xml
+++ b/apollo-openapi/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>apollo</artifactId>
     <groupId>com.ctrip.framework.apollo</groupId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/apollo-portal/pom.xml
+++ b/apollo-portal/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.ctrip.framework.apollo</groupId>
 		<artifactId>apollo</artifactId>
-		<version>1.7.0-SNAPSHOT</version>
+		<version>${revision}</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>com.ctrip.framework.apollo</groupId>
 	<artifactId>apollo</artifactId>
-	<version>1.7.0-SNAPSHOT</version>
+	<version>${revision}</version>
 	<name>Apollo</name>
 	<packaging>pom</packaging>
 	<description>Ctrip Configuration Center</description>
@@ -73,6 +73,7 @@
 	</developers>
 
 	<properties>
+		<revision>1.7.0-SNAPSHOT</revision>
 		<java.version>1.8</java.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<platform-bom.version>Cairo-SR4</platform-bom.version>
@@ -581,6 +582,31 @@
 					<generateGitPropertiesFile>true</generateGitPropertiesFile>
 					<failOnNoGitDirectory>false</failOnNoGitDirectory>
 				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>flatten-maven-plugin</artifactId>
+				<version>1.1.0</version>
+				<configuration>
+					<updatePomFile>true</updatePomFile>
+					<flattenMode>resolveCiFriendliesOnly</flattenMode>
+				</configuration>
+				<executions>
+					<execution>
+						<id>flatten</id>
+						<phase>process-resources</phase>
+						<goals>
+							<goal>flatten</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>flatten.clean</id>
+						<phase>clean</phase>
+						<goals>
+							<goal>clean</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 		<resources>


### PR DESCRIPTION
## What's the purpose of this PR

when the version need to be updated, we need to modify every pom.xml and then commit these files.In this pr, we replace version with {revision} variable so that only one file is required to modify. 

## Which issue(s) this PR fixes:
Fixes #3134

## Brief changelog

1.add <revision> property in parent pom.xml
2.replace version number with ${revison} variable
3.add flatten plugin which is needed to replace ${revison} with static version when execute maven commands