### PR TITLE
add ingress support for config service and admin service

### DIFF
--- a/scripts/helm/README.md
+++ b/scripts/helm/README.md
@@ -70,12 +70,18 @@ The following table lists the configurable parameters of the apollo-service char
 | `configService.replicaCount` | Replica count of apollo-configservice | `2` |
 | `configService.containerPort` | Container port of apollo-configservice | `8080` |
 | `configService.image.repository` | Image repository of apollo-configservice | `apolloconfig/apollo-configservice` |
+| `configService.image.tag` | Image tag of apollo-configservice, e.g. `1.8.0`, leave it to `nil` to use the default version | `nil` |
 | `configService.image.pullPolicy`                | Image pull policy of apollo-configservice | `IfNotPresent` |
 | `configService.imagePullSecrets`                | Image pull secrets of apollo-configservice | `[]` |
 | `configService.service.fullNameOverride` | Override the service name for apollo-configservice | `nil` |
 | `configService.service.port` | The port for the service of apollo-configservice | `8080` |
 | `configService.service.targetPort` | The target port for the service of apollo-configservice | `8080` |
 | `configService.service.type` | The service type of apollo-configservice                     | `ClusterIP` |
+| `configService.ingress.enabled` | Whether to enable the ingress for config-service or not | `false` |
+| `configService.ingress.annotations` | The annotations of the ingress for config-service | `{}` |
+| `configService.ingress.hosts.host` | The host of the ingress for config-service | `nil` |
+| `configService.ingress.hosts.paths` | The paths of the ingress for config-service | `[]` |
+| `configService.ingress.tls` | The tls definition of the ingress for config-service | `[]` |
 | `configService.liveness.initialDelaySeconds` | The initial delay seconds of liveness probe | `100` |
 | `configService.liveness.periodSeconds` | The period seconds of liveness probe | `10` |
 | `configService.readiness.initialDelaySeconds` | The initial delay seconds of readiness probe | `30` |
@@ -83,6 +89,7 @@ The following table lists the configurable parameters of the apollo-service char
 | `configService.config.profiles` | specify the spring profiles to activate | `github,kubernetes` |
 | `configService.config.configServiceUrlOverride` | Override `apollo.config-service.url`: config service url to be accessed by apollo-client | `nil` |
 | `configService.config.adminServiceUrlOverride` | Override `apollo.admin-service.url`: admin service url to be accessed by apollo-portal | `nil` |
+| `configService.config.contextPath` | specify the context path, e.g. `/apollo`, then users could access config service via `http://{config_service_address}/apollo` | `nil` |
 | `configService.env` | Environment variables passed to the container, e.g. <br />`JAVA_OPTS: -Xss256k` | `{}` |
 | `configService.strategy` | The deployment strategy of apollo-configservice | `{}` |
 | `configService.resources` | The resources definition of apollo-configservice | `{}` |
@@ -93,17 +100,24 @@ The following table lists the configurable parameters of the apollo-service char
 | `adminService.replicaCount` | Replica count of apollo-adminservice | `2` |
 | `adminService.containerPort` | Container port of apollo-adminservice | `8090` |
 | `adminService.image.repository` | Image repository of apollo-adminservice | `apolloconfig/apollo-adminservice` |
+| `adminService.image.tag` | Image tag of apollo-adminservice, e.g. `1.8.0`, leave it to `nil` to use the default version | `nil` |
 | `adminService.image.pullPolicy`                | Image pull policy of apollo-adminservice | `IfNotPresent` |
 | `adminService.imagePullSecrets`                | Image pull secrets of apollo-adminservice | `[]` |
 | `adminService.service.fullNameOverride` | Override the service name for apollo-adminservice | `nil` |
 | `adminService.service.port` | The port for the service of apollo-adminservice | `8090` |
 | `adminService.service.targetPort` | The target port for the service of apollo-adminservice | `8090` |
 | `adminService.service.type` | The service type of apollo-adminservice                     | `ClusterIP` |
+| `adminService.ingress.enabled` | Whether to enable the ingress for admin-service or not | `false` |
+| `adminService.ingress.annotations` | The annotations of the ingress for admin-service | `{}` |
+| `adminService.ingress.hosts.host` | The host of the ingress for admin-service | `nil` |
+| `adminService.ingress.hosts.paths` | The paths of the ingress for admin-service | `[]` |
+| `adminService.ingress.tls` | The tls definition of the ingress for admin-service | `[]` |
 | `adminService.liveness.initialDelaySeconds` | The initial delay seconds of liveness probe | `100` |
 | `adminService.liveness.periodSeconds` | The period seconds of liveness probe | `10` |
 | `adminService.readiness.initialDelaySeconds` | The initial delay seconds of readiness probe | `30` |
 | `adminService.readiness.periodSeconds` | The period seconds of readiness probe | `5` |
 | `adminService.config.profiles` | specify the spring profiles to activate | `github,kubernetes` |
