### PR TITLE
test(apollo-client): use assertEquals instead of assertThat

### DIFF
--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/internals/LocalFileConfigRepositoryTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/internals/LocalFileConfigRepositoryTest.java
@@ -1,8 +1,6 @@
 package com.ctrip.framework.apollo.internals;
 
-import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -138,9 +136,9 @@ public class LocalFileConfigRepositoryTest {
 
     Properties result = localFileConfigRepository.getConfig();
 
-    assertThat(
+    assertEquals(
         "LocalFileConfigRepository's properties should be the same as fallback repo's when there is no local cache",
-        result.entrySet(), equalTo(someProperties.entrySet()));
+        result, someProperties);
     assertEquals(someSourceType, localFileConfigRepository.getSourceType());
   }
 
@@ -159,9 +157,9 @@ public class LocalFileConfigRepositoryTest {
 
     Properties anotherProperties = anotherLocalRepoWithNoFallback.getConfig();
 
-    assertThat(
+    assertEquals(
         "LocalFileConfigRepository should persist local cache files and return that afterwards",
-        someProperties.entrySet(), equalTo(anotherProperties.entrySet()));
+        someProperties, anotherProperties);
     assertEquals(someSourceType, localRepo.getSourceType());
   }
 


### PR DESCRIPTION
## What's the purpose of this PR

Fix test fail when use java 9 or above.

## Which issue(s) this PR fixes:

NONE

## Brief changelog

Use equals to compare properties directly.

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.

## details

Consider code like follow
```java
import java.util.Properties;

public class Main {

  public static void main(String[] args) {
    Properties a = new Properties();
    a.put("x", "0");

    Properties b = new Properties();
    b.put("x", "0");

    System.out.println(a.equals(b));
    System.out.println(a.entrySet().equals(b.entrySet()));
  }
}
```

In Jdk 8, the output will be
```
true
true
```

But in Jdk 9 or above, the output will change to
```
true
false
```

One can run it on website https://www.jdoodle.com/online-java-compiler/

So it need to compare properties directly instread of using entrySet.