### PR TITLE
fix #3551 and optimize ldap samples

### DIFF
--- a/apollo-portal/src/main/config/application-ldap-activedirectory-sample.yml
+++ b/apollo-portal/src/main/config/application-ldap-activedirectory-sample.yml
@@ -14,5 +14,5 @@ ldap:
     loginId: "sAMAccountName" # ldap 用户惟一 id，用来作为登录的 id
     userDisplayName: "cn" # ldap 用户名，用来作为显示名
     email: "userPrincipalName" # ldap 邮箱属性
-  filter: # 可选项，配置过滤，目前只支持 memberOf
-    memberOf: "CN=ServiceDEV,OU=test,DC=example,DC=com|CN=WebDEV,OU=test,DC=example,DC=com" # 只允许 memberOf 属性为 ServiceDEV 和 WebDEV 的用户访问
+#  filter: # 可选项，配置过滤，目前只支持 memberOf
+#    memberOf: "CN=ServiceDEV,OU=test,DC=example,DC=com|CN=WebDEV,OU=test,DC=example,DC=com" # 只允许 memberOf 属性为 ServiceDEV 和 WebDEV 的用户访问

--- a/apollo-portal/src/main/config/application-ldap-apacheds-sample.yml
+++ b/apollo-portal/src/main/config/application-ldap-apacheds-sample.yml
@@ -15,8 +15,8 @@ ldap:
     rdnKey: "cn" # ldap rdn key，可选项，如需启用group search需要配置
     userDisplayName: "displayName" # ldap 用户名，用来作为显示名
     email: "mail" # ldap 邮箱属性
-  group: # 配置ldap group，可选配置，启用后只有特定group的用户可以登录apollo
-    objectClass: "groupOfNames"  # 配置groupClassName
-    groupBase: "ou=group" # group search base
-    groupSearch: "(&(cn=dev))" # group filter
-    groupMembership: "member" # group memberShip eg. member or memberUid
+#  group: # 配置ldap group，可选配置，启用后只有特定group的用户可以登录apollo
+#    objectClass: "groupOfNames"  # 配置groupClassName
+#    groupBase: "ou=group" # group search base
+#    groupSearch: "(&(cn=dev))" # group filter
+#    groupMembership: "member" # group memberShip eg. member or memberUid

--- a/apollo-portal/src/main/config/application-ldap-openldap-sample.yml
+++ b/apollo-portal/src/main/config/application-ldap-openldap-sample.yml
@@ -15,8 +15,8 @@ ldap:
     rdnKey: "uid" # ldap rdn key，可选项，如需启用group search需要配置
     userDisplayName: "cn" # ldap 用户名，用来作为显示名
     email: "mail" # ldap 邮箱属性
-  group: # 启用group search，可选配置，启用后只有特定group的用户可以登录apollo
-    objectClass: "posixGroup"  # 配置groupClassName
-    groupBase: "ou=group" # group search base
-    groupSearch: "(&(cn=dev))" # group filter
-    groupMembership: "memberUid" # group memberShip eg. member or memberUid
+#  group: # 启用group search，可选配置，启用后只有特定group的用户可以登录apollo
+#    objectClass: "posixGroup"  # 配置groupClassName
+#    groupBase: "ou=group" # group search base
+#    groupSearch: "(&(cn=dev))" # group filter
+#    groupMembership: "memberUid" # group memberShip eg. member or memberUid

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/PortalApplication.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/PortalApplication.java
@@ -4,6 +4,7 @@ import com.ctrip.framework.apollo.common.ApolloCommonConfig;
 import com.ctrip.framework.apollo.openapi.PortalOpenApiConfig;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.ldap.LdapAutoConfiguration;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
@@ -11,7 +12,7 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 @EnableAspectJAutoProxy
 @Configuration
-@EnableAutoConfiguration
+@EnableAutoConfiguration(exclude = {LdapAutoConfiguration.class})
 @EnableTransactionManagement
 @ComponentScan(basePackageClasses = {ApolloCommonConfig.class,
     PortalApplication.class, PortalOpenApiConfig.class})


### PR DESCRIPTION
## What's the purpose of this PR

Fix the issue that apollo portal won't start when ldap is enabled and optimize ldap samples.

## Which issue(s) this PR fixes:
Fixes #3551

## Brief changelog

1. Exclude LdapAutoConfiguration
2. Simplify ldap configuration samples

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
