### PR TITLE
apollo-portal-oidc

### DIFF
--- a/apollo-portal/pom.xml
+++ b/apollo-portal/pom.xml
@@ -27,6 +27,14 @@
 			<groupId>com.ctrip.framework.apollo</groupId>
 			<artifactId>apollo-openapi</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-oauth2-client</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+		</dependency>
 		<!-- yml processing -->
 		<dependency>
 			<groupId>org.yaml</groupId>

--- a/apollo-portal/src/main/config/application-oidc-sample.yml
+++ b/apollo-portal/src/main/config/application-oidc-sample.yml
@@ -1,0 +1,45 @@
+spring:
+  security:
+    oauth2:
+      client:
+        provider:
+          # provider-name 是 oidc 提供者的名称, 任意字符均可, registration 的配置需要用到这个名称
+          provider-name:
+            # 必须是 https, oidc 的 issuer-uri, 和 jwt 的 issuer-uri 一致的话直接引用即可, 也可以单独设置
+            issuer-uri: ${spring.security.oauth2.resourceserver.jwt.issuer-uri}
+        registration:
+          # registration-name 是 oidc 客户端的名称, 任意字符均可, oidc 登录必须配置一个 authorization_code 类型的 registration
+          registration-name:
+            # oidc 登录必须配置一个 authorization_code 类型的 registration
+            authorization-grant-type: authorization_code
+            client-authentication-method: basic
+            # client-id 是在 oidc 提供者处配置的客户端ID, 用于登录 provider
+            client-id: apollo-portal
+            # provider 的名称, 需要和上面配置的 provider 名称保持一致
+            provider: provider-name
+            # openid 为 oidc 登录的必须 scope, 此处可以添加其它自定义的 scope
+            scope:
+              - openid
+            # client-secret 是在 oidc 提供者处配置的客户端密码, 用于登录 provider
+            # 从安全角度考虑更推荐使用环境变量来配置, 环境变量的命名规则为: 将配置项的 key 当中的 点(.)、横杠(-)替换为下划线(_), 然后将所有字母改为大写, spring boot 会自动处理符合此规则的环境变量
+            # 例如 spring.security.oauth2.client.registration.registration-name.client-secret -> SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_NAME_VDISK_CLIENT_SECRET (REGISTRATION_NAME 可以替换为自定义的 oidc 客户端的名称)
+            client-secret: d43c91c0-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+          # registration-name-client 是 oidc 客户端的名称, 任意字符均可, client_credentials 类型的 registration 为选填项, 可以不配置
+          registration-name-client:
+            # client_credentials 类型的 registration 为选填项, 用于 apollo-portal 作为客户端请求其它被 oidc 保护的资源, 可以不配置
+            authorization-grant-type: client_credentials
+            client-authentication-method: basic
+            # client-id 是在 oidc 提供者处配置的客户端ID, 用于登录 provider
+            client-id: apollo-portal
+            # provider 的名称, 需要和上面配置的 provider 名称保持一致
+            provider: provider-name
+            # openid 为 oidc 登录的必须 scope, 此处可以添加其它自定义的 scope
+            scope:
+              - openid
+            # client-secret 是在 oidc 提供者处配置的客户端密码, 用于登录 provider, 多个 registration 的密码如果一致可以直接引用
+            client-secret: ${spring.security.oauth2.client.registration.registration-name.client-secret}
+      resourceserver:
+        jwt:
+          # 必须是 https, jwt 的 issuer-uri
+          # 例如 你的 issuer-uri 是 https://host:port/auth/realms/apollo/.well-known/openid-configuration, 那么此处只需要配置 https://host:port/auth/realms/apollo 即可, spring boot 处理的时候会自动加上 /.well-known/openid-configuration 的后缀
+          issuer-uri: https://host:port/auth/realms/apollo

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/configuration/AuthConfiguration.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/configuration/AuthConfiguration.java
@@ -480,9 +480,13 @@ public class AuthConfiguration {
 
     private final InMemoryClientRegistrationRepository clientRegistrationRepository;
 
+    private final OAuth2ResourceServerProperties oauth2ResourceServerProperties;
+
     public OidcWebSecurityConfigurerAdapter(
-        InMemoryClientRegistrationRepository clientRegistrationRepository) {
+        InMemoryClientRegistrationRepository clientRegistrationRepository,
+        OAuth2ResourceServerProperties oauth2ResourceServerProperties) {
       this.clientRegistrationRepository = clientRegistrationRepository;
+      this.oauth2ResourceServerProperties = oauth2ResourceServerProperties;
     }
 
     @Override
@@ -495,7 +499,11 @@ public class AuthConfiguration {
               new ExcludeClientCredentialsClientRegistrationRepository(
                   this.clientRegistrationRepository)));
       http.oauth2Client();
