### PR TITLE
use jdk 8 to publish apollo-client-config-data

### DIFF
--- a/.github/workflows/release-1.8.yml
+++ b/.github/workflows/release-1.8.yml
@@ -16,7 +16,7 @@
 # This workflow will build a Java project with Maven
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
-name: publish sdks
+name: publish apollo-client-config-data
 
 on:
   workflow_dispatch:
@@ -34,14 +34,14 @@ jobs:
     - name: Set up Maven Central Repository
       uses: actions/setup-java@v1
       with:
-        java-version: 7
+        java-version: 8
         server-id: ${{ github.event.inputs.repository }}
         server-username: MAVEN_USERNAME
         server-password: MAVEN_CENTRAL_TOKEN
         gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
         gpg-passphrase: MAVEN_GPG_PASSPHRASE
     - name: Publish to Apache Maven Central
-      run: mvn clean deploy -pl apollo-client,apollo-mockserver,apollo-openapi -am -DskipTests=true "-Dreleases.repo=https://oss.sonatype.org/service/local/staging/deploy/maven2" "-Dsnapshots.repo=https://oss.sonatype.org/content/repositories/snapshots"
+      run: mvn clean deploy -pl apollo-client-config-data -DskipTests=true "-Dreleases.repo=https://oss.sonatype.org/service/local/staging/deploy/maven2" "-Dsnapshots.repo=https://oss.sonatype.org/content/repositories/snapshots"
       env:
         MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
         MAVEN_CENTRAL_TOKEN: ${{ secrets.MAVEN_CENTRAL_TOKEN }}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -71,6 +71,7 @@ Apollo 1.9.0
 * [support json/yaml/xml format for public namespace](https://github.com/ctripcorp/apollo/pull/3836)
 * [Translate application into 应用 not 项目](https://github.com/ctripcorp/apollo/pull/3877)
 * [add spring configuration metadata for property names cache](https://github.com/ctripcorp/apollo/pull/3879)
+* [use jdk 8 to publish apollo-client-config-data](https://github.com/ctripcorp/apollo/pull/3880)
 
 ------------------
 All issues and pull requests are [here](https://github.com/ctripcorp/apollo/milestone/6?closed=1)


### PR DESCRIPTION
## What's the purpose of this PR

apollo-client-config-data depends on spring boot 2.x which requires java 8, so we have to use jave 8 to deploy it.

## Brief changelog

Create another github action with java 8 to deploy apollo-client-config-data

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [x] Update the [`CHANGES` log](https://github.com/ctripcorp/apollo/blob/master/CHANGES.md).
