### PR TITLE
speed up the stale issue mark and close phase

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -17,7 +17,7 @@
 
 # General configuration
 # Number of days of inactivity before an issue becomes stale
-daysUntilStale: 60
+daysUntilStale: 30
 # Issues with these labels will never be considered stale
 exemptLabels:
   - bug
@@ -43,34 +43,34 @@ staleLabel: stale
 pulls:
   # Number of days of inactivity before a stale Issue or Pull Request is closed.
   # Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
-  daysUntilClose: 30
+  daysUntilClose: 14
   # Comment to post when marking as stale. Set to `false` to disable
   markComment: >
     This pull request has been automatically marked as stale because it has not had activity
-    in the last 90 days. It will be closed in 30 days if no further activity occurs. Please
+    in the last 30 days. It will be closed in 14 days if no further activity occurs. Please
     feel free to give a status update now, ping for review, or re-open when it's ready.
     Thank you for your contributions!
   # Comment to post when closing a stale Issue or Pull Request.
   closeComment: >
      This pull request has been automatically closed because it has not had
-     activity in the last 30 days. Please feel free to give a status update now, ping for review, or re-open when it's ready.
+     activity in the last 14 days. Please feel free to give a status update now, ping for review, or re-open when it's ready.
      Thank you for your contributions!
   # Limit the number of actions per hour, from 1-30. Default is 30
-  limitPerRun: 1
+  limitPerRun: 30
 
 # Issue specific configuration
 issues:
   # Number of days of inactivity before a stale Issue or Pull Request is closed.
-  daysUntilClose: 14
+  daysUntilClose: 7
   # Comment to post when marking as stale. Set to `false` to disable
   markComment: >
     This issue has been automatically marked as stale because it has not had activity in the
-    last 90 days. It will be closed in 14 days unless it is tagged "help wanted" or other activity
+    last 30 days. It will be closed in 7 days unless it is tagged "help wanted" or other activity
     occurs. Thank you for your contributions.
   # Comment to post when closing a stale Issue or Pull Request.
   closeComment: >
     This issue has been automatically closed because it has not had activity in the
-    last 14 days. If this issue is still valid, please ping a maintainer and ask them to label it as "help wanted".
+    last 7 days. If this issue is still valid, please ping a maintainer and ask them to label it as "help wanted".
     Thank you for your contributions.
   # Limit the number of actions per hour, from 1-30. Default is 30
-  limitPerRun: 1
+  limitPerRun: 30

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -53,6 +53,7 @@ Apollo 1.9.0
 * [feature: shared session for multi apollo portal](https://github.com/ctripcorp/apollo/pull/3786)
 * [feature: add email for select user on apollo portal](https://github.com/ctripcorp/apollo/pull/3797)
 * [feature: modify item comment valid size](https://github.com/ctripcorp/apollo/pull/3803)
+* [speed up the stale issue mark and close phase](https://github.com/ctripcorp/apollo/pull/3808)
 ------------------
 All issues and pull requests are [here](https://github.com/ctripcorp/apollo/milestone/6?closed=1)
 


### PR DESCRIPTION
## What's the purpose of this PR

Currently the issues would be marked as stale after 60 days inactivity and would be closed in another 30 days inactivity, which is very long. So I think it's necessary to speed up the stale bot process to make the community more active.

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [x] Update the [`CHANGES` log](https://github.com/ctripcorp/apollo/blob/master/CHANGES.md).