-      http.oauth2ResourceServer().jwt();
+      // make jwt optional
+      String jwtIssuerUri = this.oauth2ResourceServerProperties.getJwt().getIssuerUri();
+      if (!StringUtils.isBlank(jwtIssuerUri)) {
+        http.oauth2ResourceServer().jwt();
+      }
     }
   }
 

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/configuration/AuthConfiguration.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/configuration/AuthConfiguration.java
@@ -3,6 +3,7 @@ package com.ctrip.framework.apollo.portal.spi.configuration;
 import com.ctrip.framework.apollo.common.condition.ConditionalOnMissingProfile;
 import com.ctrip.framework.apollo.core.utils.StringUtils;
 import com.ctrip.framework.apollo.portal.component.config.PortalConfig;
+import com.ctrip.framework.apollo.portal.repository.UserRepository;
 import com.ctrip.framework.apollo.portal.spi.LogoutHandler;
 import com.ctrip.framework.apollo.portal.spi.SsoHeartbeatHandler;
 import com.ctrip.framework.apollo.portal.spi.UserInfoHolder;
@@ -18,10 +19,16 @@ import com.ctrip.framework.apollo.portal.spi.defaultimpl.DefaultUserService;
 import com.ctrip.framework.apollo.portal.spi.ldap.ApolloLdapAuthenticationProvider;
 import com.ctrip.framework.apollo.portal.spi.ldap.FilterLdapByGroupUserSearch;
 import com.ctrip.framework.apollo.portal.spi.ldap.LdapUserService;
+import com.ctrip.framework.apollo.portal.spi.oidc.ExcludeClientCredentialsClientRegistrationRepository;
+import com.ctrip.framework.apollo.portal.spi.oidc.OidcAuthenticationSuccessEventListener;
+import com.ctrip.framework.apollo.portal.spi.oidc.OidcLocalUserService;
+import com.ctrip.framework.apollo.portal.spi.oidc.OidcUserInfoHolder;
 import com.ctrip.framework.apollo.portal.spi.springsecurity.SpringSecurityUserInfoHolder;
 import com.ctrip.framework.apollo.portal.spi.springsecurity.SpringSecurityUserService;
 import com.google.common.collect.Maps;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties;
+import org.springframework.boot.autoconfigure.security.oauth2.resource.OAuth2ResourceServerProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.boot.web.servlet.ServletListenerRegistrationBean;
@@ -44,6 +51,7 @@ import org.springframework.security.ldap.authentication.BindAuthenticator;
 import org.springframework.security.ldap.authentication.LdapAuthenticationProvider;
 import org.springframework.security.ldap.search.FilterBasedLdapUserSearch;
 import org.springframework.security.ldap.userdetails.DefaultLdapAuthoritiesPopulator;
+import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
 import org.springframework.security.provisioning.JdbcUserDetailsManager;
 import org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint;
 
@@ -421,11 +429,81 @@ public class AuthConfiguration {
     }
   }
 
