### PR TITLE
switch off console appenders when running as backend services

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
       run: mvn clean compile -pl apollo-client,apollo-mockserver,apollo-openapi -am -Dmaven.gitcommitid.skip=true
     - name: JDK 8
       if: matrix.jdk == '8'
-      run: mvn -B package -P travis jacoco:report -Dmaven.gitcommitid.skip=true
+      run: mvn -B clean package -P travis jacoco:report -Dmaven.gitcommitid.skip=true
     - name: JDK 11 
       if: matrix.jdk == '11'
       run: mvn clean compile -Dmaven.gitcommitid.skip=true

--- a/apollo-adminservice/pom.xml
+++ b/apollo-adminservice/pom.xml
@@ -94,9 +94,6 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
-				<configuration>
-					<executable>true</executable>
-				</configuration>
 			</plugin>
 			<plugin>
 				<artifactId>maven-assembly-plugin</artifactId>

--- a/apollo-adminservice/src/main/config/apollo-adminservice.conf
+++ b/apollo-adminservice/src/main/config/apollo-adminservice.conf
@@ -1,3 +1,8 @@
 MODE=service
 PID_FOLDER=.
+# console appender log file folder
 LOG_FOLDER=/opt/logs/100003172/
+# console appender file name
+LOG_FILENAME=console.log
+# write application logs only to file appender
+export LOG_APPENDERS=FILE

--- a/apollo-adminservice/src/main/resources/logback.xml
+++ b/apollo-adminservice/src/main/resources/logback.xml
@@ -6,7 +6,23 @@
 	<include resource="org/springframework/boot/logging/logback/file-appender.xml" />
 	<include resource="org/springframework/boot/logging/logback/console-appender.xml" />
 	<root level="INFO">
-		<appender-ref ref="FILE" />
-		<appender-ref ref="CONSOLE" />
+		<if condition='isDefined("LOG_APPENDERS")'>
+			<then>
+				<if condition='property("LOG_APPENDERS").contains("CONSOLE")'>
+					<then>
+						<appender-ref ref="CONSOLE"/>
+					</then>
+				</if>
+				<if condition='property("LOG_APPENDERS").contains("FILE")'>
+					<then>
+						<appender-ref ref="FILE"/>
+					</then>
+				</if>
+			</then>
+			<else>
+				<appender-ref ref="FILE" />
+				<appender-ref ref="CONSOLE" />
+			</else>
+		</if>
 	</root>
 </configuration>

--- a/apollo-adminservice/src/main/scripts/shutdown.sh
+++ b/apollo-adminservice/src/main/scripts/shutdown.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 SERVICE_NAME=apollo-adminservice
+export APP_NAME=$SERVICE_NAME
 
 if [[ -z "$JAVA_HOME" && -d /usr/java/latest/ ]]; then
     export JAVA_HOME=/usr/java/latest/

--- a/apollo-adminservice/src/main/scripts/startup.sh
+++ b/apollo-adminservice/src/main/scripts/startup.sh
@@ -25,12 +25,13 @@ then
     export SPRING_DATASOURCE_PASSWORD=$DS_PASSWORD
 fi
 export JAVA_OPTS="$JAVA_OPTS -Dserver.port=$SERVER_PORT -Dlogging.file=$LOG_DIR/$SERVICE_NAME.log -XX:HeapDumpPath=$LOG_DIR/HeapDumpOnOutOfMemoryError/"
