### PR TITLE
change mysql driver class to 'com.mysql.cj.jdbc.Driver' as 'com.mysql.jdbc.Driver' is deprecated

### DIFF
--- a/apollo-common/src/main/resources/application.properties
+++ b/apollo-common/src/main/resources/application.properties
@@ -2,6 +2,7 @@ spring.http.converters.preferred-json-mapper=gson
 
 # DataSource
 spring.datasource.hikari.connectionInitSql=set names utf8mb4
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 # Naming strategy
 spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl


### PR DESCRIPTION
## What's the purpose of this PR

change mysql driver class to 'com.mysql.cj.jdbc.Driver' as 'com.mysql.jdbc.Driver' is deprecated

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
