### PR TITLE
docker-compose构建容器无法运行的问题

### DIFF
--- a/scripts/docker-quick-start/README.md
+++ b/scripts/docker-quick-start/README.md
@@ -1,0 +1,107 @@
+Apollo Quick Start Docker部署
+-----
+
+如果您对Docker非常熟悉，可以使用Docker的方式快速部署Apollo，从而快速的了解Apollo。如果您对Docker并不是很了解，请参考[常规方式部署Quick Start](https://github.com/ctripcorp/apollo/wiki/Quick-Start) 。
+
+另外需要说明的是，不管是Docker方式部署Quick Start还是常规方式部署的，Quick Start只是用来快速入门、了解Apollo。如果部署Apollo在公司中使用，请参考[分布式部署指南](https://github.com/ctripcorp/apollo/wiki/%E5%88%86%E5%B8%83%E5%BC%8F%E9%83%A8%E7%BD%B2%E6%8C%87%E5%8D%97) 。
+
+> 由于Docker对windows的支持并不是很好，所以不建议您在windows环境下使用Docker方式部署，除非您对windows docker非常了解
+
+# 一、 准备工作
+## 1.1 安装Docker
+具体步骤可以参考[Docker安装指南](https://yeasy.gitbooks.io/docker_practice/content/install/) ，通过以下命令测试是否成功安装
+```shell script
+docker -v
+```
+为了加速Docker镜像下载，建议[配置镜像加速器](https://yeasy.gitbooks.io/docker_practice/content/install/mirror.html) 。
+
+## 1.2 下载Docker Quick Start配置文件
+确保[docker-quick-start](https://github.com/ctripcorp/apollo/tree/master/scripts/docker-quick-start) 文件夹已经在本地存在，如果本地已经clone过Apollo的代码，则可以跳过此步骤。
+
+# 二、启动Apollo配置中心
+在docker-quick-start目录下执行`docker-compose up`，第一次执行会触发下载镜像等操作，需要耐心等待一些时间。
+
+搜索所有apollo-quick-start开头的日志，看到以下日志说明启动成功：
+
+```shell script
+apollo-quick-start    | ==== starting service ====
+apollo-quick-start    | Service logging file is ./service/apollo-service.log
+apollo-quick-start    | Started [45]
+apollo-quick-start    | Waiting for config service startup.......
+apollo-quick-start    | Config service started. You may visit http://localhost:8080 for service status now!
+apollo-quick-start    | Waiting for admin service startup......
+apollo-quick-start    | Admin service started
+apollo-quick-start    | ==== starting portal ====
+apollo-quick-start    | Portal logging file is ./portal/apollo-portal.log
+apollo-quick-start    | Started [254]
+apollo-quick-start    | Waiting for portal startup.......
+apollo-quick-start    | Portal started. You can visit http://localhost:8070 now!
+```
+> 注1：数据库的端口映射为13306，所以如果希望在宿主机上访问数据库，可以通过localhost:13306，用户名是root，密码留空。
+
+> 注2：如要查看更多服务的日志，可以通过docker exec -it apollo-quick-start bash登录， 然后到/apollo-quick-start/service和/apollo-quick-start/portal下查看日志信息。
+
+> docker-compose.yml 默认配置
+
+```yml
+version: '2'
+
+services:
+  apollo-quick-start:
+    image: nobodyiam/apollo-quick-start
+    container_name: apollo-quick-start
+    depends_on:
+      - apollo-db
+    ports:
+      - "8080:8080"
+      - "8070:8070"
+    links:
+      - apollo-db
+
+  apollo-db:
+    image: mysql:5.7
+    container_name: apollo-db
+    environment:
+      TZ: Asia/Shanghai
+      MYSQL_ROOT_PASSWORD: root
+    depends_on:
+      - apollo-dbdata
+    ports:
+      - "13306:3306"
+    volumes:
+      - ./sql:/docker-entrypoint-initdb.d
+    volumes_from:
+      - apollo-dbdata
+
+  apollo-dbdata:
+    image: alpine:latest
+    container_name: apollo-dbdata
+    volumes:
+      - /var/lib/mysql
+```
+
+> docker-compose.yml 使用已存在的Mysql Docker容器实例时，请确保该Mysql容器实例已经导入过sql脚本文件：apolloconfigdb.sql、apolloportaldb.sql
+```yml
+version: '2'
+  
+services:
+  apollo-quick-start:
+    image: nobodyiam/apollo-quick-start
+    container_name: apollo-quick-start
+    environment:
+      - APOLLO_CONFIG_DB_URL=jdbc:mysql://192.168.1.10:3306/ApolloConfigDB?characterEncoding=utf8
+      - APOLLO_PORTAL_DB_URL=jdbc:mysql://192.168.1.10:3306/ApolloPortalDB?characterEncoding=utf8
+      - APOLLO_DB_USERNAME=root
+      - APOLLO_DB_PASSWORD=youpassword
+    ports:
+      - "8080:8080"
+      - "8070:8070"
+```
+
+# 三、使用Apollo配置中心
+使用相关步骤可以参考[Quick Start - 四、使用Apollo配置中心](https://github.com/ctripcorp/apollo/wiki/Quick-Start#%E5%9B%9B%E4%BD%BF%E7%94%A8apollo%E9%85%8D%E7%BD%AE%E4%B8%AD%E5%BF%83) 
+
+需要注意的是，在Docker环境下需要通过下面的命令运行Demo客户端：
+```shell script
+docker exec -i apollo-quick-start /apollo-quick-start/demo.sh client
+```

--- a/scripts/docker-quick-start/README.md
+++ b/scripts/docker-quick-start/README.md
@@ -89,10 +89,9 @@ services:
     image: nobodyiam/apollo-quick-start
     container_name: apollo-quick-start
     environment:
-      - APOLLO_CONFIG_DB_URL=jdbc:mysql://192.168.1.10:3306/ApolloConfigDB?characterEncoding=utf8
-      - APOLLO_PORTAL_DB_URL=jdbc:mysql://192.168.1.10:3306/ApolloPortalDB?characterEncoding=utf8
+      - APOLLO_DB_HOST=192.168.1.10
       - APOLLO_DB_USERNAME=root
-      - APOLLO_DB_PASSWORD=youpassword
+      - APOLLO_DB_PASSWORD=root
     ports:
       - "8080:8080"
       - "8070:8070"

--- a/scripts/docker-quick-start/docker-compose.yml
+++ b/scripts/docker-quick-start/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     container_name: apollo-db
     environment:
       TZ: Asia/Shanghai
-      MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
+      MYSQL_ROOT_PASSWORD: root
     depends_on:
       - apollo-dbdata
     ports:

--- a/scripts/docker-quick-start/docker-compose.yml
+++ b/scripts/docker-quick-start/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     depends_on:
       - apollo-dbdata
     ports:
-      - "13306:3306"
+      - "3306:3306"
     volumes:
       - ./sql:/docker-entrypoint-initdb.d
     volumes_from:


### PR DESCRIPTION
- 增加支持使用已有mysql容器
- root 用户增加了默认密码
同步需要更新https://github.com/nobodyiam/apollo-build-scripts/