### PR TITLE
shell变量读取应该加$符号

### DIFF
--- a/apollo-adminservice/src/main/scripts/startup.sh
+++ b/apollo-adminservice/src/main/scripts/startup.sh
@@ -120,7 +120,7 @@ do
     fi
 done
 
-if [[ ! -f PATH_TO_JAR && -d current ]]; then
+if [[ ! -f $PATH_TO_JAR && -d current ]]; then
     cd current
     for i in `ls $SERVICE_NAME-*.jar 2>/dev/null`
     do

--- a/apollo-configservice/src/main/scripts/startup.sh
+++ b/apollo-configservice/src/main/scripts/startup.sh
@@ -120,7 +120,7 @@ do
     fi
 done
 
-if [[ ! -f PATH_TO_JAR && -d current ]]; then
+if [[ ! -f $PATH_TO_JAR && -d current ]]; then
     cd current
     for i in `ls $SERVICE_NAME-*.jar 2>/dev/null`
     do

--- a/apollo-portal/src/main/scripts/startup.sh
+++ b/apollo-portal/src/main/scripts/startup.sh
@@ -120,7 +120,7 @@ do
     fi
 done
 
-if [[ ! -f PATH_TO_JAR && -d current ]]; then
+if [[ ! -f $PATH_TO_JAR && -d current ]]; then
     cd current
     for i in `ls $SERVICE_NAME-*.jar 2>/dev/null`
     do


### PR DESCRIPTION
admin/config/portal 三个模块的启动脚本中查找 SERVICE_NAME-*.jar  的逻辑中，判断文件是否存在时没有正确读取 shell 变量，需要添加 $ 符号到 shell 变量左边。
