### PR TITLE
fix: 修复 user sql 错误

### DIFF
--- a/scripts/docker-quick-start/sql/apolloportaldb.sql
+++ b/scripts/docker-quick-start/sql/apolloportaldb.sql
@@ -299,7 +299,7 @@ CREATE TABLE `Users` (
   `Id` int(10) unsigned NOT NULL AUTO_INCREMENT COMMENT '自增Id',
   `Username` varchar(64) NOT NULL DEFAULT 'default' COMMENT '用户登录账户',
   `Password` varchar(64) NOT NULL DEFAULT 'default' COMMENT '密码',
-  `UserDisplayName` varchar(512) NOT NULL DEFAULT 'default' COMMENT '用户名称',
+  `PreferredUsername` varchar(512) NOT NULL DEFAULT 'default' COMMENT '用户名称',
   `Email` varchar(64) NOT NULL DEFAULT 'default' COMMENT '邮箱地址',
   `Enabled` tinyint(4) DEFAULT NULL COMMENT '是否有效',
   PRIMARY KEY (`Id`)


### PR DESCRIPTION
## What's the purpose of this PR

插入用户表的 SQL 语句与创建的 SQL 语句字段不一致导致无法启动成功，

原：创建语句为：

```sql
CREATE TABLE `Users` (
  `Id` int(10) unsigned NOT NULL AUTO_INCREMENT COMMENT '自增Id',
  `Username` varchar(64) NOT NULL DEFAULT 'default' COMMENT '用户登录账户',
  `Password` varchar(64) NOT NULL DEFAULT 'default' COMMENT '密码',
  `UserDisplayName` varchar(512) NOT NULL DEFAULT 'default' COMMENT '用户名称',
  `Email` varchar(64) NOT NULL DEFAULT 'default' COMMENT '邮箱地址',
  `Enabled` tinyint(4) DEFAULT NULL COMMENT '是否有效',
  PRIMARY KEY (`Id`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='用户表';
```

插入语句为：
```sql
INSERT INTO `Users` (`Username`, `Password`, `PreferredUsername`, `Email`, `Enabled`)
VALUES
    ('apollo', '$2a$10$7r20uS.BQ9uBpf3Baj3uQOZvMVvB1RN3PYoKE94gtz2.WAOuiiwXS', 'apollo', 'apollo@acme.com', 1);
```

启动时会报 `PreferredUsername` 不存在。


修改方式：

将 `UserDisplayName` 替换为 `PreferredUsername`
