### PR TITLE
feat(openapi): app domain service impl, controller migration and tests

### DIFF
--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/server/service/AppOpenApiService.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/server/service/AppOpenApiService.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2025 Apollo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ctrip.framework.apollo.openapi.server.service;
+
+import com.ctrip.framework.apollo.openapi.model.MultiResponseEntity;
+import com.ctrip.framework.apollo.openapi.model.OpenAppDTO;
+import com.ctrip.framework.apollo.openapi.model.OpenCreateAppDTO;
+import com.ctrip.framework.apollo.openapi.model.OpenEnvClusterDTO;
+import org.springframework.lang.NonNull;
+
+import java.util.List;
+import java.util.Set;
+
+public interface AppOpenApiService {
+
+  void createApp(@NonNull OpenCreateAppDTO req);
+
+  List<OpenEnvClusterDTO> getEnvClusterInfo(String appId);
+
+  List<OpenAppDTO> getAllApps();
+
+  List<OpenAppDTO> getAppsInfo(List<String> appIds);
+
+  List<OpenAppDTO> getAuthorizedApps();
+
+  void updateApp(OpenAppDTO openAppDTO);
+
+  List<OpenAppDTO> getAppsBySelf(Set<String> appIds, Integer page, Integer size);
+
+  void createAppInEnv(String env, OpenAppDTO app, String operator);
+
+  OpenAppDTO deleteApp(String appId);
+
+  MultiResponseEntity findMissEnvs(String appId);
+
+  MultiResponseEntity getAppNavTree(String appId);
+}

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/server/service/ServerAppOpenApiService.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/server/service/ServerAppOpenApiService.java
@@ -18,21 +18,38 @@ package com.ctrip.framework.apollo.openapi.server.service;
 
 import com.ctrip.framework.apollo.common.dto.ClusterDTO;
 import com.ctrip.framework.apollo.common.entity.App;
+import com.ctrip.framework.apollo.common.exception.BadRequestException;
 import com.ctrip.framework.apollo.common.utils.BeanUtils;
-import com.ctrip.framework.apollo.openapi.api.AppOpenApiService;
-import com.ctrip.framework.apollo.openapi.dto.OpenAppDTO;
-import com.ctrip.framework.apollo.openapi.dto.OpenCreateAppDTO;
-import com.ctrip.framework.apollo.openapi.dto.OpenEnvClusterDTO;
-import com.ctrip.framework.apollo.openapi.util.OpenApiBeanUtils;
+import com.ctrip.framework.apollo.core.ConfigConsts;
+import com.ctrip.framework.apollo.openapi.model.OpenAppDTO;
+import com.ctrip.framework.apollo.openapi.model.OpenCreateAppDTO;
+import com.ctrip.framework.apollo.openapi.model.OpenEnvClusterDTO;
+import com.ctrip.framework.apollo.openapi.model.MultiResponseEntity;
+import com.ctrip.framework.apollo.openapi.model.OpenEnvClusterInfo;
+import com.ctrip.framework.apollo.openapi.model.RichResponseEntity;
+import com.ctrip.framework.apollo.openapi.util.OpenApiModelConverters;
 import com.ctrip.framework.apollo.portal.component.PortalSettings;
 import com.ctrip.framework.apollo.portal.entity.model.AppModel;
 import com.ctrip.framework.apollo.portal.environment.Env;
+import com.ctrip.framework.apollo.portal.listener.AppDeletionEvent;
+import com.ctrip.framework.apollo.portal.listener.AppInfoChangedEvent;
 import com.ctrip.framework.apollo.portal.service.AppService;
 import com.ctrip.framework.apollo.portal.service.ClusterService;
