### PR TITLE
feat: add history details for not key-value type of namespace

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -63,7 +63,7 @@ Apollo 1.9.0
 * [fix the issue that release messages might be missed in certain scenarios](https://github.com/ctripcorp/apollo/pull/3819)
 * [use official docker images for manual kubernetes deployment](https://github.com/ctripcorp/apollo/pull/3840)
 * [fix size of create project button](https://github.com/ctripcorp/apollo/pull/3849)
-* [feature: add history detail for not key-value type of namespace]()
+* [feature: add history detail for not key-value type of namespace](https://github.com/ctripcorp/apollo/pull/3856)
 ------------------
 All issues and pull requests are [here](https://github.com/ctripcorp/apollo/milestone/6?closed=1)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -63,6 +63,7 @@ Apollo 1.9.0
 * [fix the issue that release messages might be missed in certain scenarios](https://github.com/ctripcorp/apollo/pull/3819)
 * [use official docker images for manual kubernetes deployment](https://github.com/ctripcorp/apollo/pull/3840)
 * [fix size of create project button](https://github.com/ctripcorp/apollo/pull/3849)
+* [feature: add history detail for not key-value type of namespace]()
 ------------------
 All issues and pull requests are [here](https://github.com/ctripcorp/apollo/milestone/6?closed=1)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -62,6 +62,7 @@ Apollo 1.9.0
 * [docs: English catalog in sidebar](https://github.com/ctripcorp/apollo/pull/3831)
 * [fix the issue that release messages might be missed in certain scenarios](https://github.com/ctripcorp/apollo/pull/3819)
 * [use official docker images for manual kubernetes deployment](https://github.com/ctripcorp/apollo/pull/3840)
+* [fix size of create project button](https://github.com/ctripcorp/apollo/pull/3849)
 ------------------
 All issues and pull requests are [here](https://github.com/ctripcorp/apollo/milestone/6?closed=1)
 

--- a/apollo-portal/src/main/resources/static/styles/common-style.css
+++ b/apollo-portal/src/main/resources/static/styles/common-style.css
@@ -303,7 +303,6 @@ table th {
 
 #treeview .list-group {
     margin: 0;
-
 }
 
 #treeview .list-group .list-group-item {
@@ -368,7 +367,6 @@ table th {
 
 .config-item-container .second-panel-heading .nav-tabs .node_active {
     border-bottom: 3px #1b6d85 solid;
-
 }
 
 .config-item-container .config-items {
@@ -434,7 +432,6 @@ table th {
     cursor: pointer;
     width: 23px;
     height: 23px;
-
 }
 
 .namespace-panel .namespace-view-table table {
@@ -766,7 +763,7 @@ table th {
 
 .create-app-list .create-btn {
     background: #a9d96c;
-    color: #fff
+    color: #fff;
 }
 
 .create-app-list .create-btn:hover {
@@ -775,7 +772,8 @@ table th {
 
 .create-app-list .create-btn img {
     width: 26px;
-    height: 26px
+    height: 26px;
+    margin-top: 4px;
 }
 
 .favorites-app-list .media-left {
@@ -823,7 +821,7 @@ table th {
 }
 
 .project-setting .panel-body {
-    padding-top: 35px
+    padding-top: 35px;
 }
 
 .project-setting .panel-body .context {

--- a/apollo-portal/src/main/resources/static/views/component/namespace-panel-branch-tab.html
+++ b/apollo-portal/src/main/resources/static/views/component/namespace-panel-branch-tab.html
@@ -538,20 +538,80 @@
                         </table>
 
                         <!--not properties format-->
-                        <div ng-if="!namespace.isPropertiesFormat">
-                            <div ng-repeat="item in commits.changeSets.createItems">
-                                <textarea class="form-control no-radius" rows="20" ng-disabled="true"
-                                    ng-bind="item.value">
-                                </textarea>
-                            </div>
+                        <table class="table table-bordered table-striped text-center table-hover"
+                               style="margin-top: 5px;" ng-if="!namespace.isPropertiesFormat">
+                            <thead>
+                            <tr>
+                                <th>
+                                    {{'Component.Namespace.Branch.History.ItemType' | translate }}
+                                </th>
+                                <th>
+                                    {{'Component.Namespace.Branch.History.ItemOldValue' | translate }}
+                                </th>
+                                <th>
+                                    {{'Component.Namespace.Branch.History.ItemNewValue' | translate }}
+                                </th>
+                                <th>
+                                    {{'Component.Namespace.Branch.History.ItemComment' | translate }}
+                                </th>
+                            </tr>
+                            </thead>
+                            <tbody>
 
-                            <div ng-repeat="item in commits.changeSets.updateItems">
-                                <textarea class="form-control no-radius" rows="20" ng-disabled="true"
-                                    ng-bind="item.newItem.value">
-                                </textarea>
-                            </div>
-                        </div>
-
+                            <!--兼容老数据,不显示item类型为空行和注释的item-->
+                            <tr ng-repeat="item in commits.changeSets.createItems" ng-show="item.key">
+                                <td width="6%">
+                                    {{'Component.Namespace.Branch.History.NewAdded' | translate }}
+                                </td>
+                                <td width="28%">
+                                </td>
+                                <td width="28%" class="cursor-pointer" title="{{item.value}}"
+                                    ng-click="showText(item.value)">
+                                    <span ng-bind="item.value | limitTo: 250"></span>
+                                    <span ng-bind="item.value.length > 250 ? '...': ''"></span>
+                                </td>
+                                <td width="18%" title="{{item.comment}}">
+                                    <span ng-bind="item.comment | limitTo: 250"></span>
+                                    <span ng-bind="item.comment.length > 250 ?'...' : ''"></span>
+                                </td>
+                            </tr>
+                            <tr ng-repeat="item in commits.changeSets.updateItems">
+                                <td width="6%">
+                                    {{'Component.Namespace.Branch.History.Modified' | translate }}
+                                </td>
+                                <td width="28%" class="cursor-pointer" title="{{item.oldItem.value}}"
+                                    ng-click="showText(item.oldItem.value)">
+                                    <span ng-bind="item.oldItem.value | limitTo: 250"></span>
+                                    <span ng-bind="item.oldItem.value.length > 250 ? '...': ''"></span>
+                                </td>
+                                <td width="28%" class="cursor-pointer" title="{{item.newItem.value}}"
+                                    ng-click="showText(item.newItem.value)">
+                                    <span ng-bind="item.newItem.value | limitTo: 250"></span>
+                                    <span ng-bind="item.newItem.value.length > 250 ? '...': ''"></span>
+                                </td>
+                                <td width="18%" title="{{item.newItem.comment}}">
+                                    <span ng-bind="item.newItem.comment | limitTo: 250"></span>
+                                    <span ng-bind="item.newItem.comment.length > 250 ?'...' : ''"></span>
+                                </td>
+                            </tr>
+                            <tr ng-repeat="item in commits.changeSets.deleteItems"
+                                ng-show="item.key || item.comment">
+                                <td width="6%">
+                                    {{'Component.Namespace.Branch.History.Deleted' | translate }}
+                                </td>
+                                <td width="28%" title="{{item.value}}">
+                                    <span ng-bind="item.value | limitTo: 250"></span>
+                                    <span ng-bind="item.value.length > 250 ? '...': ''"></span>
+                                </td>
+                                <td width="28%">
+                                </td>
+                                <td width="18%" title="{{item.comment}}">
+                                    <span ng-bind="item.comment | limitTo: 250"></span>
+                                    <span ng-bind="item.comment.length > 250 ?'...' : ''"></span>
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
 
                     </div>
                     <hr>

--- a/apollo-portal/src/main/resources/static/views/component/namespace-panel-master-tab.html
+++ b/apollo-portal/src/main/resources/static/views/component/namespace-panel-master-tab.html
@@ -835,20 +835,80 @@
                         </table>
 
                         <!--not properties format-->
-                        <div ng-if="!namespace.isPropertiesFormat">
-                            <div ng-repeat="item in commits.changeSets.createItems">
-                                <textarea class="form-control no-radius" rows="20" ng-disabled="true"
-                                    ng-bind="item.value">
-                                </textarea>
-                            </div>
+                        <table class="table table-bordered table-striped text-center table-hover"
+                            style="margin-top: 5px;" ng-if="!namespace.isPropertiesFormat">
+                            <thead>
+                                <tr>
+                                    <th>
+                                        {{'Component.Namespace.Master.Items.Body.HistoryView.ItemType' | translate }}
+                                    </th>
+                                    <th>
+                                        {{'Component.Namespace.Master.Items.Body.HistoryView.ItemOldValue' | translate }}
+                                    </th>
+                                    <th>
+                                        {{'Component.Namespace.Master.Items.Body.HistoryView.ItemNewValue' | translate }}
+                                    </th>
+                                    <th>
+                                        {{'Component.Namespace.Master.Items.Body.HistoryView.ItemComment' | translate }}
+                                    </th>
+                                </tr>
+                            </thead>
+                            <tbody>
 
-                            <div ng-repeat="item in commits.changeSets.updateItems">
-                                <textarea class="form-control no-radius" rows="20" ng-disabled="true"
-                                    ng-bind="item.newItem.value">
-                                </textarea>
-                            </div>
-                        </div>
-
+                                <!--兼容老数据,不显示item类型为空行和注释的item-->
+                                <tr ng-repeat="item in commits.changeSets.createItems" ng-show="item.key">
+                                    <td width="6%">
+                                        {{'Component.Namespace.Master.Items.Body.HistoryView.NewAdded' | translate }}
+                                    </td>
+                                    <td width="28%">
+                                    </td>
+                                    <td width="28%" class="cursor-pointer" title="{{item.value}}"
+                                        ng-click="showText(item.value)">
+                                        <span ng-bind="item.value | limitTo: 250"></span>
+                                        <span ng-bind="item.value.length > 250 ? '...': ''"></span>
+                                    </td>
+                                    <td width="18%" title="{{item.comment}}">
+                                        <span ng-bind="item.comment | limitTo: 250"></span>
+                                        <span ng-bind="item.comment.length > 250 ?'...' : ''"></span>
+                                    </td>
+                                </tr>
+                                <tr ng-repeat="item in commits.changeSets.updateItems">
+                                    <td width="6%">
+                                        {{'Component.Namespace.Master.Items.Body.HistoryView.Updated' | translate }}
+                                    </td>
+                                    <td width="28%" class="cursor-pointer" title="{{item.oldItem.value}}"
+                                        ng-click="showText(item.oldItem.value)">
+                                        <span ng-bind="item.oldItem.value | limitTo: 250"></span>
+                                        <span ng-bind="item.oldItem.value.length > 250 ? '...': ''"></span>
+                                    </td>
+                                    <td width="28%" class="cursor-pointer" title="{{item.newItem.value}}"
+                                        ng-click="showText(item.newItem.value)">
+                                        <span ng-bind="item.newItem.value | limitTo: 250"></span>
+                                        <span ng-bind="item.newItem.value.length > 250 ? '...': ''"></span>
+                                    </td>
+                                    <td width="18%" title="{{item.newItem.comment}}">
+                                        <span ng-bind="item.newItem.comment | limitTo: 250"></span>
+                                        <span ng-bind="item.newItem.comment.length > 250 ?'...' : ''"></span>
+                                    </td>
+                                </tr>
+                                <tr ng-repeat="item in commits.changeSets.deleteItems"
+                                    ng-show="item.key || item.comment">
+                                    <td width="6%">
+                                        {{'Component.Namespace.Master.Items.Body.HistoryView.Deleted' | translate }}
+                                    </td>
+                                    <td width="28%" title="{{item.value}}">
+                                        <span ng-bind="item.value | limitTo: 250"></span>
+                                        <span ng-bind="item.value.length > 250 ? '...': ''"></span>
+                                    </td>
+                                    <td width="28%">
+                                    </td>
+                                    <td width="18%" title="{{item.comment}}">
+                                        <span ng-bind="item.comment | limitTo: 250"></span>
+                                        <span ng-bind="item.comment.length > 250 ?'...' : ''"></span>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
 
                     </div>
                     <hr>


### PR DESCRIPTION
## What's the purpose of this PR

Add history details for not key-value type of namespace

## Which issue(s) this PR fixes:
Fixes #3715

## Brief changelog

After change:
![image](https://user-images.githubusercontent.com/1269496/127172053-dbed56ba-cd21-4cbf-b0c4-170ad134d745.png)

With tooltip:
![image](https://user-images.githubusercontent.com/1269496/127172435-5a493e07-075f-4aad-a10a-29efe41f792c.png)

Show details by click:
![image](https://user-images.githubusercontent.com/1269496/127172578-70a12f55-fd05-4da9-9411-033efff2ef34.png)


Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit tests to verify the code.
- [ ] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [x] Update the [`CHANGES` log](https://github.com/ctripcorp/apollo/blob/master/CHANGES.md).
