### PR TITLE
fix: adapt to the scenario that the ConfigService sets context-path (#3316)

### DIFF
--- a/apollo-configservice/src/main/java/com/ctrip/framework/apollo/configservice/filter/ClientAuthenticationFilter.java
+++ b/apollo-configservice/src/main/java/com/ctrip/framework/apollo/configservice/filter/ClientAuthenticationFilter.java
@@ -64,9 +64,9 @@ public class ClientAuthenticationFilter implements Filter {
       }
 
       // check signature
-      String path = request.getServletPath();
+      String uri = request.getRequestURI();
       String query = request.getQueryString();
-      if (!checkAuthorization(authorization, availableSecrets, timestamp, path, query)) {
+      if (!checkAuthorization(authorization, availableSecrets, timestamp, uri, query)) {
         logger.warn("Invalid authorization. appId={},authorization={}", appId, authorization);
         response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized");
         return;


### PR DESCRIPTION
## What's the purpose of this PR

After setting context-path in ConfigService, the AccessKey feature went wrong.
This PR fixes such a scenario. 

## Which issue(s) this PR fixes:
Fixes #3316 

## Brief changelog

Replace `request.getServletPath()` with `request.getRequestURI()`, when `ClientAuthenticationFilter` get the request path from client.

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
