### PR TITLE
apollo client shared object context

### DIFF
--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/shared/ApolloSharedContext.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/shared/ApolloSharedContext.java
@@ -1,0 +1,23 @@
+package com.ctrip.framework.apollo.shared;
+
+/**
+ * @author vdisk <vdisk@foxmail.com>
+ */
+public interface ApolloSharedContext {
+
+  /**
+   * Sets an object that is shared by apollo client {@link com.ctrip.framework.apollo.internals.DefaultInjector}.
+   *
+   * @param sharedType the Class to key the shared object by.
+   * @param object     the Object to store
+   */
+  <C> void setSharedObject(Class<C> sharedType, C object);
+
+  /**
+   * Gets a shared Object. Note that object heirarchies are not considered.
+   *
+   * @param sharedType the type of the shared Object
+   * @return the shared Object or null if it is not found
+   */
+  <C> C getSharedObject(Class<C> sharedType);
+}

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/shared/ApolloSharedContextImpl.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/shared/ApolloSharedContextImpl.java
@@ -1,0 +1,26 @@
+package com.ctrip.framework.apollo.shared;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * @author vdisk <vdisk@foxmail.com>
+ */
+public class ApolloSharedContextImpl implements ApolloSharedContext {
+
+  /**
+   * shared Objects
+   */
+  private final ConcurrentMap<Class<?>, Object> sharedObjects = new ConcurrentHashMap<>();
+
+  @Override
+  public <C> void setSharedObject(Class<C> sharedType, C object) {
+    this.sharedObjects.put(sharedType, object);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public <C> C getSharedObject(Class<C> sharedType) {
+    return (C) this.sharedObjects.get(sharedType);
+  }
+}

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spi/ApolloSharedContextCustomizer.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spi/ApolloSharedContextCustomizer.java
@@ -1,0 +1,16 @@
+package com.ctrip.framework.apollo.spi;
+
+import com.ctrip.framework.apollo.shared.ApolloSharedContext;
+
+/**
+ * @author vdisk <vdisk@foxmail.com>
+ */
+public interface ApolloSharedContextCustomizer {
+
+  /**
+   * Performs the customizations on the ApolloSharedContext.
+   *
+   * @param sharedContext input ApolloSharedContext
+   */
+  void customize(ApolloSharedContext sharedContext);
+}

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/util/http/DefaultHttpClient.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/util/http/DefaultHttpClient.java
@@ -1,0 +1,169 @@
+package com.ctrip.framework.apollo.util.http;
+
+import com.ctrip.framework.apollo.build.ApolloInjector;
+import com.ctrip.framework.apollo.exceptions.ApolloConfigException;
+import com.ctrip.framework.apollo.exceptions.ApolloConfigStatusCodeException;
+import com.ctrip.framework.apollo.util.ConfigUtil;
+import com.google.common.base.Function;
+import com.google.common.io.CharStreams;
+import com.google.gson.Gson;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.lang.reflect.Type;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+/**
+ * @author Jason Song(song_s@ctrip.com)
+ */
+public class DefaultHttpClient implements HttpUtil {
+  private ConfigUtil m_configUtil;
+  private static final Gson GSON = new Gson();
+
+  /**
+   * Constructor.
+   */
+  public DefaultHttpClient() {
+    m_configUtil = ApolloInjector.getInstance(ConfigUtil.class);
+  }
+
+  /**
+   * Do get operation for the http request.
+   *
+   * @param httpRequest  the request
+   * @param responseType the response type
+   * @return the response
+   * @throws ApolloConfigException if any error happened or response code is neither 200 nor 304
+   */
+  @Override
+  public <T> HttpResponse<T> doGet(HttpRequest httpRequest, final Class<T> responseType) {
+    Function<String, T> convertResponse = new Function<String, T>() {
+      @Override
+      public T apply(String input) {
+        return GSON.fromJson(input, responseType);
+      }
+    };
+
+    return doGetWithSerializeFunction(httpRequest, convertResponse);
+  }
+
+  /**
+   * Do get operation for the http request.
+   *
+   * @param httpRequest  the request
+   * @param responseType the response type
+   * @return the response
+   * @throws ApolloConfigException if any error happened or response code is neither 200 nor 304
+   */
+  @Override
+  public <T> HttpResponse<T> doGet(HttpRequest httpRequest, final Type responseType) {
+    Function<String, T> convertResponse = new Function<String, T>() {
+      @Override
+      public T apply(String input) {
+        return GSON.fromJson(input, responseType);
+      }
+    };
+
+    return doGetWithSerializeFunction(httpRequest, convertResponse);
+  }
+
+  private <T> HttpResponse<T> doGetWithSerializeFunction(HttpRequest httpRequest,
+                                                         Function<String, T> serializeFunction) {
+    InputStreamReader isr = null;
+    InputStreamReader esr = null;
+    int statusCode;
+    try {
+      HttpURLConnection conn = (HttpURLConnection) new URL(httpRequest.getUrl()).openConnection();
+
+      conn.setRequestMethod("GET");
+
+      Map<String, String> headers = httpRequest.getHeaders();
+      if (headers != null && headers.size() > 0) {
+        for (Map.Entry<String, String> entry : headers.entrySet()) {
+          conn.setRequestProperty(entry.getKey(), entry.getValue());
+        }
+      }
+
+      int connectTimeout = httpRequest.getConnectTimeout();
+      if (connectTimeout < 0) {
+        connectTimeout = m_configUtil.getConnectTimeout();
+      }
+
+      int readTimeout = httpRequest.getReadTimeout();
+      if (readTimeout < 0) {
+        readTimeout = m_configUtil.getReadTimeout();
+      }
+
+      conn.setConnectTimeout(connectTimeout);
+      conn.setReadTimeout(readTimeout);
+
+      conn.connect();
+
+      statusCode = conn.getResponseCode();
+      String response;
+
+      try {
+        isr = new InputStreamReader(conn.getInputStream(), StandardCharsets.UTF_8);
+        response = CharStreams.toString(isr);
+      } catch (IOException ex) {
+        /**
+         * according to https://docs.oracle.com/javase/7/docs/technotes/guides/net/http-keepalive.html,
+         * we should clean up the connection by reading the response body so that the connection
+         * could be reused.
+         */
+        InputStream errorStream = conn.getErrorStream();
+
+        if (errorStream != null) {
+          esr = new InputStreamReader(errorStream, StandardCharsets.UTF_8);
+          try {
+            CharStreams.toString(esr);
+          } catch (IOException ioe) {
+            //ignore
+          }
+        }
+
+        // 200 and 304 should not trigger IOException, thus we must throw the original exception out
+        if (statusCode == 200 || statusCode == 304) {
+          throw ex;
+        }
+        // for status codes like 404, IOException is expected when calling conn.getInputStream()
+        throw new ApolloConfigStatusCodeException(statusCode, ex);
+      }
+
+      if (statusCode == 200) {
+        return new HttpResponse<>(statusCode, serializeFunction.apply(response));
+      }
+
+      if (statusCode == 304) {
+        return new HttpResponse<>(statusCode, null);
+      }
+    } catch (ApolloConfigStatusCodeException ex) {
+      throw ex;
+    } catch (Throwable ex) {
+      throw new ApolloConfigException("Could not complete get operation", ex);
+    } finally {
+      if (isr != null) {
+        try {
+          isr.close();
+        } catch (IOException ex) {
+          // ignore
+        }
+      }
+
+      if (esr != null) {
+        try {
+          esr.close();
+        } catch (IOException ex) {
+          // ignore
+        }
+      }
+    }
+
+    throw new ApolloConfigStatusCodeException(statusCode,
+        String.format("Get operation failed for %s", httpRequest.getUrl()));
+  }
+
+}

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/util/http/HttpUtil.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/util/http/HttpUtil.java
@@ -1,34 +1,12 @@
 package com.ctrip.framework.apollo.util.http;
 
-import com.ctrip.framework.apollo.build.ApolloInjector;
 import com.ctrip.framework.apollo.exceptions.ApolloConfigException;
-import com.ctrip.framework.apollo.exceptions.ApolloConfigStatusCodeException;
-import com.ctrip.framework.apollo.util.ConfigUtil;
-import com.google.common.base.Function;
-import com.google.common.io.CharStreams;
-import com.google.gson.Gson;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.lang.reflect.Type;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
-import java.util.Map;
 
 /**
  * @author Jason Song(song_s@ctrip.com)
  */
-public class HttpUtil {
-  private ConfigUtil m_configUtil;
-  private static final Gson GSON = new Gson();
-
-  /**
-   * Constructor.
-   */
-  public HttpUtil() {
-    m_configUtil = ApolloInjector.getInstance(ConfigUtil.class);
-  }
+public interface HttpUtil {
 
   /**
    * Do get operation for the http request.
@@ -38,16 +16,7 @@ public class HttpUtil {
    * @return the response
    * @throws ApolloConfigException if any error happened or response code is neither 200 nor 304
    */
-  public <T> HttpResponse<T> doGet(HttpRequest httpRequest, final Class<T> responseType) {
-    Function<String, T> convertResponse = new Function<String, T>() {
-      @Override
-      public T apply(String input) {
-        return GSON.fromJson(input, responseType);
-      }
-    };
-
-    return doGetWithSerializeFunction(httpRequest, convertResponse);
-  }
+  <T> HttpResponse<T> doGet(HttpRequest httpRequest, final Class<T> responseType);
 
   /**
    * Do get operation for the http request.
@@ -57,111 +26,5 @@ public class HttpUtil {
    * @return the response
    * @throws ApolloConfigException if any error happened or response code is neither 200 nor 304
    */
-  public <T> HttpResponse<T> doGet(HttpRequest httpRequest, final Type responseType) {
-    Function<String, T> convertResponse = new Function<String, T>() {
-      @Override
-      public T apply(String input) {
-        return GSON.fromJson(input, responseType);
-      }
-    };
-
-    return doGetWithSerializeFunction(httpRequest, convertResponse);
-  }
-
-  private <T> HttpResponse<T> doGetWithSerializeFunction(HttpRequest httpRequest,
-                                                         Function<String, T> serializeFunction) {
-    InputStreamReader isr = null;
-    InputStreamReader esr = null;
-    int statusCode;
-    try {
-      HttpURLConnection conn = (HttpURLConnection) new URL(httpRequest.getUrl()).openConnection();
-
-      conn.setRequestMethod("GET");
-
-      Map<String, String> headers = httpRequest.getHeaders();
-      if (headers != null && headers.size() > 0) {
-        for (Map.Entry<String, String> entry : headers.entrySet()) {
-          conn.setRequestProperty(entry.getKey(), entry.getValue());
-        }
-      }
-
-      int connectTimeout = httpRequest.getConnectTimeout();
-      if (connectTimeout < 0) {
-        connectTimeout = m_configUtil.getConnectTimeout();
-      }
-
-      int readTimeout = httpRequest.getReadTimeout();
-      if (readTimeout < 0) {
-        readTimeout = m_configUtil.getReadTimeout();
-      }
-
-      conn.setConnectTimeout(connectTimeout);
-      conn.setReadTimeout(readTimeout);
-
-      conn.connect();
-
-      statusCode = conn.getResponseCode();
-      String response;
-
-      try {
-        isr = new InputStreamReader(conn.getInputStream(), StandardCharsets.UTF_8);
-        response = CharStreams.toString(isr);
-      } catch (IOException ex) {
-        /**
-         * according to https://docs.oracle.com/javase/7/docs/technotes/guides/net/http-keepalive.html,
-         * we should clean up the connection by reading the response body so that the connection
-         * could be reused.
-         */
-        InputStream errorStream = conn.getErrorStream();
-
-        if (errorStream != null) {
-          esr = new InputStreamReader(errorStream, StandardCharsets.UTF_8);
-          try {
-            CharStreams.toString(esr);
-          } catch (IOException ioe) {
-            //ignore
-          }
-        }
-
-        // 200 and 304 should not trigger IOException, thus we must throw the original exception out
-        if (statusCode == 200 || statusCode == 304) {
-          throw ex;
-        }
-        // for status codes like 404, IOException is expected when calling conn.getInputStream()
-        throw new ApolloConfigStatusCodeException(statusCode, ex);
-      }
-
-      if (statusCode == 200) {
-        return new HttpResponse<>(statusCode, serializeFunction.apply(response));
-      }
-
-      if (statusCode == 304) {
-        return new HttpResponse<>(statusCode, null);
-      }
-    } catch (ApolloConfigStatusCodeException ex) {
-      throw ex;
-    } catch (Throwable ex) {
-      throw new ApolloConfigException("Could not complete get operation", ex);
-    } finally {
-      if (isr != null) {
-        try {
-          isr.close();
-        } catch (IOException ex) {
-          // ignore
-        }
-      }
-
-      if (esr != null) {
-        try {
-          esr.close();
-        } catch (IOException ex) {
-          // ignore
-        }
-      }
-    }
-
-    throw new ApolloConfigStatusCodeException(statusCode,
-        String.format("Get operation failed for %s", httpRequest.getUrl()));
-  }
-
+  <T> HttpResponse<T> doGet(HttpRequest httpRequest, final Type responseType);
 }

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/internals/RemoteConfigRepositoryTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/internals/RemoteConfigRepositoryTest.java
@@ -407,7 +407,7 @@ public class RemoteConfigRepositoryTest {
     }
   }
 
-  public static class MockHttpUtil extends HttpUtil {
+  public static class MockHttpUtil implements HttpUtil {
 
     @Override
     public <T> HttpResponse<T> doGet(HttpRequest httpRequest, Class<T> responseType) {


### PR DESCRIPTION
## What's the purpose of this PR
1. add a shared object context as a common way to customize apollo client
2. customize http client by the shared object context 