### PR TITLE
Fix typo on doc "development guide" chapter 2.3.3

### DIFF
--- a/docs/zh/development/apollo-development-guide.md
+++ b/docs/zh/development/apollo-development-guide.md
@@ -151,7 +151,7 @@ Apollo本地开发需要以下组件：
 ![NewConfiguration-Application](https://raw.githubusercontent.com/ctripcorp/apollo/master/doc/images/local-development/NewConfiguration-Application.png)
 
 ### 2.3.3 Main class配置
-`SimpleApolloConfigDemo`
+`com.ctrip.framework.apollo.demo.api.SimpleApolloConfigDemo`
 
 ### 2.3.4 VM options配置
 ![apollo-demo-vm-options](https://raw.githubusercontent.com/ctripcorp/apollo/master/doc/images/local-development/apollo-demo-vm-options.png)


### PR DESCRIPTION
fix main class configuration to correct
in docs/zh/development/apollo-development-guide.md

## What's the purpose of this PR

fix a typo in document
使此行与前几个小节类似内容格式一致，按文档配置 Main Class 时能够直接复制。

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit tests to verify the code.
- [ ] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [ ] Update the [`CHANGES` log](https://github.com/ctripcorp/apollo/blob/master/CHANGES.md).
