### PR TITLE
http client spi

### DIFF
--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/DefaultInjector.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/DefaultInjector.java
@@ -7,6 +7,7 @@ import com.ctrip.framework.apollo.spi.ConfigRegistry;
 import com.ctrip.framework.apollo.spi.DefaultConfigFactory;
 import com.ctrip.framework.apollo.spi.DefaultConfigFactoryManager;
 import com.ctrip.framework.apollo.spi.DefaultConfigRegistry;
+import com.ctrip.framework.apollo.spi.HttpClientFactory;
 import com.ctrip.framework.apollo.tracer.Tracer;
 import com.ctrip.framework.apollo.util.ConfigUtil;
 import com.ctrip.framework.apollo.util.factory.DefaultPropertiesFactory;
@@ -14,8 +15,10 @@ import com.ctrip.framework.apollo.util.factory.PropertiesFactory;
 import com.ctrip.framework.apollo.util.http.HttpUtil;
 
 import com.ctrip.framework.apollo.util.yaml.YamlParser;
+import com.ctrip.framework.foundation.internals.ServiceBootstrap;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
+import com.google.inject.Provider;
 import com.google.inject.Singleton;
 
 /**
@@ -60,7 +63,12 @@ public class DefaultInjector implements Injector {
       bind(ConfigRegistry.class).to(DefaultConfigRegistry.class).in(Singleton.class);
       bind(ConfigFactory.class).to(DefaultConfigFactory.class).in(Singleton.class);
       bind(ConfigUtil.class).in(Singleton.class);
-      bind(HttpUtil.class).in(Singleton.class);
+      bind(HttpUtil.class).toProvider(new Provider<HttpUtil>() {
+        @Override
+        public HttpUtil get() {
+          return ServiceBootstrap.loadPrimary(HttpClientFactory.class).createHttpClient();
+        }
+      }).in(Singleton.class);
       bind(ConfigServiceLocator.class).in(Singleton.class);
       bind(RemoteConfigLongPollService.class).in(Singleton.class);
       bind(YamlParser.class).in(Singleton.class);

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spi/DefaultHttpClientFactory.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spi/DefaultHttpClientFactory.java
@@ -1,0 +1,21 @@
+package com.ctrip.framework.apollo.spi;
+
+import com.ctrip.framework.apollo.core.spi.Ordered;
+import com.ctrip.framework.apollo.util.http.DefaultHttpUtil;
+import com.ctrip.framework.apollo.util.http.HttpUtil;
+
+/**
+ * @author vdisk <vdisk@foxmail.com>
+ */
+public class DefaultHttpClientFactory implements HttpClientFactory {
+
+  @Override
+  public HttpUtil createHttpClient() {
+    return new DefaultHttpUtil();
+  }
+
+  @Override
+  public int getOrder() {
+    return Ordered.LOWEST_PRECEDENCE;
+  }
+}

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spi/HttpClientFactory.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spi/HttpClientFactory.java
@@ -1,0 +1,17 @@
+package com.ctrip.framework.apollo.spi;
+
+import com.ctrip.framework.apollo.core.spi.Ordered;
+import com.ctrip.framework.apollo.util.http.HttpUtil;
+
+/**
+ * @author vdisk <vdisk@foxmail.com>
+ */
+public interface HttpClientFactory extends Ordered {
+
+  /**
+   * create HttpClient
+   *
+   * @return instance of HttpUtil
+   */
+  HttpUtil createHttpClient();
+}

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/util/http/DefaultHttpUtil.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/util/http/DefaultHttpUtil.java
@@ -1,0 +1,169 @@
+package com.ctrip.framework.apollo.util.http;
+
+import com.ctrip.framework.apollo.build.ApolloInjector;
+import com.ctrip.framework.apollo.exceptions.ApolloConfigException;
+import com.ctrip.framework.apollo.exceptions.ApolloConfigStatusCodeException;
+import com.ctrip.framework.apollo.util.ConfigUtil;
+import com.google.common.base.Function;
+import com.google.common.io.CharStreams;
+import com.google.gson.Gson;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.lang.reflect.Type;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+/**
+ * @author Jason Song(song_s@ctrip.com)
+ */
+public class DefaultHttpUtil implements HttpUtil {
+  private ConfigUtil m_configUtil;
+  private static final Gson GSON = new Gson();
+
+  /**
+   * Constructor.
+   */
+  public DefaultHttpUtil() {
+    m_configUtil = ApolloInjector.getInstance(ConfigUtil.class);
+  }
+
+  /**
+   * Do get operation for the http request.
+   *
+   * @param httpRequest  the request
+   * @param responseType the response type
+   * @return the response
+   * @throws ApolloConfigException if any error happened or response code is neither 200 nor 304
+   */
+  @Override
+  public <T> HttpResponse<T> doGet(HttpRequest httpRequest, final Class<T> responseType) {
+    Function<String, T> convertResponse = new Function<String, T>() {
+      @Override
+      public T apply(String input) {
+        return GSON.fromJson(input, responseType);
+      }
+    };
+
+    return doGetWithSerializeFunction(httpRequest, convertResponse);
+  }
+
+  /**
+   * Do get operation for the http request.
+   *
+   * @param httpRequest  the request
+   * @param responseType the response type
+   * @return the response
+   * @throws ApolloConfigException if any error happened or response code is neither 200 nor 304
+   */
+  @Override
+  public <T> HttpResponse<T> doGet(HttpRequest httpRequest, final Type responseType) {
+    Function<String, T> convertResponse = new Function<String, T>() {
+      @Override
+      public T apply(String input) {
+        return GSON.fromJson(input, responseType);
+      }
+    };
+
+    return doGetWithSerializeFunction(httpRequest, convertResponse);
+  }
+
+  private <T> HttpResponse<T> doGetWithSerializeFunction(HttpRequest httpRequest,
+                                                         Function<String, T> serializeFunction) {
+    InputStreamReader isr = null;
+    InputStreamReader esr = null;
+    int statusCode;
+    try {
+      HttpURLConnection conn = (HttpURLConnection) new URL(httpRequest.getUrl()).openConnection();
+
+      conn.setRequestMethod("GET");
+
+      Map<String, String> headers = httpRequest.getHeaders();
+      if (headers != null && headers.size() > 0) {
+        for (Map.Entry<String, String> entry : headers.entrySet()) {
+          conn.setRequestProperty(entry.getKey(), entry.getValue());
+        }
+      }
+
+      int connectTimeout = httpRequest.getConnectTimeout();
+      if (connectTimeout < 0) {
+        connectTimeout = m_configUtil.getConnectTimeout();
+      }
+
+      int readTimeout = httpRequest.getReadTimeout();
+      if (readTimeout < 0) {
+        readTimeout = m_configUtil.getReadTimeout();
+      }
+
+      conn.setConnectTimeout(connectTimeout);
+      conn.setReadTimeout(readTimeout);
+
+      conn.connect();
+
+      statusCode = conn.getResponseCode();
+      String response;
+
+      try {
+        isr = new InputStreamReader(conn.getInputStream(), StandardCharsets.UTF_8);
+        response = CharStreams.toString(isr);
+      } catch (IOException ex) {
+        /**
+         * according to https://docs.oracle.com/javase/7/docs/technotes/guides/net/http-keepalive.html,
+         * we should clean up the connection by reading the response body so that the connection
+         * could be reused.
+         */
+        InputStream errorStream = conn.getErrorStream();
+
+        if (errorStream != null) {
+          esr = new InputStreamReader(errorStream, StandardCharsets.UTF_8);
+          try {
+            CharStreams.toString(esr);
+          } catch (IOException ioe) {
+            //ignore
+          }
+        }
+
+        // 200 and 304 should not trigger IOException, thus we must throw the original exception out
+        if (statusCode == 200 || statusCode == 304) {
+          throw ex;
+        }
+        // for status codes like 404, IOException is expected when calling conn.getInputStream()
+        throw new ApolloConfigStatusCodeException(statusCode, ex);
+      }
+
+      if (statusCode == 200) {
+        return new HttpResponse<>(statusCode, serializeFunction.apply(response));
+      }
+
+      if (statusCode == 304) {
+        return new HttpResponse<>(statusCode, null);
+      }
+    } catch (ApolloConfigStatusCodeException ex) {
+      throw ex;
+    } catch (Throwable ex) {
+      throw new ApolloConfigException("Could not complete get operation", ex);
+    } finally {
+      if (isr != null) {
+        try {
+          isr.close();
+        } catch (IOException ex) {
+          // ignore
+        }
+      }
+
+      if (esr != null) {
+        try {
+          esr.close();
+        } catch (IOException ex) {
+          // ignore
+        }
+      }
+    }
+
+    throw new ApolloConfigStatusCodeException(statusCode,
+        String.format("Get operation failed for %s", httpRequest.getUrl()));
+  }
+
+}

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/util/http/HttpUtil.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/util/http/HttpUtil.java
@@ -1,34 +1,12 @@
 package com.ctrip.framework.apollo.util.http;
 
