### PR TITLE
Community Governance Proposal

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,12 +1,12 @@
 # Overview 
 
-Apollo is a meritocratic, consensus-based community project. Anyone with an interest in the project can join the community, contribute to the project design and participate in the decision making process.
+Apollo is a meritocratic, consensus-based community project. Anyone with an interest in the project can join the community, contribute to the project design and participate in the decision-making process.
 
 This document describes how that participation takes place and how to set about earning merit within the project community.
 
 # Roles and Responsibilities
 
-Apollo community is comprised of and operated by the following roles:
+Apollo community is composed of and operated by the following roles:
 
 - Users
 - Contributors
@@ -69,21 +69,25 @@ The PMC(Project Management Committee) functions as the core management team that
 
 ### Privileges and responsibilities
 
-Members of the PMC do not have significant authority over other members of the community, although it is the PMC that votes on new Committers, and makes all major decisions for the future with respect to Apollo, such as project-level governance policies, management of sub-structures, security processes and so on. It also makes decisions when community consensus cannot be reached.
+- Handle reported security issues (CVE, etc.)
+- Nominate new committers and PMC members
+- Vote on new committers and new PMC members
+- Make major decisions for the future with respect to Apollo, such as project-level governance policies, management of sub-structures, security processes and so on
+- Make decisions when community consensus cannot be reached
 
-# Decision making and voting
+# Decision-making and voting
 
 Proposals and ideas can be submitted for agreement via a GitHub issue, PR, or GitHub Discussion.
 
-Major changes such as feature proposals and organization or process changes should be brought to the PMC. For the change to happen, the change must earn the supermajority (2/3) votes.
+Major changes such as feature proposals and organization or process changes should be brought to the PMC. For the change to happen, the change must earn more +1 than -1.
 
 # Conflict resolution
 
-In general, we prefer that technical issues and other disputes upon which consensus can't be reached are amicably worked out between the persons involved. If a dispute cannot be decided independently, the PMC can be called in to resolve the issue by voting. The same PR can be used or a separate PR can be opened for voting.
+In general, we prefer that technical issues and other disputes upon which consensus can't be reached are amicably worked out between the persons involved. If a dispute cannot be decided independently, the PMC can be called in to resolve the issue by voting. The same PR can be used, or a separate PR can be opened for voting.
 
 # Changes in Governance
 
