### PR TITLE
fix:Operate the accesskey continuously within one second

### DIFF
--- a/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/entity/AccessKey.java
+++ b/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/entity/AccessKey.java
@@ -17,6 +17,7 @@
 package com.ctrip.framework.apollo.biz.entity;
 
 import com.ctrip.framework.apollo.common.entity.BaseEntity;
+import java.util.Objects;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
@@ -80,4 +81,27 @@ public class AccessKey extends BaseEntity {
     return toStringHelper().add("appId", appId).add("secret", secret).add("mode", mode)
         .add("enabled", enabled).toString();
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    AccessKey accessKey = (AccessKey) o;
+
+    return mode == accessKey.mode &&
+        enabled == accessKey.enabled &&
+        Objects.equals(appId, accessKey.appId) &&
+        Objects.equals(secret, accessKey.secret);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(appId, secret, mode, enabled);
+  }
+
 }

--- a/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/repository/AccessKeyRepository.java
+++ b/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/repository/AccessKeyRepository.java
@@ -33,5 +33,8 @@ public interface AccessKeyRepository extends PagingAndSortingRepository<AccessKe
   List<AccessKey> findFirst500ByDataChangeLastModifiedTimeGreaterThanOrderByDataChangeLastModifiedTimeAsc(
       Date date);
 
+  List<AccessKey> findFirst500ByDataChangeLastModifiedTimeGreaterThanEqualOrderByDataChangeLastModifiedTimeAsc(
+      Date date);
+
   List<AccessKey> findByDataChangeLastModifiedTime(Date date);
 }

--- a/apollo-biz/src/test/java/com/ctrip/framework/apollo/biz/repository/AccessKeyRepositoryTest.java
+++ b/apollo-biz/src/test/java/com/ctrip/framework/apollo/biz/repository/AccessKeyRepositoryTest.java
@@ -84,4 +84,23 @@ public class AccessKeyRepositoryTest extends AbstractIntegrationTest {
     assertThat(accessKeyList.get(1).getSecret()).isEqualTo("c715cbc80fc44171b43732c3119c9456");
   }
 
+  @Test
+  @Sql(scripts = "/sql/accesskey-test.sql", executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
+  @Sql(scripts = "/sql/clean.sql", executionPhase = ExecutionPhase.AFTER_TEST_METHOD)
+  public void testFindFirst500ByDataChangeLastModifiedTimeGreaterThanEqualOrderByDataChangeLastModifiedTime() {
+    Instant instant =
+        LocalDateTime.of(2019, 12, 19, 13, 44, 21).atZone(ZoneId.systemDefault()).toInstant();
+    Date date = Date.from(instant);
+
+    List<AccessKey> accessKeyList = accessKeyRepository
+        .findFirst500ByDataChangeLastModifiedTimeGreaterThanEqualOrderByDataChangeLastModifiedTimeAsc(
+            date);
+
+    assertThat(accessKeyList).hasSize(2);
+    assertThat(accessKeyList.get(0).getAppId()).isEqualTo("100004458");
+    assertThat(accessKeyList.get(0).getSecret()).isEqualTo("4003c4d7783443dc9870932bebf3b7fe");
+    assertThat(accessKeyList.get(1).getAppId()).isEqualTo("100004458");
+    assertThat(accessKeyList.get(1).getSecret()).isEqualTo("c715cbc80fc44171b43732c3119c9456");
+  }
+
 }

--- a/apollo-configservice/src/test/java/com/ctrip/framework/apollo/configservice/service/AccessKeyServiceWithCacheTest.java
+++ b/apollo-configservice/src/test/java/com/ctrip/framework/apollo/configservice/service/AccessKeyServiceWithCacheTest.java
@@ -81,7 +81,7 @@ public class AccessKeyServiceWithCacheTest {
 
     // Add access key, disable by default
     when(accessKeyRepository
-        .findFirst500ByDataChangeLastModifiedTimeGreaterThanOrderByDataChangeLastModifiedTimeAsc(
+        .findFirst500ByDataChangeLastModifiedTimeGreaterThanEqualOrderByDataChangeLastModifiedTimeAsc(
             new Date(0L)))
         .thenReturn(Lists.newArrayList(firstAccessKey, secondAccessKey));
     when(accessKeyRepository.findAllById(anyList()))
@@ -94,7 +94,7 @@ public class AccessKeyServiceWithCacheTest {
     firstAccessKey = assembleAccessKey(1L, appId, "secret-1", true, false, 1577808002000L);
     secondAccessKey = assembleAccessKey(2L, appId, "secret-2", true, false, 1577808003000L);
     when(accessKeyRepository
-        .findFirst500ByDataChangeLastModifiedTimeGreaterThanOrderByDataChangeLastModifiedTimeAsc(
+        .findFirst500ByDataChangeLastModifiedTimeGreaterThanEqualOrderByDataChangeLastModifiedTimeAsc(
             new Date(1577808001000L)))
         .thenReturn(Lists.newArrayList(firstAccessKey, secondAccessKey));
     when(accessKeyRepository.findAllById(anyList()))
@@ -111,7 +111,7 @@ public class AccessKeyServiceWithCacheTest {
     // Update access key, disable the first one
     firstAccessKey = assembleAccessKey(1L, appId, "secret-1", false, false, 1577808004000L);
     when(accessKeyRepository
-        .findFirst500ByDataChangeLastModifiedTimeGreaterThanOrderByDataChangeLastModifiedTimeAsc(
+        .findFirst500ByDataChangeLastModifiedTimeGreaterThanEqualOrderByDataChangeLastModifiedTimeAsc(
             new Date(1577808003000L)))
         .thenReturn(Lists.newArrayList(firstAccessKey));
     when(accessKeyRepository.findAllById(anyList()))
@@ -128,7 +128,7 @@ public class AccessKeyServiceWithCacheTest {
 
     // Add new access key in runtime, enable by default
     when(accessKeyRepository
-        .findFirst500ByDataChangeLastModifiedTimeGreaterThanOrderByDataChangeLastModifiedTimeAsc(
+        .findFirst500ByDataChangeLastModifiedTimeGreaterThanEqualOrderByDataChangeLastModifiedTimeAsc(
             new Date(1577808004000L)))
         .thenReturn(Lists.newArrayList(thirdAccessKey));
     when(accessKeyRepository.findAllById(anyList()))


### PR DESCRIPTION
## What's the purpose of this PR

修复在同一秒内创建并更新accesskey可能出现的缓存未同步问题
如果同一秒多个的accesskey同时做了操作也有可能导致这一问题

## Which issue(s) this PR fixes:
Fixes #5483 

## Brief changelog
1. 将accessKeyRepository中根据变更时间获取前500个accesskey的查询条件从大于变成了大于等于
2. 大于等于会一直重复最后一个元素，提供了跳出循环的逻辑


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved access key query boundary conditions to ensure accurate data capture at edge timestamps.
  * Optimized cache merging logic to reduce unnecessary updates while maintaining data consistency.

* **Chores**
  * Enhanced internal equality comparison for access key objects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->