-import com.ctrip.framework.apollo.build.ApolloInjector;
 import com.ctrip.framework.apollo.exceptions.ApolloConfigException;
-import com.ctrip.framework.apollo.exceptions.ApolloConfigStatusCodeException;
-import com.ctrip.framework.apollo.util.ConfigUtil;
-import com.google.common.base.Function;
-import com.google.common.io.CharStreams;
-import com.google.gson.Gson;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.lang.reflect.Type;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
-import java.util.Map;
 
 /**
  * @author Jason Song(song_s@ctrip.com)
  */
-public class HttpUtil {
-  private ConfigUtil m_configUtil;
-  private static final Gson GSON = new Gson();
-
-  /**
-   * Constructor.
-   */
-  public HttpUtil() {
-    m_configUtil = ApolloInjector.getInstance(ConfigUtil.class);
-  }
+public interface HttpUtil {
 
   /**
    * Do get operation for the http request.
@@ -38,16 +16,7 @@ public class HttpUtil {
    * @return the response
    * @throws ApolloConfigException if any error happened or response code is neither 200 nor 304
    */
-  public <T> HttpResponse<T> doGet(HttpRequest httpRequest, final Class<T> responseType) {
-    Function<String, T> convertResponse = new Function<String, T>() {
-      @Override
-      public T apply(String input) {
-        return GSON.fromJson(input, responseType);
-      }
-    };
-
-    return doGetWithSerializeFunction(httpRequest, convertResponse);
-  }
+  <T> HttpResponse<T> doGet(HttpRequest httpRequest, final Class<T> responseType) throws ApolloConfigException;
 
   /**
    * Do get operation for the http request.
@@ -57,111 +26,5 @@ public class HttpUtil {
    * @return the response
    * @throws ApolloConfigException if any error happened or response code is neither 200 nor 304
    */
-  public <T> HttpResponse<T> doGet(HttpRequest httpRequest, final Type responseType) {
-    Function<String, T> convertResponse = new Function<String, T>() {
-      @Override
-      public T apply(String input) {
-        return GSON.fromJson(input, responseType);
-      }
-    };
-
-    return doGetWithSerializeFunction(httpRequest, convertResponse);
-  }
-
-  private <T> HttpResponse<T> doGetWithSerializeFunction(HttpRequest httpRequest,
-                                                         Function<String, T> serializeFunction) {
-    InputStreamReader isr = null;
-    InputStreamReader esr = null;
-    int statusCode;
-    try {
-      HttpURLConnection conn = (HttpURLConnection) new URL(httpRequest.getUrl()).openConnection();
-
-      conn.setRequestMethod("GET");
-
-      Map<String, String> headers = httpRequest.getHeaders();
-      if (headers != null && headers.size() > 0) {
-        for (Map.Entry<String, String> entry : headers.entrySet()) {
-          conn.setRequestProperty(entry.getKey(), entry.getValue());
-        }
-      }
-
-      int connectTimeout = httpRequest.getConnectTimeout();
-      if (connectTimeout < 0) {
-        connectTimeout = m_configUtil.getConnectTimeout();
-      }
-
-      int readTimeout = httpRequest.getReadTimeout();
-      if (readTimeout < 0) {
-        readTimeout = m_configUtil.getReadTimeout();
-      }
-
-      conn.setConnectTimeout(connectTimeout);
-      conn.setReadTimeout(readTimeout);
-
-      conn.connect();
-
-      statusCode = conn.getResponseCode();
-      String response;
-
-      try {
-        isr = new InputStreamReader(conn.getInputStream(), StandardCharsets.UTF_8);
-        response = CharStreams.toString(isr);
-      } catch (IOException ex) {
-        /**
-         * according to https://docs.oracle.com/javase/7/docs/technotes/guides/net/http-keepalive.html,
-         * we should clean up the connection by reading the response body so that the connection
-         * could be reused.
-         */
-        InputStream errorStream = conn.getErrorStream();
-
-        if (errorStream != null) {
-          esr = new InputStreamReader(errorStream, StandardCharsets.UTF_8);
-          try {
-            CharStreams.toString(esr);
-          } catch (IOException ioe) {
-            //ignore
-          }
-        }
-
-        // 200 and 304 should not trigger IOException, thus we must throw the original exception out
-        if (statusCode == 200 || statusCode == 304) {
-          throw ex;
-        }
-        // for status codes like 404, IOException is expected when calling conn.getInputStream()
-        throw new ApolloConfigStatusCodeException(statusCode, ex);
-      }
-
-      if (statusCode == 200) {
-        return new HttpResponse<>(statusCode, serializeFunction.apply(response));
-      }
-
-      if (statusCode == 304) {
-        return new HttpResponse<>(statusCode, null);
-      }
-    } catch (ApolloConfigStatusCodeException ex) {
-      throw ex;
-    } catch (Throwable ex) {
-      throw new ApolloConfigException("Could not complete get operation", ex);
-    } finally {
-      if (isr != null) {
-        try {
-          isr.close();
-        } catch (IOException ex) {
-          // ignore
-        }
-      }
-
-      if (esr != null) {
-        try {
-          esr.close();
-        } catch (IOException ex) {
-          // ignore
-        }
-      }
-    }
-
-    throw new ApolloConfigStatusCodeException(statusCode,
-        String.format("Get operation failed for %s", httpRequest.getUrl()));
-  }
-
+  <T> HttpResponse<T> doGet(HttpRequest httpRequest, final Type responseType) throws ApolloConfigException;
 }

--- a/apollo-client/src/main/resources/META-INF/services/com.ctrip.framework.apollo.spi.HttpClientFactory
+++ b/apollo-client/src/main/resources/META-INF/services/com.ctrip.framework.apollo.spi.HttpClientFactory
@@ -1,0 +1,1 @@
+com.ctrip.framework.apollo.spi.DefaultHttpClientFactory

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/internals/RemoteConfigRepositoryTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/internals/RemoteConfigRepositoryTest.java
@@ -407,7 +407,7 @@ public class RemoteConfigRepositoryTest {
     }
   }
 
-  public static class MockHttpUtil extends HttpUtil {
+  public static class MockHttpUtil implements HttpUtil {
 
     @Override
     public <T> HttpResponse<T> doGet(HttpRequest httpRequest, Class<T> responseType) {


### PR DESCRIPTION
HttpUtil 更改为接口, 通过 spi 的方式加载, 可以让使用者自由替换 HttpUtil 的实现类, 从而可以在发送http请求时做一些附加操作, 例如添加 http basic 请求头, 添加 Bearer Token 等等
原 HttpUtil 作为默认实现 DefaultHttpUtil, 没有提供其它实现类时保持和原有逻辑一致