-Any change in this Governance document, or similar nature of changes to other governance related documents, shall go through the voting process as described in [Decision making and voting](#decision-making-and-voting).
+Any change in this Governance document, or similar nature of changes to other governance related documents, shall go through the voting process as described in [Decision-making and voting](#decision-making-and-voting).
 
 # Credits
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -34,6 +34,8 @@ You are also encouraged to participate in the projects in the following ways:
 - Submit valuable issues
 - Report or fix known and unknown bugs
 - Write articles about source code analysis and usage cases for a project.
+- Give representations of Apollo topic in conferences.
+- Take part in our discussions of features, enhancements, etc.
 
 ## Committers
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -61,7 +61,7 @@ A Committer must have accomplished one or more of the following items:
 
 The PMC(Project Management Committee) functions as the core management team that oversees the Apollo community. The PMC has additional responsibilities over and above those of Committers. These responsibilities ensure the smooth running of the project.
 
-### How to become a PMC
+### How to become a PMC member
 
 - Membership of the PMC is by invitation from the existing PMC members. 
 - A nomination will result in discussion and then a vote by the existing PMC members.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -49,7 +49,7 @@ A Committer must have accomplished one or more of the following items:
 - Demonstrated deep understanding of Apollo components by contributing significantly as:
     - Finished 2 or more tasks of Medium difficulty
     - Fixed 1 or more tasks of Hard difficulty
-- Nominated by one PMC and gained supermajority (2/3) votes from PMCs
+- Nominated by one PMC member and gained more +1 than -1.
 
 ### Privileges and responsibilities
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -73,7 +73,7 @@ Members of the PMC do not have significant authority over other members of the c
 
 # Decision making and voting
 
-Proposals and ideas can be submitted for agreement via a github issue or PR.
+Proposals and ideas can be submitted for agreement via a GitHub issue, PR, or GitHub Discussion.
 
 Major changes such as feature proposals and organization or process changes should be brought to the PMC. For the change to happen, the change must earn the supermajority (2/3) votes.
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,88 @@
+# Overview 
+
+Apollo is a meritocratic, consensus-based community project. Anyone with an interest in the project can join the community, contribute to the project design and participate in the decision making process.
+
+This document describes how that participation takes place and how to set about earning merit within the project community.
+
+# Roles and Responsibilities
+
+Apollo community is comprised of and operated by the following roles:
+
+- Users
+- Contributors
+- Committers
+- Project Management Committee (PMC)
+
+## Users
+
+Users are community members who have a need for the project. They are the most important members of the community and without them the project would have no purpose. Anyone can be a user and there are no special requirements.
+
+## Contributors
+
+Contributors are community members who contribute in concrete ways to the project.
+
+### How to become a Contributor
+
+- merged at least 1 pull request
+
+You are also encouraged to participate in the projects in the following ways:
+
+- Actively answer technical questions raised by community users in GitHub issues.
+- Help test the projects
+- Help review the pull requests (PRs) submitted by others
+- Help improve technical documents
+- Submit valuable issues
+- Report or fix known and unknown bugs
+- Write articles about source code analysis and usage cases for a project.
+
+## Committers
+
+Committers are contributors who have shown that they are committed to the continued development of the project through ongoing engagement with the community and recognized by PMCs for their outstanding contributions.
+
+### How to become a Committer
+
+A Committer must have accomplished one or more of the following items:
+
+- Demonstrated a good sense of responsibility in PR reviews.
+- Demonstrated deep understanding of Apollo components by contributing significantly as:
+    - Finished 2 or more tasks of Medium difficulty
+    - Fixed 1 or more tasks of Hard difficulty
+- Nominated by one PMC and gained supermajority (2/3) votes from PMCs
+
+### Privileges and responsibilities
+
+- Control overall code quality of projects
+- Guide Contributors to contribute to the community continuously
+- Participate in design discussions
+
+## Project Management Committee
+
+The PMC(Project Management Committee) functions as the core management team that oversees the Apollo community. The PMC has additional responsibilities over and above those of Committers. These responsibilities ensure the smooth running of the project.
+
+### How to become a PMC
+
+- Membership of the PMC is by invitation from the existing PMC members. 
+- A nomination will result in discussion and then a vote by the existing PMC members.
+- PMC membership votes are subject to consensus approval of the current PMC members.
+
+### Privileges and responsibilities
+
+Members of the PMC do not have significant authority over other members of the community, although it is the PMC that votes on new Committers, and makes all major decisions for the future with respect to Apollo, such as project-level governance policies, management of sub-structures, security processes and so on. It also makes decisions when community consensus cannot be reached.
+
+# Decision making and voting
+
+Proposals and ideas can be submitted for agreement via a github issue or PR.
+
+Major changes such as feature proposals and organization or process changes should be brought to the PMC. For the change to happen, the change must earn the supermajority (2/3) votes.
+
+# Conflict resolution
+
+In general, we prefer that technical issues and other disputes upon which consensus can't be reached are amicably worked out between the persons involved. If a dispute cannot be decided independently, the PMC can be called in to resolve the issue by voting. The same PR can be used or a separate PR can be opened for voting.
+
+# Changes in Governance
+
+Any change in this Governance document, or similar nature of changes to other governance related documents, shall go through the voting process as described in [Decision making and voting](#decision-making-and-voting).
+
+# Credits
+
+The contents of this document are based on <http://oss-watch.ac.uk/resources/meritocraticgovernancemodel> by Ross Gardler and Gabriel Hanganu, and [TiDB Governance](https://github.com/pingcap/community/blob/master/GOVERNANCE.md).


### PR DESCRIPTION
Apollo has now been widely adopted in hundreds (if not thousands) of companies, which in my opinion is because we have made great efforts in product quality and user support.

However, as the old saying goes: "If you want to go fast, go alone. If you want to go far, go together.", to make Apollo go further, we now need to put more efforts in community side so that more people could join us and hence make the community stronger.

As another saying goes: "Nothing can be accomplished without norms or standards", so I think the first thing is to define our community governance rules in order to make it clear who we are, how we make decisions so that people could understand and join us without concerns.

The initial governance rules are drafted in this pull request and I wish they could be fully reviewed. So no matter you are a user/contributor/committer, please help to review and feel free to comment if you have any suggestion/idea/question.