### PR TITLE
Fix typo about the AccessKey Chinese translation

### DIFF
--- a/apollo-portal/src/main/resources/static/i18n/zh-CN.json
+++ b/apollo-portal/src/main/resources/static/i18n/zh-CN.json
@@ -339,7 +339,7 @@
   "Config.MissEnv": "缺失的环境",
   "Config.MissNamespace": "缺失的Namespace",
   "Config.ProjectManage": "管理项目",
-  "Config.AccessKeyManage": "管理秘钥",
+  "Config.AccessKeyManage": "管理密钥",
   "Config.CreateAppMissEnv": "补缺环境",
   "Config.CreateAppMissNamespace": "补缺Namespace",
   "Config.AddCluster": "添加集群",


### PR DESCRIPTION
## What's the purpose of this PR

I had made a little mistake with the `AccessKey` Chinese translation.
It seems should use `密钥` than `秘钥`. 
And other parts have already used `密钥`, only here have a typo.

@nobodyiam 
It should also update some screen snapshot images and the [wiki](https://github.com/ctripcorp/apollo/wiki/Apollo%E4%BD%BF%E7%94%A8%E6%8C%87%E5%8D%97#62-%E9%85%8D%E7%BD%AE%E8%AE%BF%E9%97%AE%E7%A7%98%E9%92%A5) if accept this PR. (But for some limitation, I cannot commit.)


## Which issue(s) this PR fixes:

None

## Brief changelog

Just one Chinese typo

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
