### PR TITLE
修复chart在未开启mysql服务代理时无法使用配置的mysql端口问题

### DIFF
--- a/scripts/helm/apollo-portal/templates/_helpers.tpl
+++ b/scripts/helm/apollo-portal/templates/_helpers.tpl
@@ -49,3 +49,14 @@ Service name for portaldb
 {{- .Values.portaldb.host -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Service port for portaldb
+*/}}
+{{- define "apollo.portaldb.servicePort" -}}
+{{- if .Values.portaldb.service.enabled -}}
+{{- .Values.portaldb.service.port -}}
+{{- else -}}
+{{- .Values.portaldb.port -}}
+{{- end -}}
+{{- end -}}

--- a/scripts/helm/apollo-portal/templates/deployment-portal.yaml
+++ b/scripts/helm/apollo-portal/templates/deployment-portal.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ $portalFullName }}
 data:
   application-github.properties: |
-    spring.datasource.url = jdbc:mysql://{{include "apollo.portaldb.serviceName" .}}:{{include "apollo.portaldb.servicePort" .}}/{{ .Values.portaldb.dbName }}{{ if .Values.portaldb.connectionStringProperties }}?{{ .Values.portaldb.connectionStringProperties }}{{ end }} 
+    spring.datasource.url = jdbc:mysql://{{include "apollo.portaldb.serviceName" .}}:{{include "apollo.portaldb.servicePort" .}}/{{ .Values.portaldb.dbName }}{{ if .Values.portaldb.connectionStringProperties }}?{{ .Values.portaldb.connectionStringProperties }}{{ end }}
     spring.datasource.username = {{ required "portaldb.userName is required!" .Values.portaldb.userName }}
     spring.datasource.password = {{ required "portaldb.password is required!" .Values.portaldb.password }}
     {{- if .Values.config.envs }}

--- a/scripts/helm/apollo-portal/templates/deployment-portal.yaml
+++ b/scripts/helm/apollo-portal/templates/deployment-portal.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ $portalFullName }}
 data:
   application-github.properties: |
-    spring.datasource.url = jdbc:mysql://{{include "apollo.portaldb.serviceName" .}}:{{ .Values.portaldb.service.port }}/{{ .Values.portaldb.dbName }}{{ if .Values.portaldb.connectionStringProperties }}?{{ .Values.portaldb.connectionStringProperties }}{{ end }}
+    spring.datasource.url = jdbc:mysql://{{include "apollo.portaldb.serviceName" .}}:{{include "apollo.portaldb.servicePort" .}}/{{ .Values.portaldb.dbName }}{{ if .Values.portaldb.connectionStringProperties }}?{{ .Values.portaldb.connectionStringProperties }}{{ end }} 
     spring.datasource.username = {{ required "portaldb.userName is required!" .Values.portaldb.userName }}
     spring.datasource.password = {{ required "portaldb.password is required!" .Values.portaldb.password }}
     {{- if .Values.config.envs }}

--- a/scripts/helm/apollo-service/templates/_helpers.tpl
+++ b/scripts/helm/apollo-service/templates/_helpers.tpl
@@ -25,6 +25,17 @@ Service name for configdb
 {{- end -}}
 
 {{/*
+Service port for configdb
+*/}}
+{{- define "apollo.configdb.servicePort" -}}
+{{- if .Values.configdb.service.enabled -}}
+{{- .Values.configdb.service.port -}}
+{{- else -}}
+{{- .Values.configdb.port -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Full name for config service
 */}}
 {{- define "apollo.configService.fullName" -}}

--- a/scripts/helm/apollo-service/templates/deployment-adminservice.yaml
+++ b/scripts/helm/apollo-service/templates/deployment-adminservice.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ $adminServiceFullName }}
 data:
   application-github.properties: |
-    spring.datasource.url = jdbc:mysql://{{include "apollo.configdb.serviceName" .}}:{{ .Values.configdb.service.port }}/{{ .Values.configdb.dbName }}{{ if .Values.configdb.connectionStringProperties }}?{{ .Values.configdb.connectionStringProperties }}{{ end }}
+    spring.datasource.url = jdbc:mysql://{{include "apollo.configdb.serviceName" .}}:{{include "apollo.configdb.servicePort" .}}/{{ .Values.configdb.dbName }}{{ if .Values.configdb.connectionStringProperties }}?{{ .Values.configdb.connectionStringProperties }}{{ end }}
     spring.datasource.username = {{ required "configdb.userName is required!" .Values.configdb.userName }}
     spring.datasource.password = {{ required "configdb.password is required!" .Values.configdb.password }}
     {{- if .Values.adminService.config.contextPath }}