+export APP_NAME=$SERVICE_NAME
 
 PATH_TO_JAR=$SERVICE_NAME".jar"
 SERVER_URL="http://localhost:$SERVER_PORT"
 
 function checkPidAlive {
-    for i in `ls -t $SERVICE_NAME*.pid 2>/dev/null`
+    for i in `ls -t $APP_NAME/$APP_NAME.pid 2>/dev/null`
     do
         read pid < $i
 

--- a/apollo-assembly/pom.xml
+++ b/apollo-assembly/pom.xml
@@ -38,9 +38,6 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
-				<configuration>
-					<executable>true</executable>
-				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/apollo-assembly/src/main/resources/logback.xml
+++ b/apollo-assembly/src/main/resources/logback.xml
@@ -6,7 +6,23 @@
 	<include resource="org/springframework/boot/logging/logback/file-appender.xml" />
 	<include resource="org/springframework/boot/logging/logback/console-appender.xml" />
 	<root level="INFO">
-		<appender-ref ref="FILE" />
-		<appender-ref ref="CONSOLE" />
+		<if condition='isDefined("LOG_APPENDERS")'>
+			<then>
+				<if condition='property("LOG_APPENDERS").contains("CONSOLE")'>
+					<then>
+						<appender-ref ref="CONSOLE"/>
+					</then>
+				</if>
+				<if condition='property("LOG_APPENDERS").contains("FILE")'>
+					<then>
+						<appender-ref ref="FILE"/>
+					</then>
+				</if>
+			</then>
+			<else>
+				<appender-ref ref="FILE" />
+				<appender-ref ref="CONSOLE" />
+			</else>
+		</if>
 	</root>
 </configuration>

--- a/apollo-common/pom.xml
+++ b/apollo-common/pom.xml
@@ -52,9 +52,10 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!-- logback dependencies-->
         <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
+            <groupId>org.codehaus.janino</groupId>
+            <artifactId>janino</artifactId>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>

--- a/apollo-configservice/pom.xml
+++ b/apollo-configservice/pom.xml
@@ -105,9 +105,6 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
-				<configuration>
-					<executable>true</executable>
-				</configuration>
 			</plugin>
 			<plugin>
 				<artifactId>maven-assembly-plugin</artifactId>

--- a/apollo-configservice/src/main/config/apollo-configservice.conf
+++ b/apollo-configservice/src/main/config/apollo-configservice.conf
@@ -1,3 +1,8 @@
 MODE=service
 PID_FOLDER=.
+# console appender log file folder
 LOG_FOLDER=/opt/logs/100003171/
+# console appender log file name
+LOG_FILENAME=console.log
+# write application logs only to file appender
+export LOG_APPENDERS=FILE

--- a/apollo-configservice/src/main/resources/logback.xml
+++ b/apollo-configservice/src/main/resources/logback.xml
@@ -6,7 +6,23 @@
 	<include resource="org/springframework/boot/logging/logback/file-appender.xml" />
 	<include resource="org/springframework/boot/logging/logback/console-appender.xml" />
 	<root level="INFO">
-		<appender-ref ref="FILE" />
-		<appender-ref ref="CONSOLE" />
+		<if condition='isDefined("LOG_APPENDERS")'>
+			<then>
+				<if condition='property("LOG_APPENDERS").contains("CONSOLE")'>
+					<then>
+						<appender-ref ref="CONSOLE"/>
+					</then>
+				</if>
+				<if condition='property("LOG_APPENDERS").contains("FILE")'>
+					<then>
+						<appender-ref ref="FILE"/>
+					</then>
+				</if>
+			</then>
+			<else>
+				<appender-ref ref="FILE" />
+				<appender-ref ref="CONSOLE" />
+			</else>
+		</if>
 	</root>
 </configuration>

--- a/apollo-configservice/src/main/scripts/shutdown.sh
+++ b/apollo-configservice/src/main/scripts/shutdown.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 SERVICE_NAME=apollo-configservice
+export APP_NAME=$SERVICE_NAME
 
 if [[ -z "$JAVA_HOME" && -d /usr/java/latest/ ]]; then
     export JAVA_HOME=/usr/java/latest/

--- a/apollo-configservice/src/main/scripts/startup.sh
+++ b/apollo-configservice/src/main/scripts/startup.sh
@@ -25,12 +25,13 @@ then
     export SPRING_DATASOURCE_PASSWORD=$DS_PASSWORD
 fi
 export JAVA_OPTS="$JAVA_OPTS -Dserver.port=$SERVER_PORT -Dlogging.file=$LOG_DIR/$SERVICE_NAME.log -XX:HeapDumpPath=$LOG_DIR/HeapDumpOnOutOfMemoryError/"
+export APP_NAME=$SERVICE_NAME
 
 PATH_TO_JAR=$SERVICE_NAME".jar"
 SERVER_URL="http://localhost:$SERVER_PORT"
 
 function checkPidAlive {
-    for i in `ls -t $SERVICE_NAME*.pid 2>/dev/null`
+    for i in `ls -t $APP_NAME/$APP_NAME.pid 2>/dev/null`
     do
         read pid < $i
 

--- a/apollo-portal/pom.xml
+++ b/apollo-portal/pom.xml
@@ -81,9 +81,6 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
-				<configuration>
-					<executable>true</executable>
-				</configuration>
 			</plugin>
 			<plugin>
 				<artifactId>maven-assembly-plugin</artifactId>

--- a/apollo-portal/src/main/config/apollo-portal.conf
+++ b/apollo-portal/src/main/config/apollo-portal.conf
@@ -1,3 +1,8 @@
 MODE=service
 PID_FOLDER=.
+# console appender log file folder
 LOG_FOLDER=/opt/logs/100003173/
+# console appender log file name
+LOG_FILENAME=console.log
+# write application logs only to file appender
+export LOG_APPENDERS=FILE

--- a/apollo-portal/src/main/resources/logback.xml
+++ b/apollo-portal/src/main/resources/logback.xml
@@ -6,7 +6,23 @@
 	<include resource="org/springframework/boot/logging/logback/file-appender.xml" />
 	<include resource="org/springframework/boot/logging/logback/console-appender.xml" />
 	<root level="INFO">
-		<appender-ref ref="FILE" />
-		<appender-ref ref="CONSOLE" />
+		<if condition='isDefined("LOG_APPENDERS")'>
+			<then>
+				<if condition='property("LOG_APPENDERS").contains("CONSOLE")'>
+					<then>
+						<appender-ref ref="CONSOLE"/>
+					</then>
+				</if>
+				<if condition='property("LOG_APPENDERS").contains("FILE")'>
+					<then>
+						<appender-ref ref="FILE"/>
+					</then>
+				</if>
+			</then>
+			<else>
+				<appender-ref ref="FILE" />
+				<appender-ref ref="CONSOLE" />
+			</else>
+		</if>
 	</root>
 </configuration>

--- a/apollo-portal/src/main/scripts/shutdown.sh
+++ b/apollo-portal/src/main/scripts/shutdown.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 SERVICE_NAME=apollo-portal
+export APP_NAME=$SERVICE_NAME
 
 if [[ -z "$JAVA_HOME" && -d /usr/java/latest/ ]]; then
     export JAVA_HOME=/usr/java/latest/

--- a/apollo-portal/src/main/scripts/startup.sh
+++ b/apollo-portal/src/main/scripts/startup.sh
@@ -25,12 +25,13 @@ then
     export SPRING_DATASOURCE_PASSWORD=$DS_PASSWORD
 fi
 export JAVA_OPTS="$JAVA_OPTS -Dserver.port=$SERVER_PORT -Dlogging.file=$LOG_DIR/$SERVICE_NAME.log -XX:HeapDumpPath=$LOG_DIR/HeapDumpOnOutOfMemoryError/"
+export APP_NAME=$SERVICE_NAME
 
 PATH_TO_JAR=$SERVICE_NAME".jar"
 SERVER_URL="http://localhost:$SERVER_PORT"
 
 function checkPidAlive {
-    for i in `ls -t $SERVICE_NAME*.pid 2>/dev/null`
+    for i in `ls -t $APP_NAME/$APP_NAME.pid 2>/dev/null`
     do
         read pid < $i
 

--- a/pom.xml
+++ b/pom.xml
@@ -480,7 +480,11 @@
 				<plugin>
 					<groupId>org.springframework.boot</groupId>
 					<artifactId>spring-boot-maven-plugin</artifactId>
-					<version>1.3.5.RELEASE</version>
+					<version>${spring-boot.version}</version>
+					<configuration>
+						<executable>true</executable>
+						<attach>false</attach>
+					</configuration>
 					<executions>
 						<execution>
 							<goals>


### PR DESCRIPTION


## What's the purpose of this PR

switch off console appenders when running as backend services

## Which issue(s) this PR fixes:
Fixes #3272 #2459

## Brief changelog

1. add `LOG_APPENDERS` environment variables to make logback appenders switchable
2. set `LOG_APPENDERS=FILE` when running as backend services
3. upgrade spring-boot-maven-plugin to 2.0.5.RELEASE

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
