### PR TITLE
fix: correct spelling errors across codebase

### DIFF
--- a/apollo-portal/src/main/resources/static/scripts/directive/namespace-panel-directive.js
+++ b/apollo-portal/src/main/resources/static/scripts/directive/namespace-panel-directive.js
@@ -751,12 +751,12 @@ function directive($window, $translate, toastr, AppUtil, EventManager, Permissio
                 }
                 namespace.isTextEditing = !namespace.isTextEditing;
                 if (namespace.isTextEditing) {//切换为编辑状态
-                    namespace.commited = false;
+                    namespace.committed = false;
                     namespace.backupText = namespace.text;
                     namespace.editText = parseModel2Text(namespace);
 
                 } else {
-                    if (!namespace.commited) {//取消编辑,则复原
+                    if (!namespace.committed) {//取消编辑,则复原
                         namespace.text = namespace.backupText;
                     }
                 }
@@ -825,7 +825,7 @@ function directive($window, $translate, toastr, AppUtil, EventManager, Permissio
                             return false;
                         }
                     );
-                namespace.commited = true;
+                namespace.committed = true;
             }
 
             function syntaxCheck(namespace) {

--- a/changes/changes-1.9.0.md
+++ b/changes/changes-1.9.0.md
@@ -41,7 +41,7 @@ Apollo 1.9.0
 * [Bump xstream from 1.4.16 to 1.4.17](https://github.com/ctripcorp/apollo/pull/3692)
 * [Improve the nacos registry configuration document](https://github.com/ctripcorp/apollo/pull/3695)
 * [Remove redundant invoke of trySyncFromUpstream](https://github.com/ctripcorp/apollo/pull/3699)
-* [add apollo team introduction and community releated contents](https://github.com/ctripcorp/apollo/pull/3713)
+* [add apollo team introduction and community related contents](https://github.com/ctripcorp/apollo/pull/3713)
 * [fix oidc sql](https://github.com/ctripcorp/apollo/pull/3720)
 * [feat(apollo-client): add method interestedChangedKeys to ConfigChangeEvent](https://github.com/ctripcorp/apollo/pull/3666)
 * [add More... link for known users](https://github.com/ctripcorp/apollo/pull/3757)

--- a/docs/en/deployment/third-party-tool-rainbond.md
+++ b/docs/en/deployment/third-party-tool-rainbond.md
@@ -56,7 +56,7 @@ Parameters：
 | team name | User-defined workspace isolated by namespace                 |
 | cluster name |  Select which K8s cluster Apollo will be deployed to           |
 | application | Select the application to which Apollo will be deployed, which contains several associated components |
-| version | Select the version of Apollo, the useable version is 1.9.2       |
+| version | Select the version of Apollo, the usable version is 1.9.2       |
 
 After a few minutes, the Apollo is installed and up and running.
 

--- a/docs/en/extension/portal-how-to-enable-webhook-notification.md
+++ b/docs/en/extension/portal-how-to-enable-webhook-notification.md
@@ -40,7 +40,7 @@ parameter name    | parameter annotation
     "releaseTitle": "",  // release title 
     "releaseComment": "",  // release Comment
     "releaseTime": "",  // release time  eg：2020-01-01T00:00:00.000+0800
-    "configuration": [ { // all configurations to be released; also applys to gray release
+    "configuration": [ { // all configurations to be released; also applies to gray release
         "firstEntity": "",  // key of configuration
         "secondEntity": ""  // value of configuration
     } ],

--- a/docs/scripts/multiple-language-redirect.js
+++ b/docs/scripts/multiple-language-redirect.js
@@ -136,7 +136,7 @@ function changeLinkInTranslationsListItem(currrentPath, translationsListItem) {
 function generateMultipleLanguagesNavbarPluginByListItemName(name) {
     return function (hook, vm) {
         const bindEventForChangeHrefInNavbar = () => {
-            // when user's mouse down, chanage href in navbar
+            // when user's mouse down, change href in navbar
             document.addEventListener("mousedown", _mouseEvent => {
                 const currrentPath = vm.route.path;
                 // find navbar list item by hard code name


### PR DESCRIPTION
## What's the purpose of this PR

- Fix 'chanage' to 'change' in documentation
- Fix 'releated' to 'related' in changelog
- Fix 'useable' to 'usable' in deployment guide
- Fix 'applys' to 'applies' in webhook documentation
- Fix 'commited' to 'committed' in JavaScript code

我才发现 `wapper` 也许不是一个拼写错误

## Which issue(s) this PR fixes:

Fixes #5402 

## Brief changelog

Resolves issue #5402 

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [ ] Update the [`CHANGES` log](https://github.com/apolloconfig/apollo/blob/master/CHANGES.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected spelling errors in user interface elements to improve clarity.

- **Documentation**
  - Fixed typographical errors in release notes and various documentation files for improved readability and professionalism.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->