### PR TITLE
fix: size of create project button

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -62,6 +62,7 @@ Apollo 1.9.0
 * [docs: English catalog in sidebar](https://github.com/ctripcorp/apollo/pull/3831)
 * [fix the issue that release messages might be missed in certain scenarios](https://github.com/ctripcorp/apollo/pull/3819)
 * [use official docker images for manual kubernetes deployment](https://github.com/ctripcorp/apollo/pull/3840)
+* [fix size of create project button](https://github.com/ctripcorp/apollo/pull/3849)
 ------------------
 All issues and pull requests are [here](https://github.com/ctripcorp/apollo/milestone/6?closed=1)
 

--- a/apollo-portal/src/main/resources/static/styles/common-style.css
+++ b/apollo-portal/src/main/resources/static/styles/common-style.css
@@ -303,7 +303,6 @@ table th {
 
 #treeview .list-group {
     margin: 0;
-
 }
 
 #treeview .list-group .list-group-item {
@@ -368,7 +367,6 @@ table th {
 
 .config-item-container .second-panel-heading .nav-tabs .node_active {
     border-bottom: 3px #1b6d85 solid;
-
 }
 
 .config-item-container .config-items {
@@ -434,7 +432,6 @@ table th {
     cursor: pointer;
     width: 23px;
     height: 23px;
-
 }
 
 .namespace-panel .namespace-view-table table {
@@ -766,7 +763,7 @@ table th {
 
 .create-app-list .create-btn {
     background: #a9d96c;
-    color: #fff
+    color: #fff;
 }
 
 .create-app-list .create-btn:hover {
@@ -775,7 +772,8 @@ table th {
 
 .create-app-list .create-btn img {
     width: 26px;
-    height: 26px
+    height: 26px;
+    margin-top: 4px;
 }
 
 .favorites-app-list .media-left {
@@ -823,7 +821,7 @@ table th {
 }
 
 .project-setting .panel-body {
-    padding-top: 35px
+    padding-top: 35px;
 }
 
 .project-setting .panel-body .context {


### PR DESCRIPTION
## What's the purpose of this PR
Resubmit with Changes update
Fix the Create Project button size and make it has same style with others.

## Which issue(s) this PR fixes:
No

## Brief changelog
Change style for the Create project button.
Before change:
![image](https://user-images.githubusercontent.com/1269496/126998975-b597fc4a-2e73-47ef-95f3-556706ada964.png)

After change:
![image](https://user-images.githubusercontent.com/1269496/126999003-664b3e8e-812b-468f-9ccf-5fc93de28e24.png)

All box size are same.