+| `adminService.config.contextPath` | specify the context path, e.g. `/apollo`, then users could access admin service via `http://{admin_service_address}/apollo` | `nil` |
 | `adminService.env` | Environment variables passed to the container, e.g. <br />`JAVA_OPTS: -Xss256k` | `{}` |
 | `adminService.strategy` | The deployment strategy of apollo-adminservice | `{}` |
 | `adminService.resources` | The resources definition of apollo-adminservice | `{}` |
@@ -149,6 +163,35 @@ configdb:
   password: somePassword
   connectionStringProperties: characterEncoding=utf8&useSSL=false
 ```
+
+4. Expose config service as Ingress with custom path `/config`
+
+```yaml
+# use /config as root, should specify configService.config.contextPath as /config
+configService:
+  config:
+    contextPath: /config
+  ingress:
+    enabled: true
+    hosts:
+      - paths:
+          - /config
+```
+
+5. Expose admin service as Ingress with custom path `/admin`
+
+```yaml
+# use /admin as root, should specify adminService.config.contextPath as /admin
+adminService:
+  config:
+    contextPath: /admin
+  ingress:
+    enabled: true
+    hosts:
+      - paths:
+          - /admin
+```
+
 ## 5. Deployments of apollo-portal
 
 ### 5.1 Install
@@ -193,6 +236,7 @@ The following table lists the configurable parameters of the apollo-portal chart
 | `replicaCount` | Replica count of apollo-portal | `2` |
 | `containerPort` | Container port of apollo-portal | `8070` |
 | `image.repository` | Image repository of apollo-portal | `apolloconfig/apollo-portal` |
+| `image.tag` | Image tag of apollo-portal, e.g. `1.8.0`, leave it to `nil` to use the default version | `nil` |
 | `image.pullPolicy`                | Image pull policy of apollo-portal | `IfNotPresent` |
 | `imagePullSecrets`                | Image pull secrets of apollo-portal | `[]` |
 | `service.fullNameOverride` | Override the service name for apollo-portal | `nil` |

--- a/scripts/helm/apollo-portal/templates/NOTES.txt
+++ b/scripts/helm/apollo-portal/templates/NOTES.txt
@@ -1,11 +1,5 @@
-Get apollo portal url by running these commands:
-{{- if .Values.ingress.enabled }}
-{{- range $host := .Values.ingress.hosts }}
-  {{- range .paths }}
-  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
-  {{- end }}
-{{- end }}
-{{- else if contains "NodePort" .Values.service.type }}
+Portal url for current release:
+{{- if contains "NodePort" .Values.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "apollo.portal.fullName" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT
@@ -18,4 +12,14 @@ Get apollo portal url by running these commands:
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ include "apollo.portal.fullName" . }}" -o jsonpath="{.items[0].metadata.name}")
   echo "Visit http://127.0.0.1:8070 to use your application"
   kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8070:8070
+{{- end }}
+
+{{- if .Values.ingress.enabled }}
+
+Ingress:
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
 {{- end }}

--- a/scripts/helm/apollo-portal/templates/deployment-portal.yaml
+++ b/scripts/helm/apollo-portal/templates/deployment-portal.yaml
@@ -66,7 +66,7 @@ spec:
             defaultMode: 420
       containers:
         - name: {{ .Values.name }}
-          image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/scripts/helm/apollo-portal/values.yaml
+++ b/scripts/helm/apollo-portal/values.yaml
@@ -4,6 +4,7 @@ replicaCount: 2
 containerPort: 8070
 image:
   repository: apolloconfig/apollo-portal
+  tag: ""
   pullPolicy: IfNotPresent
 imagePullSecrets: []
 service:

--- a/scripts/helm/apollo-service/Chart.yaml
+++ b/scripts/helm/apollo-service/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: apollo-service
 description: A Helm chart for Apollo Config Service and Apollo Admin Service
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: 1.8.0-SNAPSHOT
 home: https://github.com/ctripcorp/apollo
 icon: https://raw.githubusercontent.com/ctripcorp/apollo/master/apollo-portal/src/main/resources/static/img/logo-simple.png

--- a/scripts/helm/apollo-service/templates/NOTES.txt
+++ b/scripts/helm/apollo-service/templates/NOTES.txt
@@ -1,18 +1,32 @@
-Get meta service url for current release by running these commands:
+Meta service url for current release:
 {{- if contains "NodePort" .Values.configService.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "apollo.configService.fullName" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-  echo http://$NODE_IP:$NODE_PORT
+  echo http://$NODE_IP:$NODE_PORT{{ .Values.configService.config.contextPath }}
 {{- else if contains "LoadBalancer" .Values.configService.service.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
            You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "apollo.configService.fullName" . }}'
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "apollo.configService.serviceName" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
-  echo http://$SERVICE_IP:{{ .Values.service.port }}
+  echo http://$SERVICE_IP:{{ .Values.service.port }}{{ .Values.configService.config.contextPath }}
 {{- else if contains "ClusterIP" .Values.configService.service.type }}
-  echo http://{{ include "apollo.configService.serviceName" .}}.{{ .Release.Namespace }}:{{ .Values.configService.service.port }}
+  echo {{ include "apollo.configService.serviceUrl" .}}
 
 For local test use:
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ include "apollo.configService.fullName" . }}" -o jsonpath="{.items[0].metadata.name}")
-  echo http://127.0.0.1:8080
+  echo http://127.0.0.1:8080{{ .Values.configService.config.contextPath }}
   kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:8080
 {{- end }}
+
+{{- if .Values.configService.ingress.enabled }}
+
+Ingress:
+{{- range $host := .Values.configService.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.configService.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
+{{- end }}
+
+Urls registered to meta service:
+Config service: {{ include "apollo.configService.serviceUrl" .}}
+Admin service: {{ include "apollo.adminService.serviceUrl" .}}

--- a/scripts/helm/apollo-service/templates/_helpers.tpl
+++ b/scripts/helm/apollo-service/templates/_helpers.tpl
@@ -57,7 +57,7 @@ Config service url to be accessed by apollo-client
 {{- if .Values.configService.config.configServiceUrlOverride -}}
 {{ .Values.configService.config.configServiceUrlOverride }}
 {{- else -}}
-http://{{ include "apollo.configService.serviceName" .}}.{{ .Release.Namespace }}:{{ .Values.configService.service.port }}
+http://{{ include "apollo.configService.serviceName" .}}.{{ .Release.Namespace }}:{{ .Values.configService.service.port }}{{ .Values.configService.config.contextPath }}
 {{- end -}}
 {{- end -}}
 
@@ -94,6 +94,6 @@ Admin service url to be accessed by apollo-portal
 {{- if .Values.configService.config.adminServiceUrlOverride -}}
 {{ .Values.configService.config.adminServiceUrlOverride -}}
 {{- else -}}
-http://{{ include "apollo.adminService.serviceName" .}}.{{ .Release.Namespace }}:{{ .Values.adminService.service.port }}
+http://{{ include "apollo.adminService.serviceName" .}}.{{ .Release.Namespace }}:{{ .Values.adminService.service.port }}{{ .Values.adminService.config.contextPath }}
 {{- end -}}
 {{- end -}}

--- a/scripts/helm/apollo-service/templates/deployment-adminservice.yaml
+++ b/scripts/helm/apollo-service/templates/deployment-adminservice.yaml
@@ -10,6 +10,9 @@ data:
     spring.datasource.url = jdbc:mysql://{{include "apollo.configdb.serviceName" .}}:{{ .Values.configdb.service.port }}/{{ .Values.configdb.dbName }}{{ if .Values.configdb.connectionStringProperties }}?{{ .Values.configdb.connectionStringProperties }}{{ end }}
     spring.datasource.username = {{ required "configdb.userName is required!" .Values.configdb.userName }}
     spring.datasource.password = {{ required "configdb.password is required!" .Values.configdb.password }}
+    {{- if .Values.adminService.config.contextPath }}
+    server.servlet.context-path = {{ .Values.adminService.config.contextPath }}
+    {{- end }}
 
 ---
 kind: Deployment
@@ -46,7 +49,7 @@ spec:
             defaultMode: 420
       containers:
         - name: {{ .Values.adminService.name }}
-          image: "{{ .Values.adminService.image.repository }}:{{ .Chart.AppVersion }}"
+          image: "{{ .Values.adminService.image.repository }}:{{ .Values.adminService.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.adminService.image.pullPolicy }}
           ports:
             - name: http
@@ -70,7 +73,7 @@ spec:
             periodSeconds: {{ .Values.adminService.liveness.periodSeconds }}
           readinessProbe:
             httpGet:
-              path: /health
+              path: {{ .Values.adminService.config.contextPath }}/health
               port: {{ .Values.adminService.containerPort }}
             initialDelaySeconds: {{ .Values.adminService.readiness.initialDelaySeconds }}
             periodSeconds: {{ .Values.adminService.readiness.periodSeconds }}

--- a/scripts/helm/apollo-service/templates/deployment-configservice.yaml
+++ b/scripts/helm/apollo-service/templates/deployment-configservice.yaml
@@ -12,6 +12,9 @@ data:
     spring.datasource.password = {{ required "configdb.password is required!" .Values.configdb.password }}
     apollo.config-service.url = {{ include "apollo.configService.serviceUrl" .}}
     apollo.admin-service.url = {{ include "apollo.adminService.serviceUrl" .}}
+    {{- if .Values.configService.config.contextPath }}
+    server.servlet.context-path = {{ .Values.configService.config.contextPath }}
+    {{- end }}
 
 ---
 kind: Deployment
@@ -48,7 +51,7 @@ spec:
             defaultMode: 420
       containers:
         - name: {{ .Values.configService.name }}
-          image: "{{ .Values.configService.image.repository }}:{{ .Chart.AppVersion }}"
+          image: "{{ .Values.configService.image.repository }}:{{ .Values.configService.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.configService.image.pullPolicy }}
           ports:
             - name: http
@@ -72,7 +75,7 @@ spec:
             periodSeconds: {{ .Values.configService.liveness.periodSeconds }}
           readinessProbe:
             httpGet:
-              path: /health
+              path: {{ .Values.configService.config.contextPath }}/health
               port: {{ .Values.configService.containerPort }}
             initialDelaySeconds: {{ .Values.configService.readiness.initialDelaySeconds }}
             periodSeconds: {{ .Values.configService.readiness.periodSeconds }}

--- a/scripts/helm/apollo-service/templates/ingress-adminservice.yaml
+++ b/scripts/helm/apollo-service/templates/ingress-adminservice.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.adminService.ingress.enabled -}}
+{{- $fullName := include "apollo.adminService.fullName" . -}}
+{{- $svcPort := .Values.adminService.service.port -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "apollo.service.labels" . | nindent 4 }}
+  {{- with .Values.adminService.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+{{- if .Values.adminService.ingress.tls }}
+  tls:
+  {{- range .Values.adminService.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.adminService.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+        {{- range .paths }}
+          - path: {{ . }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+        {{- end }}
+  {{- end }}
+{{- end }}

--- a/scripts/helm/apollo-service/templates/ingress-configservice.yaml
+++ b/scripts/helm/apollo-service/templates/ingress-configservice.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.configService.ingress.enabled -}}
+{{- $fullName := include "apollo.configService.fullName" . -}}
+{{- $svcPort := .Values.configService.service.port -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "apollo.service.labels" . | nindent 4 }}
+  {{- with .Values.configService.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+{{- if .Values.configService.ingress.tls }}
+  tls:
+  {{- range .Values.configService.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.configService.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+        {{- range .paths }}
+          - path: {{ . }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+        {{- end }}
+  {{- end }}
+{{- end }}

--- a/scripts/helm/apollo-service/values.yaml
+++ b/scripts/helm/apollo-service/values.yaml
@@ -23,6 +23,7 @@ configService:
   containerPort: 8080
   image:
     repository: apolloconfig/apollo-configservice
+    tag: ""
     pullPolicy: IfNotPresent
   imagePullSecrets: []
   service:
@@ -30,6 +31,13 @@ configService:
     port: 8080
     targetPort: 8080
     type: ClusterIP
+  ingress:
+    enabled: false
+    annotations: { }
+    hosts:
+      - host: ""
+        paths: [ ]
+    tls: [ ]
   liveness:
     initialDelaySeconds: 100
     periodSeconds: 10
@@ -43,6 +51,8 @@ configService:
     configServiceUrlOverride: ""
     # override apollo.admin-service.url: admin service url to be accessed by apollo-portal 
     adminServiceUrlOverride: ""
+    # specify the context path, e.g. /apollo
+    contextPath: ""
   # environment variables passed to the container, e.g. JAVA_OPTS
   env: {}
   strategy: {}
@@ -58,6 +68,7 @@ adminService:
   containerPort: 8090
   image:
     repository: apolloconfig/apollo-adminservice
+    tag: ""
     pullPolicy: IfNotPresent
   imagePullSecrets: []
   service:
@@ -65,6 +76,13 @@ adminService:
     port: 8090
     targetPort: 8090
     type: ClusterIP
+  ingress:
+    enabled: false
+    annotations: { }
+    hosts:
+      - host: ""
+        paths: [ ]
+    tls: [ ]
   liveness:
     initialDelaySeconds: 100
     periodSeconds: 10
@@ -74,6 +92,8 @@ adminService:
   config:
     # spring profiles to activate
     profiles: "github,kubernetes"
+    # specify the context path, e.g. /apollo
+    contextPath: ""
   # environment variables passed to the container, e.g. JAVA_OPTS
   env: {}
   strategy: {}


### PR DESCRIPTION
## What's the purpose of this PR

add ingress support for config service and admin service

## Which issue(s) this PR fixes:
Fixes #3316

## Brief changelog

1. add context path and ingress support for config service and admin service
2. allow users to override image tags

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
