### PR TITLE
add spring configuration metadata for property names cache

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -70,6 +70,7 @@ Apollo 1.9.0
 * [make jdbc session enable default](https://github.com/ctripcorp/apollo/pull/3869)
 * [support json/yaml/xml format for public namespace](https://github.com/ctripcorp/apollo/pull/3836)
 * [Translate application into 应用 not 项目](https://github.com/ctripcorp/apollo/pull/3877)
+* [add spring configuration metadata for property names cache](https://github.com/ctripcorp/apollo/pull/3879)
 
 ------------------
 All issues and pull requests are [here](https://github.com/ctripcorp/apollo/milestone/6?closed=1)

--- a/apollo-client/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/apollo-client/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -63,6 +63,13 @@
       "description": "apollo meta server address."
     },
     {
+      "name": "apollo.property.names.cache.enable",
+      "type": "java.lang.Boolean",
+      "sourceType": "com.ctrip.framework.apollo.util.ConfigUtil",
+      "description": "enable property names cache.",
+      "defaultValue": false
+    },
+    {
       "name": "apollo.property.order.enable",
       "type": "java.lang.Boolean",
       "sourceType": "com.ctrip.framework.apollo.util.factory.PropertiesFactory",


### PR DESCRIPTION
## What's the purpose of this PR

add spring configuration metadata for `apollo.property.names.cache.enable`

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [x] Update the [`CHANGES` log](https://github.com/ctripcorp/apollo/blob/master/CHANGES.md).