+  @Profile("oidc")
+  @EnableConfigurationProperties({OAuth2ClientProperties.class, OAuth2ResourceServerProperties.class})
+  @Configuration
+  static class OidcAuthAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean(SsoHeartbeatHandler.class)
+    public SsoHeartbeatHandler defaultSsoHeartbeatHandler() {
+      return new DefaultSsoHeartbeatHandler();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(UserInfoHolder.class)
+    public UserInfoHolder oidcUserInfoHolder() {
+      return new OidcUserInfoHolder();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(LogoutHandler.class)
+    public LogoutHandler logoutHandler() {
+      return new DefaultLogoutHandler();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(JdbcUserDetailsManager.class)
+    public JdbcUserDetailsManager jdbcUserDetailsManager(AuthenticationManagerBuilder auth,
+        DataSource datasource) throws Exception {
+      return new SpringSecurityAuthAutoConfiguration().jdbcUserDetailsManager(auth, datasource);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(UserService.class)
+    public OidcLocalUserService oidcLocalUserService(JdbcUserDetailsManager userDetailsManager,
+        UserRepository userRepository) {
+      return new OidcLocalUserService(userDetailsManager, userRepository);
+    }
+
+    @Bean
+    public OidcAuthenticationSuccessEventListener oidcAuthenticationSuccessEventListener(OidcLocalUserService oidcLocalUserService) {
+      return new OidcAuthenticationSuccessEventListener(oidcLocalUserService);
+    }
+  }
+
+  @Profile("oidc")
+  @EnableWebSecurity
+  @EnableGlobalMethodSecurity(prePostEnabled = true)
+  @Configuration
+  static class OidcWebSecurityConfigurerAdapter extends WebSecurityConfigurerAdapter {
+
+    private final InMemoryClientRegistrationRepository clientRegistrationRepository;
+
+    public OidcWebSecurityConfigurerAdapter(
+        InMemoryClientRegistrationRepository clientRegistrationRepository) {
+      this.clientRegistrationRepository = clientRegistrationRepository;
+    }
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+      http.csrf().disable();
+      http.authorizeRequests(requests -> requests.antMatchers(BY_PASS_URLS).permitAll());
+      http.authorizeRequests(requests -> requests.anyRequest().authenticated());
+      http.oauth2Login(configure ->
+          configure.clientRegistrationRepository(
+              new ExcludeClientCredentialsClientRegistrationRepository(
+                  this.clientRegistrationRepository)));
+      http.oauth2Client();
+      http.oauth2ResourceServer().jwt();
+    }
+  }
+
   /**
    * default profile
    */
   @Configuration
-  @ConditionalOnMissingProfile({"ctrip", "auth", "ldap"})
+  @ConditionalOnMissingProfile({"ctrip", "auth", "ldap", "oidc"})
   static class DefaultAuthAutoConfiguration {
 
     @Bean
@@ -453,7 +531,7 @@ public class AuthConfiguration {
     }
   }
 
-  @ConditionalOnMissingProfile({"auth", "ldap"})
+  @ConditionalOnMissingProfile({"auth", "ldap", "oidc"})
   @Configuration
   @EnableWebSecurity
   @EnableGlobalMethodSecurity(prePostEnabled = true)

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/oidc/ExcludeClientCredentialsClientRegistrationRepository.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/oidc/ExcludeClientCredentialsClientRegistrationRepository.java
@@ -1,0 +1,61 @@
+package com.ctrip.framework.apollo.portal.spi.oidc;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+
+/**
+ * @author vdisk <vdisk@foxmail.com>
+ */
+public class ExcludeClientCredentialsClientRegistrationRepository implements
+    ClientRegistrationRepository, Iterable<ClientRegistration> {
+
+  /**
+   * origin clientRegistrationRepository
+   */
+  private final InMemoryClientRegistrationRepository delegate;
+
+  /**
+   * exclude client_credentials
+   */
+  private final List<ClientRegistration> clientRegistrationList;
+
+  public ExcludeClientCredentialsClientRegistrationRepository(
+      InMemoryClientRegistrationRepository delegate) {
+    Objects.requireNonNull(delegate, "clientRegistrationRepository cannot be null");
+    this.delegate = delegate;
+    this.clientRegistrationList = Collections.unmodifiableList(StreamSupport
+        .stream(Spliterators.spliteratorUnknownSize(delegate.iterator(), Spliterator.ORDERED),
+            false)
+        .filter(clientRegistration -> !AuthorizationGrantType.CLIENT_CREDENTIALS
+            .equals(clientRegistration.getAuthorizationGrantType()))
+        .collect(Collectors.toList()));
+  }
+
+  @Override
+  public ClientRegistration findByRegistrationId(String registrationId) {
+    ClientRegistration clientRegistration = this.delegate.findByRegistrationId(registrationId);
+    if (clientRegistration == null) {
+      return null;
+    }
+    if (AuthorizationGrantType.CLIENT_CREDENTIALS
+        .equals(clientRegistration.getAuthorizationGrantType())) {
+      return null;
+    }
+    return clientRegistration;
+  }
+
+  @Override
+  public Iterator<ClientRegistration> iterator() {
+    return this.clientRegistrationList.iterator();
+  }
+}

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/oidc/OidcAuthenticationSuccessEventListener.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/oidc/OidcAuthenticationSuccessEventListener.java
@@ -1,0 +1,76 @@
+package com.ctrip.framework.apollo.portal.spi.oidc;
+
+import com.ctrip.framework.apollo.portal.entity.bo.UserInfo;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationListener;
+import org.springframework.security.authentication.event.AuthenticationSuccessEvent;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+/**
+ * @author vdisk <vdisk@foxmail.com>
+ */
+public class OidcAuthenticationSuccessEventListener implements
+    ApplicationListener<AuthenticationSuccessEvent> {
+
+  private static final Logger log = LoggerFactory
+      .getLogger(OidcAuthenticationSuccessEventListener.class);
+
+  private final OidcLocalUserService oidcLocalUserService;
+
+  private final ConcurrentMap<String, String> userIdCache = new ConcurrentHashMap<>();
+
+  public OidcAuthenticationSuccessEventListener(
+      OidcLocalUserService oidcLocalUserService) {
+    this.oidcLocalUserService = oidcLocalUserService;
+  }
+
+  @Override
+  public void onApplicationEvent(AuthenticationSuccessEvent event) {
+    Object principal = event.getAuthentication().getPrincipal();
+    if (principal instanceof OidcUser) {
+      this.oidcUserLogin((OidcUser) principal);
+      return;
+    }
+    if (principal instanceof Jwt) {
+      this.jwtLogin((Jwt) principal);
+      return;
+    }
+    log.warn("principal is neither oidcUser nor jwt, principal=[{}]", principal);
+  }
+
+  private void oidcUserLogin(OidcUser oidcUser) {
+    if (this.contains(oidcUser.getSubject())) {
+      return;
+    }
+    UserInfo newUserInfo = new UserInfo();
+    newUserInfo.setUserId(oidcUser.getSubject());
+    newUserInfo.setName(oidcUser.getPreferredUsername());
+    newUserInfo.setEmail(oidcUser.getEmail());
+    this.oidcLocalUserService.createLocalUser(newUserInfo);
+  }
+
+  private boolean contains(String userId) {
+    if (this.userIdCache.containsKey(userId)) {
+      return true;
+    }
+    UserInfo userInfo = this.oidcLocalUserService.findByUserId(userId);
+    if (userInfo != null) {
+      this.userIdCache.put(userId, userId);
+      return true;
+    }
+    return false;
+  }
+
+  private void jwtLogin(Jwt jwt) {
+    if (this.contains(jwt.getSubject())) {
+      return;
+    }
+    UserInfo newUserInfo = new UserInfo();
+    newUserInfo.setUserId(jwt.getSubject());
+    this.oidcLocalUserService.createLocalUser(newUserInfo);
+  }
+}

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/oidc/OidcLocalUserService.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/oidc/OidcLocalUserService.java
@@ -1,0 +1,91 @@
+package com.ctrip.framework.apollo.portal.spi.oidc;
+
+import com.ctrip.framework.apollo.core.utils.StringUtils;
+import com.ctrip.framework.apollo.portal.entity.bo.UserInfo;
+import com.ctrip.framework.apollo.portal.entity.po.UserPO;
+import com.ctrip.framework.apollo.portal.repository.UserRepository;
+import com.ctrip.framework.apollo.portal.spi.UserService;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.provisioning.JdbcUserDetailsManager;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.CollectionUtils;
+
+/**
+ * @author vdisk <vdisk@foxmail.com>
+ */
+public class OidcLocalUserService implements UserService {
+
+  private final Collection<? extends GrantedAuthority> authorities = Collections
+      .singletonList(new SimpleGrantedAuthority("ROLE_USER"));
+
+  private final JdbcUserDetailsManager userDetailsManager;
+
+  private final UserRepository userRepository;
+
+  public OidcLocalUserService(
+      JdbcUserDetailsManager userDetailsManager,
+      UserRepository userRepository) {
+    this.userDetailsManager = userDetailsManager;
+    this.userRepository = userRepository;
+  }
+
+  @Transactional(rollbackFor = Exception.class)
+  public void createLocalUser(UserInfo newUserInfo) {
+    UserDetails user = new User(newUserInfo.getUserId(), "{nonsensical}" + this.nonsensicalPassword(), authorities);
+    userDetailsManager.createUser(user);
+    UserPO managedUser = userRepository.findByUsername(newUserInfo.getUserId());
+    if (!StringUtils.isBlank(newUserInfo.getEmail())) {
+      managedUser.setEmail(newUserInfo.getEmail());
+      userRepository.save(managedUser);
+    }
+  }
+
+  /**
+   * generate a random password with no meaning
+   */
+  private String nonsensicalPassword() {
+    byte[] bytes = new byte[32];
+    ThreadLocalRandom.current().nextBytes(bytes);
+    return Base64.getEncoder().encodeToString(bytes);
+  }
+
+  @Override
+  public List<UserInfo> searchUsers(String keyword, int offset, int limit) {
+    List<UserPO> users;
+    if (StringUtils.isEmpty(keyword)) {
+      users = userRepository.findFirst20ByEnabled(1);
+    } else {
+      users = userRepository.findByUsernameLikeAndEnabled("%" + keyword + "%", 1);
+    }
+    if (CollectionUtils.isEmpty(users)) {
+      return Collections.emptyList();
+    }
+    return users.stream().map(UserPO::toUserInfo)
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public UserInfo findByUserId(String userId) {
+    UserPO userPO = userRepository.findByUsername(userId);
+    return userPO == null ? null : userPO.toUserInfo();
+  }
+
+  @Override
+  public List<UserInfo> findByUserIds(List<String> userIds) {
+    List<UserPO> users = userRepository.findByUsernameIn(userIds);
+    if (CollectionUtils.isEmpty(users)) {
+      return Collections.emptyList();
+    }
+    return users.stream().map(UserPO::toUserInfo)
+        .collect(Collectors.toList());
+  }
+}

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/oidc/OidcLogoutHandler.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/oidc/OidcLogoutHandler.java
@@ -1,0 +1,21 @@
+package com.ctrip.framework.apollo.portal.spi.oidc;
+
+import com.ctrip.framework.apollo.portal.spi.LogoutHandler;
+import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * @author vdisk <vdisk@foxmail.com>
+ */
+public class OidcLogoutHandler implements LogoutHandler {
+
+  @Override
+  public void logout(HttpServletRequest request, HttpServletResponse response) {
+    try {
+      response.sendRedirect("/logout");
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/oidc/OidcUserInfoHolder.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/oidc/OidcUserInfoHolder.java
@@ -1,0 +1,57 @@
+package com.ctrip.framework.apollo.portal.spi.oidc;
+
+import com.ctrip.framework.apollo.portal.entity.bo.UserInfo;
+import com.ctrip.framework.apollo.portal.spi.UserInfoHolder;
+import java.security.Principal;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.core.oidc.StandardClaimNames;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+/**
+ * @author vdisk <vdisk@foxmail.com>
+ */
+public class OidcUserInfoHolder implements UserInfoHolder {
+
+  private static final Logger log = LoggerFactory.getLogger(OidcUserInfoHolder.class);
+
+  @Override
+  public UserInfo getUser() {
+    Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+    if (principal instanceof OidcUser) {
+      UserInfo userInfo = new UserInfo();
+      OidcUser oidcUser = (OidcUser) principal;
+      userInfo.setUserId(oidcUser.getSubject());
+      userInfo.setName(oidcUser.getPreferredUsername());
+      userInfo.setEmail(oidcUser.getEmail());
+      return userInfo;
+    }
+    if (principal instanceof Jwt) {
+      Jwt jwt = (Jwt) principal;
+      UserInfo userInfo = new UserInfo();
+      userInfo.setUserId(jwt.getSubject());
+      return userInfo;
+    }
+    log.debug("principal is neither oidcUser nor jwt, principal=[{}]", principal);
+    if (principal instanceof OAuth2User) {
+      UserInfo userInfo = new UserInfo();
+      OAuth2User oAuth2User = (OAuth2User) principal;
+      userInfo.setUserId(oAuth2User.getName());
+      userInfo.setName(oAuth2User.getAttribute(StandardClaimNames.PREFERRED_USERNAME));
+      userInfo.setEmail(oAuth2User.getAttribute(StandardClaimNames.EMAIL));
+      return userInfo;
+    }
+    if (principal instanceof Principal) {
+      UserInfo userInfo = new UserInfo();
+      Principal userPrincipal = (Principal) principal;
+      userInfo.setUserId(userPrincipal.getName());
+      return userInfo;
+    }
+    UserInfo userInfo = new UserInfo();
+    userInfo.setUserId(String.valueOf(principal));
+    return userInfo;
+  }
+}


### PR DESCRIPTION
## What's the purpose of this PR

provide OpenID Connect login

1. to configure **application-oidc.yml**
```yaml
spring:
  security:
    oauth2:
      client:
        provider:
          # provider-name 是 oidc 提供者的名称, 任意字符均可, registration 的配置需要用到这个名称
          provider-name:
            # 必须是 https, oidc 的 issuer-uri, 和 jwt 的 issuer-uri 一致的话直接引用即可, 也可以单独设置
            issuer-uri: ${spring.security.oauth2.resourceserver.jwt.issuer-uri}
        registration:
          # registration-name 是 oidc 客户端的名称, 任意字符均可
          registration-name:
            # oidc 登录必须配置一个 authorization_code 类型的 registration
            authorization-grant-type: authorization_code
            client-authentication-method: basic
            # client-id 是在 oidc 提供者处配置的客户端ID, 用于登录 provider
            client-id: apollo-portal
            # provider 的名称, 需要和上面配置的 provider 名称保持一致
            provider: provider-name
            scope:
              - openid
            # client-secret 是在 oidc 提供者处配置的客户端密码, 用于登录 provider
            # 更推荐使用环境变量来配置 SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_NAME_VDISK_CLIENT_SECRET (REGISTRATION_NAME 需替换为自定义的 oidc 客户端的名称)
            client-secret: d43c91c0-xxxx-xxxx-xxxx-xxxxxxxxxxxx
          # registration-name-client 是 oidc 客户端的名称, 任意字符均可, client_credentials 类型的 registration 为选填项, 可以不配置
          registration-name-client:
            # client_credentials 类型的 registration 为选填项, 可以不配置
            authorization-grant-type: client_credentials
            client-authentication-method: basic
            # client-id 是在 oidc 提供者处配置的客户端ID, 用于登录 provider
            client-id: apollo-portal
            # provider 的名称, 需要和上面配置的 provider 名称保持一致
            provider: provider-name
            scope:
              - openid
            # client-secret 是在 oidc 提供者处配置的客户端密码, 用于登录 provider, 多个 registration 的密码如果一致可以直接引用
            client-secret: ${spring.security.oauth2.client.registration.registration-name.client-secret}
      resourceserver:
        jwt:
          # 必须是 https, jwt 的 issuer-uri
          issuer-uri: https://host:port/auth/realms/apollo

```
2. to configure **startup.sh**
-Dspring.profiles.active=github,oidc