### PR TITLE
feature: modify item comment valid size(#3799)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -52,6 +52,7 @@ Apollo 1.9.0
 * [feat(open-api): get authorized apps](https://github.com/ctripcorp/apollo/pull/3647)
 * [feature: shared session for multi apollo portal](https://github.com/ctripcorp/apollo/pull/3786)
 * [feature: add email for select user on apollo portal](https://github.com/ctripcorp/apollo/pull/3797)
+* [feature: modify item comment valid size](https://github.com/ctripcorp/apollo/pull/3803)
 ------------------
 All issues and pull requests are [here](https://github.com/ctripcorp/apollo/milestone/6?closed=1)
 

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/v1/controller/ItemController.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/v1/controller/ItemController.java
@@ -76,8 +76,8 @@ public class ItemController {
       throw new BadRequestException("User " + item.getDataChangeCreatedBy() + " doesn't exist!");
     }
 
-    if(!StringUtils.isEmpty(item.getComment()) && item.getComment().length() > 1024){
-      throw new BadRequestException("Comment length should not exceed 1024 characters");
+    if(!StringUtils.isEmpty(item.getComment()) && item.getComment().length() > 256){
+      throw new BadRequestException("Comment length should not exceed 256 characters");
     }
 
     ItemDTO toCreate = OpenApiBeanUtils.transformToItemDTO(item);
@@ -113,8 +113,8 @@ public class ItemController {
       throw new BadRequestException("user(dataChangeLastModifiedBy) not exists");
     }
 
-    if(!StringUtils.isEmpty(item.getComment()) && item.getComment().length() > 1024){
-      throw new BadRequestException("Comment length should not exceed 1024 characters");
+    if(!StringUtils.isEmpty(item.getComment()) && item.getComment().length() > 256){
+      throw new BadRequestException("Comment length should not exceed 256 characters");
     }
 
     try {

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/v1/controller/ItemController.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/v1/controller/ItemController.java
@@ -76,8 +76,8 @@ public class ItemController {
       throw new BadRequestException("User " + item.getDataChangeCreatedBy() + " doesn't exist!");
     }
 
-    if(!StringUtils.isEmpty(item.getComment()) && item.getComment().length() > 64){
-      throw new BadRequestException("Comment length should not exceed 64 characters");
+    if(!StringUtils.isEmpty(item.getComment()) && item.getComment().length() > 1024){
+      throw new BadRequestException("Comment length should not exceed 1024 characters");
     }
 
     ItemDTO toCreate = OpenApiBeanUtils.transformToItemDTO(item);
@@ -113,8 +113,8 @@ public class ItemController {
       throw new BadRequestException("user(dataChangeLastModifiedBy) not exists");
     }
 
-    if(!StringUtils.isEmpty(item.getComment()) && item.getComment().length() > 64){
-      throw new BadRequestException("Comment length should not exceed 64 characters");
+    if(!StringUtils.isEmpty(item.getComment()) && item.getComment().length() > 1024){
+      throw new BadRequestException("Comment length should not exceed 1024 characters");
     }
 
     try {

--- a/apollo-portal/src/main/resources/static/i18n/en.json
+++ b/apollo-portal/src/main/resources/static/i18n/en.json
@@ -724,7 +724,7 @@
   "Valdr.AppNamespace.Comment.Size": "Comment length should not exceed 64 characters",
   "Valdr.Item.Key.Size": "Key cannot be longer than 128 characters",
   "Valdr.Item.Key.Required": "Key can't be empty",
-  "Valdr.Item.Comment.Size": "Comment length should not exceed 1024 characters",
+  "Valdr.Item.Comment.Size": "Comment length should not exceed 256 characters",
   "Valdr.Release.ReleaseName.Size": "Release Name cannot be longer than 64 characters",
   "Valdr.Release.ReleaseName.Required": "Release Name cannot be empty",
   "Valdr.Release.Comment.Size": "Comment length should not exceed 64 characters",

--- a/apollo-portal/src/main/resources/static/i18n/en.json
+++ b/apollo-portal/src/main/resources/static/i18n/en.json
@@ -727,7 +727,7 @@
   "Valdr.Item.Comment.Size": "Comment length should not exceed 256 characters",
   "Valdr.Release.ReleaseName.Size": "Release Name cannot be longer than 64 characters",
   "Valdr.Release.ReleaseName.Required": "Release Name cannot be empty",
-  "Valdr.Release.Comment.Size": "Comment length should not exceed 64 characters",
+  "Valdr.Release.Comment.Size": "Comment length should not exceed 256 characters",
   "ApolloConfirmDialog.DefaultConfirmBtnName": "OK",
   "ApolloConfirmDialog.SearchPlaceHolder": "Search items (App Id, App Name)",
   "RulesModal.ChooseInstances": "Select from the list of instances",

--- a/apollo-portal/src/main/resources/static/i18n/en.json
+++ b/apollo-portal/src/main/resources/static/i18n/en.json
@@ -724,7 +724,7 @@
   "Valdr.AppNamespace.Comment.Size": "Comment length should not exceed 64 characters",
   "Valdr.Item.Key.Size": "Key cannot be longer than 128 characters",
   "Valdr.Item.Key.Required": "Key can't be empty",
-  "Valdr.Item.Comment.Size": "Comment length should not exceed 64 characters",
+  "Valdr.Item.Comment.Size": "Comment length should not exceed 1024 characters",
   "Valdr.Release.ReleaseName.Size": "Release Name cannot be longer than 64 characters",
   "Valdr.Release.ReleaseName.Required": "Release Name cannot be empty",
   "Valdr.Release.Comment.Size": "Comment length should not exceed 64 characters",

--- a/apollo-portal/src/main/resources/static/i18n/zh-CN.json
+++ b/apollo-portal/src/main/resources/static/i18n/zh-CN.json
@@ -727,7 +727,7 @@
   "Valdr.Item.Comment.Size": "备注长度不能多于256个字符",
   "Valdr.Release.ReleaseName.Size": "Release Name长度不能多于64个字符",
   "Valdr.Release.ReleaseName.Required": "Release Name不能为空",
-  "Valdr.Release.Comment.Size": "备注长度不能多于64个字符",
+  "Valdr.Release.Comment.Size": "备注长度不能多于256个字符",
   "ApolloConfirmDialog.DefaultConfirmBtnName": "确认",
   "ApolloConfirmDialog.SearchPlaceHolder": "搜索项目(AppId、项目名)",
   "RulesModal.ChooseInstances": "从实例列表中选择",

--- a/apollo-portal/src/main/resources/static/i18n/zh-CN.json
+++ b/apollo-portal/src/main/resources/static/i18n/zh-CN.json
@@ -724,7 +724,7 @@
   "Valdr.AppNamespace.Comment.Size": "备注长度不能多于64个字符",
   "Valdr.Item.Key.Size": "Key长度不能多于128个字符",
   "Valdr.Item.Key.Required": "Key不能为空",
-  "Valdr.Item.Comment.Size": "备注长度不能多于64个字符",
+  "Valdr.Item.Comment.Size": "备注长度不能多于1024个字符",
   "Valdr.Release.ReleaseName.Size": "Release Name长度不能多于64个字符",
   "Valdr.Release.ReleaseName.Required": "Release Name不能为空",
   "Valdr.Release.Comment.Size": "备注长度不能多于64个字符",

--- a/apollo-portal/src/main/resources/static/i18n/zh-CN.json
+++ b/apollo-portal/src/main/resources/static/i18n/zh-CN.json
@@ -724,7 +724,7 @@
   "Valdr.AppNamespace.Comment.Size": "备注长度不能多于64个字符",
   "Valdr.Item.Key.Size": "Key长度不能多于128个字符",
   "Valdr.Item.Key.Required": "Key不能为空",
-  "Valdr.Item.Comment.Size": "备注长度不能多于1024个字符",
+  "Valdr.Item.Comment.Size": "备注长度不能多于256个字符",
   "Valdr.Release.ReleaseName.Size": "Release Name长度不能多于64个字符",
   "Valdr.Release.ReleaseName.Required": "Release Name不能为空",
   "Valdr.Release.Comment.Size": "备注长度不能多于64个字符",

--- a/apollo-portal/src/main/resources/static/scripts/valdr.js
+++ b/apollo-portal/src/main/resources/static/scripts/valdr.js
@@ -94,7 +94,7 @@ application_module.config(function (valdrProvider) {
             },
             'comment': {
                 'size': {
-                    'max': 64,
+                    'max': 1024,
                     'message': 'Valdr.Item.Comment.Size'
                 }
             }

--- a/apollo-portal/src/main/resources/static/scripts/valdr.js
+++ b/apollo-portal/src/main/resources/static/scripts/valdr.js
@@ -94,7 +94,7 @@ application_module.config(function (valdrProvider) {
             },
             'comment': {
                 'size': {
-                    'max': 1024,
+                    'max': 256,
                     'message': 'Valdr.Item.Comment.Size'
                 }
             }

--- a/apollo-portal/src/main/resources/static/scripts/valdr.js
+++ b/apollo-portal/src/main/resources/static/scripts/valdr.js
@@ -111,7 +111,7 @@ application_module.config(function (valdrProvider) {
             },
             'comment': {
                 'size': {
-                    'max': 64,
+                    'max': 256,
                     'message': 'Valdr.Release.Comment.Size'
                 }
             }

--- a/docs/zh/usage/apollo-open-api-platform.md
+++ b/docs/zh/usage/apollo-open-api-platform.md
@@ -379,7 +379,7 @@ Apollo在生产环境（PRO）有限制规则：每次发布只能有一个人�
 ---- | --- | --- | ---
 key | true | String | 配置的key，长度不能超过128个字符。非properties格式，key固定为`content`
 value |	true | String | 配置的value，长度不能超过20000个字符，非properties格式，value为文件全部内容
-comment	| false | String | 配置的备注,长度不能超过1024个字符
+comment	| false | String | 配置的备注,长度不能超过256个字符
 dataChangeCreatedBy | true | String | item的创建人，格式为域账号，也就是sso系统的User ID
 
 * **Request body sample** :
@@ -424,7 +424,7 @@ createIfNotExists | false | Boolean | 当配置不存在时是否自动创建
 ---- | --- | --- | ---
 key | true | String | 配置的key，需和url中的key值一致。非properties格式，key固定为`content`
 value |	true | String | 配置的value，长度不能超过20000个字符，非properties格式，value为文件全部内容
-comment	| false | String | 配置的备注,长度不能超过1024个字符
+comment	| false | String | 配置的备注,长度不能超过256个字符
 dataChangeLastModifiedBy | true | String | item的修改人，格式为域账号，也就是sso系统的User ID
 dataChangeCreatedBy | false | String | 当createIfNotExists为true时必选。item的创建人，格式为域账号，也就是sso系统的User ID
 


### PR DESCRIPTION
## What's the purpose of this PR

修改openapi创建item校验的comment长度大小，兼容历史业务场景升级。


## Which issue(s) this PR fixes:
Fixes #3799

## Brief changelog

1、openapi入口ItemController.java comment校验长度大小改为256
2、portal前端入口valdr.js comment长度大小同步改为256
3、en.json 、zh-CN.json 修改对应数值


Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [x] Update the [`CHANGES` log](https://github.com/ctripcorp/apollo/blob/master/CHANGES.md).