--- a/scripts/helm/apollo-service/templates/deployment-configservice.yaml
+++ b/scripts/helm/apollo-service/templates/deployment-configservice.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ $configServiceFullName }}
 data:
   application-github.properties: |
-    spring.datasource.url = jdbc:mysql://{{include "apollo.configdb.serviceName" .}}:{{include "apollo.configdb.servicePort" .}}/{{ .Values.configdb.dbName }}{{ if .Values.configdb.connectionStringProperties }}?{{ .Values.configdb.connectionStringProperties }}{{ end }} 
+    spring.datasource.url = jdbc:mysql://{{include "apollo.configdb.serviceName" .}}:{{include "apollo.configdb.servicePort" .}}/{{ .Values.configdb.dbName }}{{ if .Values.configdb.connectionStringProperties }}?{{ .Values.configdb.connectionStringProperties }}{{ end }}
     spring.datasource.username = {{ required "configdb.userName is required!" .Values.configdb.userName }}
     spring.datasource.password = {{ required "configdb.password is required!" .Values.configdb.password }}
     apollo.config-service.url = {{ include "apollo.configService.serviceUrl" .}}

--- a/scripts/helm/apollo-service/templates/deployment-configservice.yaml
+++ b/scripts/helm/apollo-service/templates/deployment-configservice.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ $configServiceFullName }}
 data:
   application-github.properties: |
-    spring.datasource.url = jdbc:mysql://{{include "apollo.configdb.serviceName" .}}:{{ .Values.configdb.service.port }}/{{ .Values.configdb.dbName }}{{ if .Values.configdb.connectionStringProperties }}?{{ .Values.configdb.connectionStringProperties }}{{ end }}
+    spring.datasource.url = jdbc:mysql://{{include "apollo.configdb.serviceName" .}}:{{include "apollo.configdb.servicePort" .}}/{{ .Values.configdb.dbName }}{{ if .Values.configdb.connectionStringProperties }}?{{ .Values.configdb.connectionStringProperties }}{{ end }} 
     spring.datasource.username = {{ required "configdb.userName is required!" .Values.configdb.userName }}
     spring.datasource.password = {{ required "configdb.password is required!" .Values.configdb.password }}
     apollo.config-service.url = {{ include "apollo.configService.serviceUrl" .}}


### PR DESCRIPTION
修复admin、config、portal三个服务在通过helm部署时，**如果不开启mysql的代理服务，values.yaml中的mysql端口不会被使用，会使用代理服务的端口**。

以**apollo-server/configserver** 为例：
如果Values.configdb.service.enabled=false时，表示不使用mysql的代理，
此时configmap中的定义是：
> spring.datasource.url = jdbc:mysql://{{include "apollo.configdb.serviceName" .}}:{{ .Values.configdb.service.port }}     

注意，服务地址使用的模板定义，但端口使用的**Values.configdb.service.port**，这意味着不开启mysql代理时，连接的是自定义的mysql服务地址+代理服务的端口(尽管此时并没有开启代理服务)。

三个服务均有该问题，如果配置的mysql端口不是默认的3306时就能发现该问题（服务连不上数据库）


**解决方案**
对数据库端口也进行模板定义，configmap中修改为：
>  spring.datasource.url = jdbc:mysql://{{include "apollo.configdb.serviceName" .}}:{{include "apollo.configdb.servicePort" .}}     

apollo.configdb.servicePort的模板定义如下：
> {{/*
Service port for configdb
*/}}
{{- define "apollo.configdb.servicePort" -}}
{{- if .Values.configdb.service.enabled -}}
{{- .Values.configdb.service.port -}}
{{- else -}}
{{- .Values.configdb.port -}}
{{- end -}}
{{- end -}}
     

以上是对configserver的修改，对adminserver只需调整configmap即可；portal则进行了以上相同的修改~

