### PR TITLE
fix the issue that release messages might be missed in certain scenarios

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -59,6 +59,7 @@ Apollo 1.9.0
 * [support release apollo-client-config-data](https://github.com/ctripcorp/apollo/pull/3822)
 * [Reduce bootstrap time in the situation with large properties](https://github.com/ctripcorp/apollo/pull/3816)
 * [docs: English catalog in sidebar](https://github.com/ctripcorp/apollo/pull/3831)
+* [fix the issue that release messages might be missed in certain scenarios](https://github.com/ctripcorp/apollo/pull/3819)
 ------------------
 All issues and pull requests are [here](https://github.com/ctripcorp/apollo/milestone/6?closed=1)
 

--- a/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/message/ReleaseMessageScanner.java
+++ b/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/message/ReleaseMessageScanner.java
@@ -16,7 +16,12 @@
  */
 package com.ctrip.framework.apollo.biz.message;
 
+import com.google.common.collect.Maps;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -40,19 +45,22 @@ import com.google.common.collect.Lists;
  */
 public class ReleaseMessageScanner implements InitializingBean {
   private static final Logger logger = LoggerFactory.getLogger(ReleaseMessageScanner.class);
+  private static final int missingReleaseMessageMaxAge = 10; // hardcoded to 10, could be configured via BizConfig if necessary
   @Autowired
   private BizConfig bizConfig;
   @Autowired
   private ReleaseMessageRepository releaseMessageRepository;
   private int databaseScanInterval;
-  private List<ReleaseMessageListener> listeners;
-  private ScheduledExecutorService executorService;
+  private final List<ReleaseMessageListener> listeners;
+  private final ScheduledExecutorService executorService;
+  private final Map<Long, Integer> missingReleaseMessages; // missing release message id => age counter
   private long maxIdScanned;
 
   public ReleaseMessageScanner() {
     listeners = Lists.newCopyOnWriteArrayList();
     executorService = Executors.newScheduledThreadPool(1, ApolloThreadFactory
         .create("ReleaseMessageScanner", true));
+    missingReleaseMessages = Maps.newHashMap();
   }
 
   @Override
@@ -62,6 +70,7 @@ public class ReleaseMessageScanner implements InitializingBean {
     executorService.scheduleWithFixedDelay(() -> {
       Transaction transaction = Tracer.newTransaction("Apollo.ReleaseMessageScanner", "scanMessage");
       try {
+        scanMissingMessages();
         scanMessages();
         transaction.setStatus(Transaction.SUCCESS);
       } catch (Throwable ex) {
@@ -108,8 +117,49 @@ public class ReleaseMessageScanner implements InitializingBean {
     }
     fireMessageScanned(releaseMessages);
     int messageScanned = releaseMessages.size();
-    maxIdScanned = releaseMessages.get(messageScanned - 1).getId();
+    long newMaxIdScanned = releaseMessages.get(messageScanned - 1).getId();
+    // check id gaps, possible reasons are release message not committed yet or already rolled back
+    if (newMaxIdScanned - maxIdScanned > messageScanned) {
+      recordMissingReleaseMessageIds(releaseMessages, maxIdScanned);
+    }
+    maxIdScanned = newMaxIdScanned;
     return messageScanned == 500;
+  }
+
+  private void scanMissingMessages() {
+    Set<Long> missingReleaseMessageIds = missingReleaseMessages.keySet();
+    Iterable<ReleaseMessage> releaseMessages = releaseMessageRepository
+        .findAllById(missingReleaseMessageIds);
+    fireMessageScanned(releaseMessages);
+    releaseMessages.forEach(releaseMessage -> {
+      missingReleaseMessageIds.remove(releaseMessage.getId());
+    });
+    growAndCleanMissingMessages();
+  }
+
+  private void growAndCleanMissingMessages() {
+    Iterator<Entry<Long, Integer>> iterator = missingReleaseMessages.entrySet()
+        .iterator();
+    while (iterator.hasNext()) {
+      Entry<Long, Integer> entry = iterator.next();
+      if (entry.getValue() > missingReleaseMessageMaxAge) {
+        iterator.remove();
+      } else {
+        entry.setValue(entry.getValue() + 1);
+      }
+    }
+  }
+
+  private void recordMissingReleaseMessageIds(List<ReleaseMessage> messages, long startId) {
+    for (ReleaseMessage message : messages) {
+      long currentId = message.getId();
+      if (currentId - startId > 1) {
+        for (long i = startId + 1; i < currentId; i++) {
+          missingReleaseMessages.putIfAbsent(i, 1);
+        }
+      }
+      startId = currentId;
+    }
   }
 
   /**
@@ -125,7 +175,7 @@ public class ReleaseMessageScanner implements InitializingBean {
    * Notify listeners with messages loaded
    * @param messages
    */
-  private void fireMessageScanned(List<ReleaseMessage> messages) {
+  private void fireMessageScanned(Iterable<ReleaseMessage> messages) {
     for (ReleaseMessage message : messages) {
       for (ReleaseMessageListener listener : listeners) {
         try {


### PR DESCRIPTION
## What's the purpose of this PR

fix the issue that release messages might be missed in certain scenarios

## Which issue(s) this PR fixes:
Fixes #3806

## Brief changelog

1. record the missing release messages when scanning
2. try to reload and notify the missing release messages for certain amount of times

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [x] Update the [`CHANGES` log](https://github.com/ctripcorp/apollo/blob/master/CHANGES.md).
