### PR TITLE
Update values.yaml

### DIFF
--- a/scripts/helm/apollo-portal/values.yaml
+++ b/scripts/helm/apollo-portal/values.yaml
@@ -1,6 +1,6 @@
 name: apollo-portal
 fullNameOverride: ""
-replicaCount: 2
+replicaCount: 1
 containerPort: 8070
 image:
   repository: apolloconfig/apollo-portal


### PR DESCRIPTION
## What's the purpose of this PR

helm portal 建议保持一个副本

## Which issue(s) this PR fixes:
Fixes #

## Brief changelog

我觉得一般的情况都是通过 ingress 访问 portal 的，ingress 一般都是直接访问 pod 的 ip 端口而不是通过 service 访问后端 pod，所以 sessionAffinity: ClientIP 这个参数在 ingress 访问下没法实现会话保持，建议 session 没有共享到 memcached，redis 啥的之前，portal 保持一个副本。
