### PR TITLE
add More... link for known users

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,6 +44,7 @@ Apollo 1.9.0
 * [add apollo team introduction and community releated contents](https://github.com/ctripcorp/apollo/pull/3713)
 * [fix oidc sql](https://github.com/ctripcorp/apollo/pull/3720)
 * [feat(apollo-client): add method interestedChangedKeys to ConfigChangeEvent](https://github.com/ctripcorp/apollo/pull/3666)
+* [add More... link for known users](https://github.com/ctripcorp/apollo/pull/3757)
 ------------------
 All issues and pull requests are [here](https://github.com/ctripcorp/apollo/milestone/6?closed=1)
 

--- a/README.md
+++ b/README.md
@@ -529,6 +529,7 @@ The project is licensed under the [Apache 2 license](https://github.com/ctripcor
 <td><img src="https://raw.githubusercontent.com/ctripcorp/apollo-community/master/images/known-users/mvmyun.png" alt="今典"></td>
 <td><img src="https://raw.githubusercontent.com/ctripcorp/apollo-community/master/images/known-users/visabao.jpg" alt="签宝科技"></td>
 <td><img src="https://raw.githubusercontent.com/ctripcorp/apollo-community/master/images/known-users/inrice.png" alt="广州趣米网络科技有限公司"></td>
+<td><a target="_blank" href="https://github.com/ctripcorp/apollo/issues/451">More...</a></td>
 </tr>
 </table>
 


### PR DESCRIPTION
## What's the purpose of this PR

I think there are already enough known users shown in the front page, so it's better to show a more link instead of adding new users.

## Brief changelog

* add a `More...` link for known users table

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [x] Update the [`CHANGES` log](https://github.com/ctripcorp/apollo/blob/master/CHANGES.md).