### PR TITLE
fix the issue that access key doesn't work if appid passed is in different case

### DIFF
--- a/apollo-configservice/src/main/java/com/ctrip/framework/apollo/configservice/service/AccessKeyServiceWithCache.java
+++ b/apollo-configservice/src/main/java/com/ctrip/framework/apollo/configservice/service/AccessKeyServiceWithCache.java
@@ -63,7 +63,7 @@ public class AccessKeyServiceWithCache implements InitializingBean {
         ApolloThreadFactory.create("AccessKeyServiceWithCache", true));
     lastTimeScanned = new Date(0L);
 
-    ListMultimap<String, AccessKey> multimap = ListMultimapBuilder.hashKeys(128)
+    ListMultimap<String, AccessKey> multimap = ListMultimapBuilder.treeKeys(String.CASE_INSENSITIVE_ORDER)
         .arrayListValues().build();
     accessKeyCache = Multimaps.synchronizedListMultimap(multimap);
     accessKeyIdCache = Maps.newConcurrentMap();

--- a/apollo-configservice/src/test/java/com/ctrip/framework/apollo/configservice/service/AccessKeyServiceWithCacheTest.java
+++ b/apollo-configservice/src/test/java/com/ctrip/framework/apollo/configservice/service/AccessKeyServiceWithCacheTest.java
@@ -81,6 +81,11 @@ public class AccessKeyServiceWithCacheTest {
 
     await().untilAsserted(() -> assertThat(accessKeyServiceWithCache.getAvailableSecrets(appId))
         .containsExactly("secret-1", "secret-2"));
+    // should also work with appid in different case
+    assertThat(accessKeyServiceWithCache.getAvailableSecrets(appId.toUpperCase()))
+        .containsExactly("secret-1", "secret-2");
+    assertThat(accessKeyServiceWithCache.getAvailableSecrets(appId.toLowerCase()))
+        .containsExactly("secret-1", "secret-2");
 
     // Update access key, disable the first one
     firstAccessKey = assembleAccessKey(1L, appId, "secret-1", false, false, 1577808004000L);


### PR DESCRIPTION
## What's the purpose of this PR

fix the issue that access key doesn't work if appid passed is in different case

## Which issue(s) this PR fixes:
Fixes #3626

## Brief changelog

Use tree set with CASE_INSENSITIVE_ORDER comparator.

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
