### PR TITLE
Lazy load ConfigUtil

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -66,6 +66,7 @@ Apollo 1.9.0
 * [translation of "portal-how-to-enable-webhook-notification.md"](https://github.com/ctripcorp/apollo/pull/3847)
 * [feature: add history detail for not key-value type of namespace](https://github.com/ctripcorp/apollo/pull/3856)
 * [fix show-text-modal number display](https://github.com/ctripcorp/apollo/pull/3851)
+* [Lazy load ConfigUtil](https://github.com/ctripcorp/apollo/pull/3864)
 
 ------------------
 All issues and pull requests are [here](https://github.com/ctripcorp/apollo/milestone/6?closed=1)

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/boot/ApolloApplicationContextInitializer.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/boot/ApolloApplicationContextInitializer.java
@@ -94,8 +94,6 @@ public class ApolloApplicationContextInitializer implements
   private final ConfigPropertySourceFactory configPropertySourceFactory = SpringInjector
       .getInstance(ConfigPropertySourceFactory.class);
 
-  private final ConfigUtil configUtil = ApolloInjector.getInstance(ConfigUtil.class);
-
   private int order = DEFAULT_ORDER;
 
   @Override
@@ -130,6 +128,7 @@ public class ApolloApplicationContextInitializer implements
     List<String> namespaceList = NAMESPACE_SPLITTER.splitToList(namespaces);
 
     CompositePropertySource composite;
+    final ConfigUtil configUtil = ApolloInjector.getInstance(ConfigUtil.class);
     if (configUtil.isPropertyNamesCacheEnabled()) {
       composite = new CachedCompositePropertySource(PropertySourcesConstants.APOLLO_BOOTSTRAP_PROPERTY_SOURCE_NAME);
     } else {

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/config/PropertySourcesProcessor.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/config/PropertySourcesProcessor.java
@@ -62,7 +62,7 @@ public class PropertySourcesProcessor implements BeanFactoryPostProcessor, Envir
 
   private final ConfigPropertySourceFactory configPropertySourceFactory = SpringInjector
       .getInstance(ConfigPropertySourceFactory.class);
-  private final ConfigUtil configUtil = ApolloInjector.getInstance(ConfigUtil.class);
+  private ConfigUtil configUtil;
   private ConfigurableEnvironment environment;
 
   public static boolean addNamespaces(Collection<String> namespaces, int order) {
@@ -71,6 +71,7 @@ public class PropertySourcesProcessor implements BeanFactoryPostProcessor, Envir
 
   @Override
   public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {
+    this.configUtil = ApolloInjector.getInstance(ConfigUtil.class);
     initializePropertySources();
     initializeAutoUpdatePropertiesFeature(beanFactory);
   }


### PR DESCRIPTION
prevent ConfigUtil init when ApolloApplicationContextInitializer initialized,
That is too early.

This issue caused by commit 6d50ca881a6afb2766725bdb3c09c14d450cc12f

## What's the purpose of this PR

XXXXX

## Which issue(s) this PR fixes:
Fixes #

## Brief changelog

XXXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

- [ ] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit tests to verify the code.
- [ ] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [ ] Update the [`CHANGES` log](https://github.com/ctripcorp/apollo/blob/master/CHANGES.md).
