### PR TITLE
ServiceBootstrap unit test fix

### DIFF
--- a/apollo-core/src/test/java/com/ctrip/framework/foundation/internals/ServiceBootstrapTest.java
+++ b/apollo-core/src/test/java/com/ctrip/framework/foundation/internals/ServiceBootstrapTest.java
@@ -48,25 +48,25 @@ public class ServiceBootstrapTest {
     ServiceBootstrap.loadPrimary(Interface7.class);
   }
 
-  public interface Interface1 {
+  interface Interface1 {
   }
 
   public static class Interface1Impl implements Interface1 {
   }
 
-  public interface Interface2 {
+  interface Interface2 {
   }
 
-  public interface Interface3 {
+  interface Interface3 {
   }
 
-  public interface Interface4 {
+  interface Interface4 {
   }
 
-  public interface Interface5 {
+  interface Interface5 {
   }
 
-  public interface Interface6 extends Ordered {
+  interface Interface6 extends Ordered {
   }
 
   public static class Interface6Impl1 implements Interface6 {
@@ -83,6 +83,6 @@ public class ServiceBootstrapTest {
     }
   }
 
-  public interface Interface7 extends Ordered {
+  interface Interface7 extends Ordered {
   }
 }

--- a/apollo-core/src/test/java/com/ctrip/framework/foundation/internals/ServiceBootstrapTest.java
+++ b/apollo-core/src/test/java/com/ctrip/framework/foundation/internals/ServiceBootstrapTest.java
@@ -48,25 +48,25 @@ public class ServiceBootstrapTest {
     ServiceBootstrap.loadPrimary(Interface7.class);
   }
 
-  private interface Interface1 {
+  public interface Interface1 {
   }
 
   public static class Interface1Impl implements Interface1 {
   }
 
-  private interface Interface2 {
+  public interface Interface2 {
   }
 
-  private interface Interface3 {
+  public interface Interface3 {
   }
 
-  private interface Interface4 {
+  public interface Interface4 {
   }
 
-  private interface Interface5 {
+  public interface Interface5 {
   }
 
-  private interface Interface6 extends Ordered {
+  public interface Interface6 extends Ordered {
   }
 
   public static class Interface6Impl1 implements Interface6 {
@@ -83,6 +83,6 @@ public class ServiceBootstrapTest {
     }
   }
 
-  private interface Interface7 extends Ordered {
+  public interface Interface7 extends Ordered {
   }
 }


### PR DESCRIPTION
on jdk11 the method ```java.util.ServiceLoader#load```  called the check method ```java.util.ServiceLoader#checkCaller```
the ```private interface``` cause the error ```service type not accessible to xxx```
```
    private static void checkCaller(Class<?> caller, Class<?> svc) {
        ...
        // Check access to the service type
        Module callerModule = caller.getModule();
        int mods = svc.getModifiers();
        if (!Reflection.verifyMemberAccess(caller, svc, null, mods)) {
            fail(svc, "service type not accessible to " + callerModule);
        }
        ...
    }

```