### PR TITLE
APOLLO_RUN_MODE 为 Docker 时 应该用 exec 来启动 java 进程

### DIFF
--- a/apollo-adminservice/src/main/scripts/startup.sh
+++ b/apollo-adminservice/src/main/scripts/startup.sh
@@ -118,7 +118,7 @@ fi
 
 # For Docker environment, start in foreground mode
 if [[ -n "$APOLLO_RUN_MODE" ]] && [[ "$APOLLO_RUN_MODE" == "Docker" ]]; then
-    $javaexe -Dsun.misc.URLClassPath.disableJarChecking=true $JAVA_OPTS -jar $PATH_TO_JAR
+    exec $javaexe -Dsun.misc.URLClassPath.disableJarChecking=true $JAVA_OPTS -jar $PATH_TO_JAR
 else
     if [[ -f $SERVICE_NAME".jar" ]]; then
       rm -rf $SERVICE_NAME".jar"

--- a/apollo-configservice/src/main/scripts/startup.sh
+++ b/apollo-configservice/src/main/scripts/startup.sh
@@ -118,7 +118,7 @@ fi
 
 # For Docker environment, start in foreground mode
 if [[ -n "$APOLLO_RUN_MODE" ]] && [[ "$APOLLO_RUN_MODE" == "Docker" ]]; then
-    $javaexe -Dsun.misc.URLClassPath.disableJarChecking=true $JAVA_OPTS -jar $PATH_TO_JAR
+    exec $javaexe -Dsun.misc.URLClassPath.disableJarChecking=true $JAVA_OPTS -jar $PATH_TO_JAR
 else
     if [[ -f $SERVICE_NAME".jar" ]]; then
         rm -rf $SERVICE_NAME".jar"

--- a/apollo-portal/src/main/scripts/startup.sh
+++ b/apollo-portal/src/main/scripts/startup.sh
@@ -118,7 +118,7 @@ fi
 
 # For Docker environment, start in foreground mode
 if [[ -n "$APOLLO_RUN_MODE" ]] && [[ "$APOLLO_RUN_MODE" == "Docker" ]]; then
-    $javaexe -Dsun.misc.URLClassPath.disableJarChecking=true $JAVA_OPTS -jar $PATH_TO_JAR
+    exec $javaexe -Dsun.misc.URLClassPath.disableJarChecking=true $JAVA_OPTS -jar $PATH_TO_JAR
 else
     if [[ -f $SERVICE_NAME".jar" ]]; then
       rm -rf $SERVICE_NAME".jar"


### PR DESCRIPTION
不使用 exec 启动 java 会让 docker 容器中出现两个进程，bash 进程和 jvm 进程 ，传递给容器的信号将被 bash 进程接收，无法正确传递给 jvm