+import com.ctrip.framework.apollo.portal.service.RoleInitializationService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
+
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
-import org.springframework.stereotype.Service;
+import java.util.Set;
 
 /**
  * @author wxq
@@ -43,14 +60,21 @@ public class ServerAppOpenApiService implements AppOpenApiService {
   private final PortalSettings portalSettings;
   private final ClusterService clusterService;
   private final AppService appService;
+  private final ApplicationEventPublisher publisher;
+  private final RoleInitializationService roleInitializationService;
+  private static final Logger logger = LoggerFactory.getLogger(ServerAppOpenApiService.class);
 
   public ServerAppOpenApiService(
       PortalSettings portalSettings,
       ClusterService clusterService,
-      AppService appService) {
+      AppService appService,
+      ApplicationEventPublisher publisher,
+      RoleInitializationService roleInitializationService) {
     this.portalSettings = portalSettings;
     this.clusterService = clusterService;
     this.appService = appService;
+    this.publisher = publisher;
+    this.roleInitializationService = roleInitializationService;
   }
 
   private App convert(OpenAppDTO dto) {
@@ -70,7 +94,11 @@ public class ServerAppOpenApiService implements AppOpenApiService {
   @Override
   public void createApp(OpenCreateAppDTO req) {
     App app = convert(req.getApp());
-    appService.createAppAndAddRolePermission(app, req.getAdmins());
+    List<String> admins = req.getAdmins();
+    if (admins == null) {
+      admins = Collections.emptyList();
+    }
+    appService.createAppAndAddRolePermission(app, new HashSet<>(admins));
   }
 
   @Override
@@ -83,7 +111,8 @@ public class ServerAppOpenApiService implements AppOpenApiService {
 
       envCluster.setEnv(env.getName());
       List<ClusterDTO> clusterDTOs = clusterService.findClusters(env, appId);
-      envCluster.setClusters(BeanUtils.toPropertySet("name", clusterDTOs));
+      Set<String> clusterNames = clusterDTOs == null ? Collections.emptySet() : BeanUtils.toPropertySet("name", clusterDTOs);
+      envCluster.setClusters(new ArrayList<>(clusterNames));
 
       envClusters.add(envCluster);
     }
@@ -94,17 +123,138 @@ public class ServerAppOpenApiService implements AppOpenApiService {
   @Override
   public List<OpenAppDTO> getAllApps() {
     final List<App> apps = this.appService.findAll();
-    return OpenApiBeanUtils.transformFromApps(apps);
+    return OpenApiModelConverters.fromApps(apps);
   }
 
   @Override
   public List<OpenAppDTO> getAppsInfo(List<String> appIds) {
+    if (appIds == null || appIds.isEmpty()) {
+      return Collections.emptyList();
+    }
     final List<App> apps = this.appService.findByAppIds(new HashSet<>(appIds));
-    return OpenApiBeanUtils.transformFromApps(apps);
+    return OpenApiModelConverters.fromApps(apps);
   }
 
   @Override
   public List<OpenAppDTO> getAuthorizedApps() {
     throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Updating Application Information - Using OpenAPI DTOs
+   * @param openAppDTO OpenAPI application DTO
+   */
+  @Override
+  public void updateApp(OpenAppDTO openAppDTO) {
+    App app = convert(openAppDTO);
+    App updatedApp = appService.updateAppInLocal(app);
+    publisher.publishEvent(new AppInfoChangedEvent(updatedApp));
+  }
+
+  /**
+   * Get the current user's app list (paginated)
+   * @param page Pagination parameter
+   * @return App list
+   */
+  @Override
+  public List<OpenAppDTO> getAppsBySelf(Set<String> appIds, Integer page, Integer size) {
+    int pageIndex = page == null ? 0 : page;
+    int pageSize = (size == null || size <= 0) ? 20 : size;
+    Pageable pageable = Pageable.ofSize(pageSize).withPage(pageIndex);
+    Set<String> targetAppIds = appIds == null ? Collections.emptySet() : appIds;
+    if (targetAppIds.isEmpty()) {
+      return Collections.emptyList();
+    }
+    List<App> apps = appService.findByAppIds(targetAppIds, pageable);
+    return OpenApiModelConverters.fromApps(apps);
+  }
+
+  /**
+   * Create an application in a specified environment
+   * @param env Environment
+   * @param app Application information
+   * @param operator Operator
+   */
+  @Override
+  public void createAppInEnv(String env, OpenAppDTO app, String operator) {
+    if (env == null) {
+      throw BadRequestException.invalidEnvFormat("null");
+    }
+    Env envEnum;
+    try {
+      envEnum = Env.valueOf(env);
+    } catch (IllegalArgumentException e) {
+      throw BadRequestException.invalidEnvFormat(env);
+    }
+    App appEntity = convert(app);
+    appService.createAppInRemote(envEnum, appEntity);
+
+    roleInitializationService.initNamespaceSpecificEnvRoles(appEntity.getAppId(),
+            ConfigConsts.NAMESPACE_APPLICATION, env, operator);
+  }
+
+  /**
+   * Delete an application
+   * @param appId application ID
+   * @return the deleted application
+   */
+  @Override
+  public OpenAppDTO deleteApp(String appId) {
+    App app = appService.deleteAppInLocal(appId);
+    publisher.publishEvent(new AppDeletionEvent(app));
+    return OpenApiModelConverters.fromApp(app);
+  }
+
+  /**
+   * Find missing environments
+   * @param appId application ID
+   * @return list of missing environments
+   */
+  public MultiResponseEntity findMissEnvs(String appId) {
+    List<RichResponseEntity> entities = new ArrayList<>();
+    MultiResponseEntity response = new MultiResponseEntity(HttpStatus.OK.value(), entities);
+    for (Env env : portalSettings.getActiveEnvs()) {
+      try {
+        appService.load(env, appId);
+      } catch (Exception e) {
+        RichResponseEntity entity;
+        if (e instanceof HttpClientErrorException &&
+                ((HttpClientErrorException) e).getStatusCode() == HttpStatus.NOT_FOUND) {
+          entity = new RichResponseEntity(HttpStatus.OK.value(), HttpStatus.OK.getReasonPhrase());
+          entity.setBody(env.toString());
+        }  else {
+          entity = new RichResponseEntity(HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                  "load env:" + env.getName() + " cluster error." + e.getMessage());
+        }
+        response.addEntitiesItem(entity);
+      }
+    }
+    return response;
+  }
+
+  /**
+   * Find AppNavTree
+   * @param appId
+   * @return list of EnvClusterInfos
+   */
+  @Override
+  public MultiResponseEntity getAppNavTree(String appId) {
+    List<RichResponseEntity> entities = new ArrayList<>();
+    MultiResponseEntity response = new MultiResponseEntity(HttpStatus.OK.value(),entities);
+    List<Env> envs = portalSettings.getActiveEnvs();
+    for (Env env : envs) {
+      try {
+        OpenEnvClusterInfo openEnvClusterInfo = OpenApiModelConverters.fromEnvClusterInfo(appService.createEnvNavNode(env, appId));
+        RichResponseEntity entity = new RichResponseEntity(HttpStatus.OK.value(), HttpStatus.OK.getReasonPhrase());
+        entity.setBody(openEnvClusterInfo);
+        response.addEntitiesItem(entity);
+      } catch (Exception e) {
+        logger.warn("Failed to load env {} navigation for app {}", env, appId, e);
+        RichResponseEntity entity = new RichResponseEntity(HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                "load env:" + env.getName() + " cluster error." + e.getMessage());
+        response.addEntitiesItem(entity);
+      }
+    }
+    return response;
   }
 }

--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/v1/controller/AppController.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/v1/controller/AppController.java
@@ -16,39 +16,49 @@
  */
 package com.ctrip.framework.apollo.openapi.v1.controller;
 
+import com.ctrip.framework.apollo.audit.annotation.ApolloAuditLog;
+import com.ctrip.framework.apollo.audit.annotation.OpType;
 import com.ctrip.framework.apollo.common.exception.BadRequestException;
-import com.ctrip.framework.apollo.openapi.api.AppOpenApiService;
-import com.ctrip.framework.apollo.openapi.dto.OpenCreateAppDTO;
+import com.ctrip.framework.apollo.openapi.api.AppManagementApi;
+import com.ctrip.framework.apollo.openapi.model.MultiResponseEntity;
+import com.ctrip.framework.apollo.openapi.model.OpenAppDTO;
+import com.ctrip.framework.apollo.openapi.model.OpenCreateAppDTO;
+import com.ctrip.framework.apollo.openapi.model.OpenEnvClusterDTO;
+import com.ctrip.framework.apollo.openapi.server.service.AppOpenApiService;
 import com.ctrip.framework.apollo.openapi.service.ConsumerService;
 import com.ctrip.framework.apollo.openapi.util.ConsumerAuthUtil;
