### PR TITLE
add network strategy guideline to docker quick start

### DIFF
--- a/docs/zh/deployment/quick-start-docker.md
+++ b/docs/zh/deployment/quick-start-docker.md
@@ -50,3 +50,5 @@ apollo-quick-start    | Portal started. You can visit http://localhost:8070 now!
 ```bash
 docker exec -i apollo-quick-start /apollo-quick-start/demo.sh client
 ```
+
+默认情况下 apollo-configservice 只会注册内网 IP，只有通过上述命令启动的客户端能连通，如果希望外部的客户端也能访问，请参考[网络策略](zh/deployment/distributed-deployment-guide?id=_14-网络策略)。

--- a/scripts/docker-quick-start/docker-compose.yml
+++ b/scripts/docker-quick-start/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - apollo-db
     ports:
       - "8080:8080"
+      - "8090:8090"
       - "8070:8070"
     links:
       - apollo-db


### PR DESCRIPTION
## What's the purpose of this PR

add network strategy guideline to docker quick start to support external client to connect to apollo-configservice

## Which issue(s) this PR fixes:
Fixes #3565

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
