### PR TITLE
support extracting placeholder from non-normalized expressions, e.g. ${user.address}/user/gateway

### DIFF
--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/property/PlaceholderHelper.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/property/PlaceholderHelper.java
@@ -120,12 +120,12 @@ public class PlaceholderHelper {
   }
 
   private boolean isNormalizedPlaceholder(String propertyString) {
-    return propertyString.startsWith(PLACEHOLDER_PREFIX) && propertyString.endsWith(PLACEHOLDER_SUFFIX);
+    return propertyString.startsWith(PLACEHOLDER_PREFIX) && propertyString.contains(PLACEHOLDER_SUFFIX);
   }
 
   private boolean isExpressionWithPlaceholder(String propertyString) {
-    return propertyString.startsWith(EXPRESSION_PREFIX) && propertyString.endsWith(EXPRESSION_SUFFIX)
-        && propertyString.contains(PLACEHOLDER_PREFIX);
+    return propertyString.startsWith(EXPRESSION_PREFIX) && propertyString.contains(EXPRESSION_SUFFIX)
+        && propertyString.contains(PLACEHOLDER_PREFIX) && propertyString.contains(PLACEHOLDER_SUFFIX);
   }
 
   private String normalizeToPlaceholder(String strVal) {

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/spring/property/PlaceholderHelperTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/spring/property/PlaceholderHelperTest.java
@@ -22,6 +22,11 @@ public class PlaceholderHelperTest {
     check("${some.key:100}", "some.key");
     check("${some.key:${some.other.key}}", "some.key", "some.other.key");
     check("${some.key:${some.other.key:100}}", "some.key", "some.other.key");
+
+    check("${some.key}/xx", "some.key");
+    check("${some.key:100}/xx", "some.key");
+    check("${some.key:${some.other.key}/xx}/yy", "some.key", "some.other.key");
+    check("${some.key:${some.other.key:100}/xx}/yy", "some.key", "some.other.key");
   }
 
   @Test
@@ -30,12 +35,21 @@ public class PlaceholderHelperTest {
     check("${${some.key:other.key}}", "some.key");
     check("${${some.key}:100}", "some.key");
     check("${${some.key}:${another.key}}", "some.key", "another.key");
+
+    check("${${some.key}/xx}/xx", "some.key");
+    check("${${some.key:other.key/xx}/xx}/xx", "some.key");
+    check("${${some.key}/xx:100}/xx", "some.key");
+    check("${${some.key}/xx:${another.key}/xx}xx", "some.key", "another.key");
+
   }
 
   @Test
   public void testExtractComplexNestedPlaceholderKeys() throws Exception {
     check("${${a}1${b}:3.${c:${d:100}}}", "a", "b", "c", "d");
     check("${1${a}2${b}3:4.${c:5${d:100}6}7}", "a", "b", "c", "d");
+
+    check("${${a}1${b}:3.${c:${d:100}}}/xx", "a", "b", "c", "d");
+    check("${1${a}2${b}3:4.${c:5${d:100}6}7}/xx", "a", "b", "c", "d");
   }
 
   @Test
@@ -45,6 +59,13 @@ public class PlaceholderHelperTest {
     check("#{new java.text.SimpleDateFormat('${some.key:${some.other.key}}').parse('${another.key}')}", "some.key", "another.key", "some.other.key");
     check("#{new java.text.SimpleDateFormat('${some.key:${some.other.key:abc}}').parse('${another.key}')}", "some.key", "another.key", "some.other.key");
     check("#{new java.text.SimpleDateFormat('${${some.key}}').parse('${${another.key:other.key}}')}", "some.key", "another.key");
+
+    check("#{new java.text.SimpleDateFormat('${some.key}/xx').parse('${another.key}/xx')}", "some.key", "another.key");
+    check("#{new java.text.SimpleDateFormat('${some.key:abc}/xx').parse('${another.key:100}/xx')}", "some.key", "another.key");
+    check("#{new java.text.SimpleDateFormat('${some.key:${some.other.key}/xx}/xx').parse('${another.key}/xx')}", "some.key", "another.key", "some.other.key");
+    check("#{new java.text.SimpleDateFormat('${some.key:${some.other.key:abc}/xx}/xx').parse('${another.key}/xx')}", "some.key", "another.key", "some.other.key");
+    check("#{new java.text.SimpleDateFormat('${${some.key}/xx}').parse('${${another.key:other.key}/xx}/xx')}", "some.key", "another.key");
+
 
     assertTrue(placeholderHelper.extractPlaceholderKeys("#{systemProperties[some.key] ?: 123}").isEmpty());
     assertTrue(placeholderHelper.extractPlaceholderKeys("#{ T(java.lang.Math).random() * 100.0 }").isEmpty());


### PR DESCRIPTION
## What's the purpose of this PR

support extracting placeholder from non-normalized expressions, e.g. ${user.address}/user/gateway

## Which issue(s) this PR fixes:
Fixes #3138 #3169

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