-import com.ctrip.framework.apollo.openapi.dto.OpenAppDTO;
-import com.ctrip.framework.apollo.openapi.dto.OpenEnvClusterDTO;
 import com.ctrip.framework.apollo.portal.entity.model.AppModel;
-import java.util.Arrays;
-import java.util.Set;
-import javax.transaction.Transactional;
+import com.ctrip.framework.apollo.portal.spi.UserService;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.util.StringUtils;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.RestController;
 
+import javax.transaction.Transactional;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 
 @RestController("openapiAppController")
-@RequestMapping("/openapi/v1")
-public class AppController {
+public class AppController implements AppManagementApi {
 
   private final ConsumerAuthUtil consumerAuthUtil;
   private final ConsumerService consumerService;
   private final AppOpenApiService appOpenApiService;
+  private final UserService userService;
 
   public AppController(
-      final ConsumerAuthUtil consumerAuthUtil,
-      final ConsumerService consumerService,
-      AppOpenApiService appOpenApiService) {
+          final ConsumerAuthUtil consumerAuthUtil,
+          final ConsumerService consumerService,
+          final AppOpenApiService appOpenApiService,
+          final UserService userService) {
     this.consumerAuthUtil = consumerAuthUtil;
     this.consumerService = consumerService;
     this.appOpenApiService = appOpenApiService;
+    this.userService = userService;
   }
 
   /**
@@ -56,10 +66,8 @@ public class AppController {
    */
   @Transactional
   @PreAuthorize(value = "@consumerPermissionValidator.hasCreateApplicationPermission()")
-  @PostMapping(value = "/apps")
-  public void createApp(
-      @RequestBody OpenCreateAppDTO req
-  ) {
+  @Override
+  public ResponseEntity<Object> createApp(OpenCreateAppDTO req) {
     if (null == req.getApp()) {
       throw new BadRequestException("App is null");
     }
@@ -69,36 +77,123 @@ public class AppController {
     }
     // create app
     this.appOpenApiService.createApp(req);
-    if (req.isAssignAppRoleToSelf()) {
+    if (Boolean.TRUE.equals(req.getAssignAppRoleToSelf())) {
       long consumerId = this.consumerAuthUtil.retrieveConsumerIdFromCtx();
       consumerService.assignAppRoleToConsumer(consumerId, app.getAppId());
     }
+    return ResponseEntity.ok().build();
   }
 
-  @GetMapping(value = "/apps/{appId}/envclusters")
-  public List<OpenEnvClusterDTO> getEnvClusterInfo(@PathVariable String appId){
-    return this.appOpenApiService.getEnvClusterInfo(appId);
+  @Override
+  public ResponseEntity<List<OpenEnvClusterDTO>> getEnvClusterInfo(String appId) {
+    return ResponseEntity.ok(appOpenApiService.getEnvClusterInfo(appId));
   }
 
-  @GetMapping("/apps")
-  public List<OpenAppDTO> findApps(@RequestParam(value = "appIds", required = false) String appIds) {
+  @Override
+  public ResponseEntity<List<OpenAppDTO>> findApps(String appIds) {
     if (StringUtils.hasText(appIds)) {
-      return this.appOpenApiService.getAppsInfo(Arrays.asList(appIds.split(",")));
+      return ResponseEntity.ok(this.appOpenApiService.getAppsInfo(Arrays.asList(appIds.split(","))));
     } else {
-      return this.appOpenApiService.getAllApps();
+      return ResponseEntity.ok(this.appOpenApiService.getAllApps());
     }
   }
 
   /**
    * @return which apps can be operated by open api
    */
-  @GetMapping("/apps/authorized")
-  public List<OpenAppDTO> findAppsAuthorized() {
+  @Override
+  public ResponseEntity<List<OpenAppDTO>> findAppsAuthorized() {
     long consumerId = this.consumerAuthUtil.retrieveConsumerIdFromCtx();
 
     Set<String> appIds = this.consumerService.findAppIdsAuthorizedByConsumerId(consumerId);
 
-    return this.appOpenApiService.getAppsInfo(new ArrayList<>(appIds));
+    return ResponseEntity.ok(appOpenApiService.getAppsInfo(new ArrayList<>(appIds)));
   }
 
+  /**
+   * get single app info (new added)
+   */
+  @Override
+  public ResponseEntity<OpenAppDTO> getApp(String appId) {
+    List<OpenAppDTO> apps = appOpenApiService.getAppsInfo(Collections.singletonList(appId));
+    if (null == apps || apps.isEmpty()) {
+      throw new BadRequestException("App not found: " + appId);
+    }
+    return ResponseEntity.ok(apps.get(0));
+  }
+
+  /**
+   * update app (new added)
+   */
+  @Override
+  @PreAuthorize(value = "@consumerPermissionValidator.isAppAdmin(#appId)")
+  @ApolloAuditLog(type = OpType.UPDATE, name = "App.update")
+  public ResponseEntity<OpenAppDTO> updateApp(String appId, String operator, OpenAppDTO dto) {
+    if (!Objects.equals(appId, dto.getAppId())) {
+      throw new BadRequestException("The App Id of path variable and request body is different");
+    }
+    if (userService.findByUserId(operator) == null) {
+      throw BadRequestException.userNotExists(operator);
+    }
+    appOpenApiService.updateApp(dto);
+
+    return ResponseEntity.ok(dto);
+  }
+
+  /**
+   * Get the current Consumer's application list (paginated) (new added)
+   */
+  @Override
+  public ResponseEntity<List<OpenAppDTO>> getAppsBySelf(Integer page, Integer size) {
+    long consumerId = this.consumerAuthUtil.retrieveConsumerIdFromCtx();
+    Set<String> authorizedAppIds = this.consumerService.findAppIdsAuthorizedByConsumerId(consumerId);
+    List<OpenAppDTO> apps = appOpenApiService.getAppsBySelf(authorizedAppIds, page, size);
+    return ResponseEntity.ok(apps);
+  }
+
+  /**
+   * Create an application in a specified environment (new added)
+   * POST /openapi/v1/apps/envs/{env}
+   */
+  @Override
+  @PreAuthorize(value = "@consumerPermissionValidator.hasCreateApplicationPermission()")
+  @ApolloAuditLog(type = OpType.CREATE, name = "App.create.forEnv")
+  public ResponseEntity<Object> createAppInEnv(String env, String operator, OpenAppDTO app) {
+    if (userService.findByUserId(operator) == null) {
+      throw BadRequestException.userNotExists(operator);
+    }
+    appOpenApiService.createAppInEnv(env, app, operator);
+
+    return ResponseEntity.ok().build();
+  }
+
+  /**
+   * Delete App (new added)
+   */
+  @Override
+  @PreAuthorize(value = "@consumerPermissionValidator.isAppAdmin(#appId)")
+  @ApolloAuditLog(type = OpType.DELETE, name = "App.delete")
+  public ResponseEntity<Object> deleteApp(String appId, String operator) {
+    if (userService.findByUserId(operator) == null) {
+      throw BadRequestException.userNotExists(operator);
+    }
+    appOpenApiService.deleteApp(appId);
+    return ResponseEntity.ok().build();
+  }
+
+  /**
+   * Find miss env (new added)
+   */
+  @Override
+  public ResponseEntity<MultiResponseEntity> findMissEnvs(String appId) {
+    return ResponseEntity.ok(appOpenApiService.findMissEnvs(appId));
+  }
+
+  /**
+   * Find appNavTree (new added)
+   */
+  @Override
+  public ResponseEntity<MultiResponseEntity> getAppNavTree(String appId) {
+    return ResponseEntity.ok(appOpenApiService.getAppNavTree(appId));
+  }
 }

--- a/apollo-portal/src/test/java/com/ctrip/framework/apollo/openapi/v1/controller/AppControllerParamBindLowLevelTest.java
+++ b/apollo-portal/src/test/java/com/ctrip/framework/apollo/openapi/v1/controller/AppControllerParamBindLowLevelTest.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2025 Apollo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.ctrip.framework.apollo.openapi.v1.controller;
+
+import com.ctrip.framework.apollo.openapi.model.OpenAppDTO;
+import com.ctrip.framework.apollo.openapi.repository.ConsumerAuditRepository;
+import com.ctrip.framework.apollo.openapi.repository.ConsumerRepository;
+import com.ctrip.framework.apollo.openapi.repository.ConsumerRoleRepository;
+import com.ctrip.framework.apollo.openapi.repository.ConsumerTokenRepository;
+import com.ctrip.framework.apollo.openapi.server.service.AppOpenApiService;
+import com.ctrip.framework.apollo.openapi.service.ConsumerService;
+import com.ctrip.framework.apollo.openapi.util.ConsumerAuthUtil;
+import com.ctrip.framework.apollo.portal.component.PortalSettings;
+import com.ctrip.framework.apollo.openapi.auth.ConsumerPermissionValidator;
+import com.ctrip.framework.apollo.portal.entity.bo.UserInfo;
+import com.ctrip.framework.apollo.portal.repository.PermissionRepository;
+import com.ctrip.framework.apollo.portal.repository.RolePermissionRepository;
+import com.ctrip.framework.apollo.portal.service.AppService;
+import com.ctrip.framework.apollo.portal.service.ClusterService;
+import com.ctrip.framework.apollo.portal.service.RoleInitializationService;
+import com.ctrip.framework.apollo.portal.service.RolePermissionService;
+import com.ctrip.framework.apollo.portal.spi.UserInfoHolder;
+import com.ctrip.framework.apollo.portal.spi.UserService;
+import com.ctrip.framework.apollo.portal.repository.RoleRepository;
+import com.google.gson.Gson;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+public class AppControllerParamBindLowLevelTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  // Keep the same mocks as your working test to satisfy context wiring
+  @MockBean(name = "consumerPermissionValidator")
+  private ConsumerPermissionValidator consumerPermissionValidator;
+  @MockBean private PortalSettings portalSettings;
+  @MockBean private AppService appService;
+  @MockBean private ClusterService clusterService;
+  @MockBean private ConsumerAuthUtil consumerAuthUtil;
+  @MockBean private PermissionRepository permissionRepository;
+  @MockBean private AppOpenApiService appOpenApiService;
+  @MockBean private ConsumerService consumerService;
+  @MockBean private RolePermissionRepository rolePermissionRepository;
+  @MockBean private UserInfoHolder userInfoHolder;
+  @MockBean private ConsumerTokenRepository consumerTokenRepository;
+  @MockBean private ConsumerRepository consumerRepository;
+  @MockBean private ConsumerAuditRepository consumerAuditRepository;
+  @MockBean private ConsumerRoleRepository consumerRoleRepository;
+  @MockBean private RolePermissionService rolePermissionService;
+  @MockBean private UserService userService;
+  @MockBean private RoleRepository roleRepository;
+  @MockBean private RoleInitializationService roleInitializationService;
+
+  private final Gson gson = new Gson();
+
+
+  @Before
+  public void setUp() {
+    when(consumerPermissionValidator.hasCreateApplicationPermission()).thenReturn(true);
+    when(consumerPermissionValidator.isAppAdmin(anyString())).thenReturn(true);
+
+    UserInfo user = new UserInfo();
+    user.setUserId("tester");
+    when(userService.findByUserId(anyString())).thenReturn(user);
+  }
+  @Before
+  public void setAuthentication() {
+    // put a dummy Authentication into SecurityContext so @PreAuthorize won't fail
+    SecurityContextHolder.clearContext();
+    SecurityContextHolder.getContext().setAuthentication(
+            new UsernamePasswordAuthenticationToken(
+                    "tester", "N/A", AuthorityUtils.NO_AUTHORITIES));
+  }
+
+  @After
+  public void clearAuthentication() {
+    SecurityContextHolder.clearContext();
+  }
+  @Test
+  public void createAppInEnv_shouldBind_env_query_body() throws Exception {
+    OpenAppDTO dto = new OpenAppDTO();
+    dto.setAppId("demo");
+    dto.setName("demo-name");
+    dto.setOwnerName("owner");
+    dto.setOwnerEmail("owner@example.com");
+    dto.setOrgId("org-1");
+    dto.setOrgName("Org");
+
+    // Adjust URL here if your mapping is different
+    mockMvc.perform(post("/openapi/v1/apps/envs/{env}", "DEV")
+                    .param("operator", "bob")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(gson.toJson(dto)))
+            .andExpect(org.springframework.test.web.servlet.result.MockMvcResultMatchers.status().isOk());
+
+    ArgumentCaptor<String> envCap = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<OpenAppDTO> dtoCap = ArgumentCaptor.forClass(OpenAppDTO.class);
+    ArgumentCaptor<String> opCap = ArgumentCaptor.forClass(String.class);
+
+    verify(appOpenApiService, times(1)).createAppInEnv(envCap.capture(), dtoCap.capture(), opCap.capture());
+    assertThat(envCap.getValue()).isEqualTo("DEV");
+    assertThat(opCap.getValue()).isEqualTo("bob");
+    assertThat(dtoCap.getValue().getAppId()).isEqualTo("demo");
+    assertThat(dtoCap.getValue().getName()).isEqualTo("demo-name");
+  }
+
+  @Test
+  public void getAppsBySelf_shouldBind_page_size_and_ids() throws Exception {
+    long consumerId = 9L;
+    Set<String> authorizedAppIds = new HashSet<>();
+    authorizedAppIds.add("app1");
+    authorizedAppIds.add("app2");
+    when(consumerAuthUtil.retrieveConsumerIdFromCtx()).thenReturn(consumerId);
+    when(consumerService.findAppIdsAuthorizedByConsumerId(consumerId))
+            .thenReturn(authorizedAppIds);
+
+    mockMvc.perform(get("/openapi/v1/apps/by-self")
+                    .param("page", "0")
+                    .param("size", "10"))
+            .andExpect(org.springframework.test.web.servlet.result.MockMvcResultMatchers.status().isOk());
+
+    ArgumentCaptor<Set> idsCap = ArgumentCaptor.forClass(Set.class);
+    ArgumentCaptor<Integer> pageCap = ArgumentCaptor.forClass(Integer.class);
+    ArgumentCaptor<Integer> sizeCap = ArgumentCaptor.forClass(Integer.class);
+
+    verify(appOpenApiService, times(1)).getAppsBySelf(idsCap.capture(), pageCap.capture(), sizeCap.capture());
+    assertThat(idsCap.getValue()).containsExactlyInAnyOrder("app1", "app2");
+    assertThat(pageCap.getValue()).isEqualTo(0);
+    assertThat(sizeCap.getValue()).isEqualTo(10);
+  }
+
+  @Test
+  public void updateApp_shouldBind_path_query_body() throws Exception {
+    OpenAppDTO dto = new OpenAppDTO();
+    dto.setAppId("app-1");
+    dto.setName("new-name");
+
+    doNothing().when(appOpenApiService).updateApp(any(OpenAppDTO.class));
+
+    mockMvc.perform(put("/openapi/v1/apps/{appId}", "app-1")
+                    .param("operator", "david")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(gson.toJson(dto)))
+            .andExpect(org.springframework.test.web.servlet.result.MockMvcResultMatchers.status().isOk());
+
+    ArgumentCaptor<OpenAppDTO> dtoCap = ArgumentCaptor.forClass(OpenAppDTO.class);
+    verify(appOpenApiService, times(1)).updateApp(dtoCap.capture());
+    assertThat(dtoCap.getValue().getAppId()).isEqualTo("app-1");
+    assertThat(dtoCap.getValue().getName()).isEqualTo("new-name");
+  }
+
+  @Test
+  public void deleteApp_shouldBind_path_and_query() throws Exception {
+    when(appOpenApiService.deleteApp("app-1")).thenReturn(new OpenAppDTO());
+
+    mockMvc.perform(delete("/openapi/v1/apps/{appId}", "app-1")
+                    .param("operator", "alice"))
+            .andExpect(org.springframework.test.web.servlet.result.MockMvcResultMatchers.status().isOk());
+
+    verify(appOpenApiService, times(1)).deleteApp("app-1");
+  }
+}

--- a/apollo-portal/src/test/java/com/ctrip/framework/apollo/openapi/v1/controller/AppControllerTest.java
+++ b/apollo-portal/src/test/java/com/ctrip/framework/apollo/openapi/v1/controller/AppControllerTest.java
@@ -16,56 +16,82 @@
  */
 package com.ctrip.framework.apollo.openapi.v1.controller;
 
-import static org.junit.Assert.assertEquals;
-
-import com.ctrip.framework.apollo.openapi.entity.ConsumerRole;
+import com.ctrip.framework.apollo.openapi.model.MultiResponseEntity;
+import com.ctrip.framework.apollo.openapi.model.OpenAppDTO;
+import com.ctrip.framework.apollo.openapi.model.OpenEnvClusterDTO;
 import com.ctrip.framework.apollo.openapi.repository.ConsumerAuditRepository;
 import com.ctrip.framework.apollo.openapi.repository.ConsumerRepository;
 import com.ctrip.framework.apollo.openapi.repository.ConsumerRoleRepository;
 import com.ctrip.framework.apollo.openapi.repository.ConsumerTokenRepository;
-import com.ctrip.framework.apollo.openapi.server.service.ServerAppOpenApiService;
+import com.ctrip.framework.apollo.openapi.server.service.AppOpenApiService;
 import com.ctrip.framework.apollo.openapi.service.ConsumerService;
 import com.ctrip.framework.apollo.openapi.util.ConsumerAuthUtil;
 import com.ctrip.framework.apollo.portal.component.PortalSettings;
-import com.ctrip.framework.apollo.portal.component.config.PortalConfig;
-import com.ctrip.framework.apollo.portal.entity.po.Role;
+import com.ctrip.framework.apollo.openapi.auth.ConsumerPermissionValidator;
+import com.ctrip.framework.apollo.portal.entity.bo.UserInfo;
 import com.ctrip.framework.apollo.portal.repository.PermissionRepository;
 import com.ctrip.framework.apollo.portal.repository.RolePermissionRepository;
-import com.ctrip.framework.apollo.portal.repository.RoleRepository;
 import com.ctrip.framework.apollo.portal.service.AppService;
 import com.ctrip.framework.apollo.portal.service.ClusterService;
+import com.ctrip.framework.apollo.portal.service.RoleInitializationService;
 import com.ctrip.framework.apollo.portal.service.RolePermissionService;
 import com.ctrip.framework.apollo.portal.spi.UserInfoHolder;
 import com.ctrip.framework.apollo.portal.spi.UserService;
+import com.ctrip.framework.apollo.portal.repository.RoleRepository;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import com.google.gson.Gson;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Import;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 /**
  * @author wxq
  */
 @RunWith(SpringRunner.class)
-@WebMvcTest(controllers = AppController.class)
-@Import({ConsumerService.class, ServerAppOpenApiService.class})
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+@TestPropertySource(properties = {
+    "api.pool.max.total=100",
+    "api.pool.max.per.route=100",
+    "api.connectionTimeToLive=30000",
+    "api.connectTimeout=5000",
+    "api.readTimeout=5000"
+})
 public class AppControllerTest {
 
   @Autowired
   private MockMvc mockMvc;
+
+  @MockBean(name = "consumerPermissionValidator")
+  private ConsumerPermissionValidator consumerPermissionValidator;
 
   @MockBean
   private PortalSettings portalSettings;
@@ -83,6 +109,12 @@ public class AppControllerTest {
   private PermissionRepository permissionRepository;
 
   @MockBean
+  private AppOpenApiService appOpenApiService;
+
+  @MockBean
+  private ConsumerService consumerService;
+
+  @MockBean
   private RolePermissionRepository rolePermissionRepository;
 
   @MockBean
@@ -96,69 +128,261 @@ public class AppControllerTest {
   @MockBean
   private ConsumerRoleRepository consumerRoleRepository;
   @MockBean
-  private PortalConfig portalConfig;
-  @MockBean
   private RolePermissionService rolePermissionService;
   @MockBean
   private UserService userService;
   @MockBean
   private RoleRepository roleRepository;
+  @MockBean
+  private RoleInitializationService roleInitializationService;
+  @MockBean
+  private ApplicationEventPublisher applicationEventPublisher;
+
+  private final Gson gson = new Gson();
+
+  @Before
+  public void setUpSecurityMocks() {
+    when(consumerPermissionValidator.hasCreateApplicationPermission()).thenReturn(true);
+    when(consumerPermissionValidator.hasCreateNamespacePermission(Mockito.any()))
+        .thenReturn(true);
+    when(consumerPermissionValidator.isAppAdmin(Mockito.anyString())).thenReturn(true);
+
+    UserInfo userInfo = new UserInfo();
+    userInfo.setUserId("test");
+    when(userService.findByUserId(Mockito.anyString())).thenReturn(userInfo);
+  }
 
   @Test
   public void testFindAppsAuthorized() throws Exception {
     final long consumerId = 123456;
-    Mockito.when(this.consumerAuthUtil.retrieveConsumerIdFromCtx()).thenReturn(consumerId);
+    when(this.consumerAuthUtil.retrieveConsumerIdFromCtx()).thenReturn(consumerId);
 
-    final List<ConsumerRole> consumerRoles = Arrays.asList(
-        generateConsumerRoleByRoleId(6),
-        generateConsumerRoleByRoleId(7),
-        generateConsumerRoleByRoleId(8)
-    );
-    Mockito.when(this.consumerRoleRepository.findByConsumerId(consumerId))
-        .thenReturn(consumerRoles);
+    Set<String> authorizedAppIds = Sets.newHashSet("app1", "app2");
+    when(this.consumerService.findAppIdsAuthorizedByConsumerId(consumerId))
+            .thenReturn(authorizedAppIds);
 
-    Mockito.when(this.roleRepository.findAllById(Mockito.any())).thenAnswer(invocation -> {
-      Set<Role> roles = new HashSet<>();
-      Iterable<Long> roleIds = invocation.getArgument(0);
-      for (Long roleId : roleIds) {
-        if (roleId == 6) {
-          roles.add(generateRoleByIdAndRoleName(6, "ModifyNamespace+app1+application+DEV"));
-        }
-        if (roleId == 7) {
-          roles.add(generateRoleByIdAndRoleName(7, "ReleaseNamespace+app1+application+DEV"));
-        }
-        if (roleId == 8) {
-          roles.add(generateRoleByIdAndRoleName(8, "Master+app2"));
-        }
-      }
-      assertEquals(3, roles.size());
-      return roles;
-    });
+    when(this.appOpenApiService.getAppsInfo(Mockito.anyList()))
+            .thenReturn(Collections.emptyList());
 
     this.mockMvc.perform(MockMvcRequestBuilders.get("/openapi/v1/apps/authorized"))
-        .andDo(MockMvcResultHandlers.print())
-        .andExpect(MockMvcResultMatchers.status().is2xxSuccessful());
+            .andDo(MockMvcResultHandlers.print())
+            .andExpect(MockMvcResultMatchers.status().is2xxSuccessful());
 
-    Mockito.verify(this.consumerRoleRepository, Mockito.times(1)).findByConsumerId(consumerId);
-    Mockito.verify(this.roleRepository, Mockito.times(1)).findAllById(Mockito.any());
+    Mockito.verify(this.consumerService, Mockito.times(1))
+            .findAppIdsAuthorizedByConsumerId(consumerId);
 
-    ArgumentCaptor<Set<String>> appIdsCaptor = ArgumentCaptor.forClass(Set.class);
-    Mockito.verify(this.appService).findByAppIds(appIdsCaptor.capture());
-    Set<String> appIds = appIdsCaptor.getValue();
-    assertEquals(Sets.newHashSet("app1", "app2"), appIds);
+    ArgumentCaptor<List> appIdsCaptor = ArgumentCaptor.forClass(List.class);
+    Mockito.verify(this.appOpenApiService).getAppsInfo(appIdsCaptor.capture());
+    @SuppressWarnings("unchecked")
+    List<String> appIds = appIdsCaptor.getValue();
+    assertEquals(authorizedAppIds, Sets.newHashSet(appIds));
   }
 
-  private static ConsumerRole generateConsumerRoleByRoleId(long roleId) {
-    ConsumerRole consumerRole = new ConsumerRole();
-    consumerRole.setRoleId(roleId);
-    return consumerRole;
+  @Test
+  public void testGetEnvClusterInfo() throws Exception {
+    String appId = "someAppId";
+
+    OpenEnvClusterDTO devCluster = new OpenEnvClusterDTO();
+    devCluster.setEnv("DEV");
+    devCluster.setClusters(Lists.newArrayList("default"));
+    OpenEnvClusterDTO fatCluster = new OpenEnvClusterDTO();
+    fatCluster.setEnv("FAT");
+    fatCluster.setClusters(Lists.newArrayList("default", "feature"));
+
+    when(appOpenApiService.getEnvClusterInfo(appId))
+            .thenReturn(Lists.newArrayList(devCluster, fatCluster));
+
+    mockMvc.perform(MockMvcRequestBuilders.get("/openapi/v1/apps/" + appId + "/envclusters"))
+            .andExpect(MockMvcResultMatchers.status().isOk())
+            .andExpect(MockMvcResultMatchers.jsonPath("$.[0].env").value("DEV"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.[0].clusters[0]").value("default"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.[1].env").value("FAT"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.[1].clusters[0]").value("default"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.[1].clusters[1]").value("feature"));
+
+    Mockito.verify(appOpenApiService).getEnvClusterInfo(appId);
   }
 
-  private static Role generateRoleByIdAndRoleName(long id, String roleName) {
-    Role role = new Role();
-    role.setId(id);
-    role.setRoleName(roleName);
-    return role;
+  @Test
+  public void testFindAppsByIds() throws Exception {
+    String appId1 = "app1";
+    String appId2 = "app2";
+    Set<String> appIds = Sets.newHashSet(appId1, appId2);
+
+    OpenAppDTO app1 = new OpenAppDTO();
+    app1.setAppId(appId1);
+    OpenAppDTO app2 = new OpenAppDTO();
+    app2.setAppId(appId2);
+    List<OpenAppDTO> apps = Lists.newArrayList(app1, app2);
+
+    when(appOpenApiService.getAppsInfo(Mockito.anyList())).thenReturn(apps);
+
+    mockMvc.perform(MockMvcRequestBuilders.get("/openapi/v1/apps").param("appIds", String.join(",", appIds)))
+            .andExpect(MockMvcResultMatchers.status().isOk())
+            .andExpect(MockMvcResultMatchers.jsonPath("$.[0].appId").value(appId1))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.[1].appId").value(appId2));
+
+    ArgumentCaptor<List> requestIdsCaptor = ArgumentCaptor.forClass(List.class);
+    Mockito.verify(appOpenApiService).getAppsInfo(requestIdsCaptor.capture());
+    @SuppressWarnings("unchecked")
+    List<String> requestedIds = requestIdsCaptor.getValue();
+    assertEquals(appIds, Sets.newHashSet(requestedIds));
   }
 
+  @Test
+  public void testFindAllApps() throws Exception {
+    OpenAppDTO app1 = new OpenAppDTO();
+    app1.setAppId("app1");
+    OpenAppDTO app2 = new OpenAppDTO();
+    app2.setAppId("app2");
+    List<OpenAppDTO> apps = Lists.newArrayList(app1, app2);
+
+    when(appOpenApiService.getAllApps()).thenReturn(apps);
+
+    mockMvc.perform(MockMvcRequestBuilders.get("/openapi/v1/apps"))
+            .andExpect(MockMvcResultMatchers.status().isOk())
+            .andExpect(MockMvcResultMatchers.jsonPath("$.[0].appId").value("app1"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.[1].appId").value("app2"));
+
+    Mockito.verify(appOpenApiService).getAllApps();
+  }
+
+  @Test
+  public void testGetApp() throws Exception {
+    String appId = "someAppId";
+    OpenAppDTO app = new OpenAppDTO();
+    app.setAppId(appId);
+
+    when(appOpenApiService.getAppsInfo(Collections.singletonList(appId)))
+            .thenReturn(Collections.singletonList(app));
+
+    mockMvc.perform(MockMvcRequestBuilders.get("/openapi/v1/apps/" + appId))
+            .andExpect(MockMvcResultMatchers.status().isOk())
+            .andExpect(MockMvcResultMatchers.jsonPath("$.appId").value(appId));
+
+    Mockito.verify(appOpenApiService)
+            .getAppsInfo(Collections.singletonList(appId));
+  }
+
+  @Test
+  public void testGetAppNotFound() throws Exception {
+    String appId = "someAppId";
+
+    when(appOpenApiService.getAppsInfo(Collections.singletonList(appId)))
+            .thenReturn(Collections.emptyList());
+
+    mockMvc.perform(MockMvcRequestBuilders.get("/openapi/v1/apps/" + appId))
+            .andExpect(MockMvcResultMatchers.status().isBadRequest());
+
+    Mockito.verify(appOpenApiService)
+            .getAppsInfo(Collections.singletonList(appId));
+  }
+
+  @Test
+  public void testGetAppsBySelf() throws Exception {
+    long consumerId = 1L;
+    int page = 0;
+    int size = 10;
+    String app1Id = "app1";
+    String app2Id = "app2";
+    Set<String> authorizedAppIds = Sets.newHashSet(app1Id, app2Id);
+
+    when(consumerAuthUtil.retrieveConsumerIdFromCtx()).thenReturn(consumerId);
+    when(this.consumerService.findAppIdsAuthorizedByConsumerId(consumerId))
+            .thenReturn(authorizedAppIds);
+
+    OpenAppDTO app1 = new OpenAppDTO();
+    app1.setAppId(app1Id);
+    OpenAppDTO app2 = new OpenAppDTO();
+    app2.setAppId(app2Id);
+    List<OpenAppDTO> apps = Lists.newArrayList(app1, app2);
+
+    when(appOpenApiService.getAppsBySelf(authorizedAppIds, page, size)).thenReturn(apps);
+
+    mockMvc.perform(MockMvcRequestBuilders.get("/openapi/v1/apps/by-self").param("page", String.valueOf(page)).param("size", String.valueOf(size)))
+            .andExpect(MockMvcResultMatchers.status().isOk())
+            .andExpect(MockMvcResultMatchers.jsonPath("$.[0].appId").value(app1Id))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.[1].appId").value(app2Id));
+
+    Mockito.verify(this.consumerService).findAppIdsAuthorizedByConsumerId(consumerId);
+    Mockito.verify(this.appOpenApiService).getAppsBySelf(authorizedAppIds, page, size);
+  }
+
+  @Test
+  public void testFindMissEnvs() throws Exception {
+    String appId = "someAppId";
+
+    when(appOpenApiService.findMissEnvs(appId)).thenReturn(new MultiResponseEntity(HttpStatus.OK.value(), new ArrayList<>()));
+    mockMvc.perform(MockMvcRequestBuilders.get("/openapi/v1/apps/" + appId + "/miss_envs"))
+            .andExpect(MockMvcResultMatchers.status().isOk());
+
+    Mockito.verify(appOpenApiService).findMissEnvs(appId);
+  }
+
+  @Test
+  public void testUpdateApp() throws Exception {
+    String appId = "app1";
+    String operator = "operatorUser";
+    OpenAppDTO requestDto = new OpenAppDTO();
+    requestDto.setAppId(appId);
+    requestDto.setName("App One");
+
+    UserInfo userInfo = new UserInfo();
+    userInfo.setUserId("test");
+    SecurityContextHolder.getContext().setAuthentication(new UsernamePasswordAuthenticationToken(userInfo, null, Collections.emptyList()));
+
+    Mockito.doNothing().when(appOpenApiService).updateApp(Mockito.any(OpenAppDTO.class));
+    when(consumerPermissionValidator.isAppAdmin(appId)).thenReturn(true);
+
+    mockMvc.perform(MockMvcRequestBuilders.put("/openapi/v1/apps/" + appId)
+                    .param("operator", operator)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(gson.toJson(requestDto)))
+            .andExpect(MockMvcResultMatchers.status().isOk())
+            .andExpect(MockMvcResultMatchers.jsonPath("$.appId").value(appId))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.name").value("App One"));
+
+  }
+
+  @Test
+  public void testUpdateAppWithMismatchedAppId() throws Exception {
+    String pathAppId = "app-path";
+    String operator = "operatorUser";
+    OpenAppDTO requestDto = new OpenAppDTO();
+    requestDto.setAppId("app-body");
+
+    UserInfo userInfo = new UserInfo();
+    userInfo.setUserId("test");
+    SecurityContextHolder.getContext().setAuthentication(new UsernamePasswordAuthenticationToken(userInfo, null, Collections.emptyList()));
+
+    when(consumerPermissionValidator.isAppAdmin(pathAppId)).thenReturn(true);
+
+    mockMvc.perform(MockMvcRequestBuilders.put("/openapi/v1/apps/" + pathAppId)
+                    .param("operator", operator)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(gson.toJson(requestDto)))
+            .andExpect(MockMvcResultMatchers.status().isBadRequest());
+
+    Mockito.verify(appOpenApiService, Mockito.never()).updateApp(Mockito.any());
+  }
+
+  @Test
+  public void testDeleteApp() throws Exception {
+    String appId = "app1";
+    String operator = "deleter";
+
+    UserInfo userInfo = new UserInfo();
+    userInfo.setUserId("test");
+    SecurityContextHolder.getContext().setAuthentication(new UsernamePasswordAuthenticationToken(userInfo, null, Collections.emptyList()));
+
+    when(appOpenApiService.deleteApp(appId)).thenReturn(new OpenAppDTO());
+    when(consumerPermissionValidator.isAppAdmin(appId)).thenReturn(true);
+
+    mockMvc.perform(delete("/openapi/v1/apps/" + appId)
+                    .param("operator", operator))
+            .andExpect(MockMvcResultMatchers.status().isOk())
+            .andExpect(MockMvcResultMatchers.content().string(""));
+
+    Mockito.verify(appOpenApiService).deleteApp(appId);
+  }
 }


### PR DESCRIPTION
  ## What's the purpose of this PR

  Complete the App domain refactor end-to-end on top of generated OpenAPI models: introduce a dedicated server-side OpenAPI service for App, migrate the
  OpenAPI AppController to use it, and update/add tests. This builds on PR3’s non-invasive converters and does not modify existing OpenApiBeanUtils.

  ## Which issue(s) this PR fixes:

  Fixes #5462 

  ## Brief changelog

  - Add server-side service interface and impl:
      - openapi/server/service/AppOpenApiService.java
      - openapi/server/service/impl/ServerAppOpenApiService.java
  - Replace DTO conversions with OpenApiModelConverters (no changes to OpenApiBeanUtils).
  - Migrate OpenAPI AppController to the new service:
      - Standardize responses to ResponseEntity<>
      - Add audit annotations where needed
      - Expose endpoints: create/update/delete app, get app(s), env-clusters, navtree, apps by self (paged), missing envs, etc.
  - Tests:
      - Update AppControllerTest and AppControllerIntegrationTest to reflect new flows and DTOs.
  - Scope limited to the App domain; no changes to other domains.
  
  - Original OpenAPI

    - openapi: GET /openapi/v1/apps → portal: GET /apps — 查询指定 appIds 或获取全部应用列表（original openapi）
    - openapi: GET /openapi/v1/apps/authorized → portal: GET /apps/by-self — 返回当前主体可操作的全部应用（original openapi）
    - openapi: GET /openapi/v1/apps/{appId}/envclusters → portal: （服务层聚合 AppService 与 ClusterService）— 环境+集群列表（original openapi）
    - openapi: POST /openapi/v1/apps → portal: POST /apps — 创建应用并初始化管理员角色（original openapi）
- New Reads
    - openapi: GET /openapi/v1/apps/{appId} → portal: GET /apps/{appId} — 拉取单个应用详情
    - openapi: GET /openapi/v1/apps/by-self → portal: GET /apps/by-self — 带 page/size 的分页版授权应用列表
    - openapi: GET /openapi/v1/apps/{appId}/miss_envs → portal: GET /apps/{appId}/miss_envs — 检查列出缺失环境
    - openapi: GET /openapi/v1/apps/{appId}/navtree → portal: GET /apps/{appId}/navtree — 生成跨环境导航树
- New Mutations
    - openapi: POST /openapi/v1/apps/envs/{env} → portal: POST /apps/envs/{env} — 在指定环境创建远端应用并补齐环境级权限
    - openapi: PUT /openapi/v1/apps/{appId} → portal: PUT /apps/{appId} — 更新应用基础信息并校验 appId
    - openapi: DELETE /openapi/v1/apps/{appId} → portal: DELETE /apps/{appId} — 删除应用并发布删除事件

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded OpenAPI: get app details, list own apps (paged), create apps in specific envs, update/delete apps, env/cluster info, missing envs, and app navigation tree.
* **Refactor**
  * Unified response wrapping, stronger input/operator validation, audit logging on mutating operations, and event-driven notifications for app changes.
* **Tests**
  * Added extensive integration-style and parameter-binding tests covering new endpoints, auth contexts, request binding, and end-to-end flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->