### PR TITLE
Fix typo on "load from specified cluster fist"

### DIFF
--- a/apollo-configservice/src/main/java/com/ctrip/framework/apollo/configservice/service/config/AbstractConfigService.java
+++ b/apollo-configservice/src/main/java/com/ctrip/framework/apollo/configservice/service/config/AbstractConfigService.java
@@ -36,7 +36,7 @@ public abstract class AbstractConfigService implements ConfigService {
   @Override
   public Release loadConfig(String clientAppId, String clientIp, String configAppId, String configClusterName,
       String configNamespace, String dataCenter, ApolloNotificationMessages clientMessages) {
-    // load from specified cluster fist
+    // load from specified cluster first
     if (!Objects.equals(ConfigConsts.CLUSTER_NAME_DEFAULT, configClusterName)) {
       Release clusterRelease = findRelease(clientAppId, clientIp, configAppId, configClusterName, configNamespace,
           clientMessages);


### PR DESCRIPTION
## Fix Typo

the comment should be "load from specified cluster first" instead of "load from specified cluster fist"
