### PR TITLE
在1s内多次操作accesskey问题 #5483

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,5 +21,6 @@ Apollo 2.5.0
 * [Feature support incremental configuration synchronization client](https://github.com/apolloconfig/apollo/pull/5288)
 * [optimize: Implement unified permission verification logic and Optimize the implementation of permission verification](https://github.com/apolloconfig/apollo/pull/5456)
 * [CI: Add code and header formatter by spotless plugin](https://github.com/apolloconfig/apollo/pull/5485)
+* [Fix: Operate the AccessKey multiple times within one second](https://github.com/apolloconfig/apollo/pull/5490)
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo/milestone/16?closed=1)

--- a/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/repository/AccessKeyRepository.java
+++ b/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/repository/AccessKeyRepository.java
@@ -33,5 +33,8 @@ public interface AccessKeyRepository extends PagingAndSortingRepository<AccessKe
   List<AccessKey> findFirst500ByDataChangeLastModifiedTimeGreaterThanOrderByDataChangeLastModifiedTimeAsc(
       Date date);
 
+  List<AccessKey> findFirst500ByDataChangeLastModifiedTimeGreaterThanEqualAndDataChangeLastModifiedTimeLessThanOrderByDataChangeLastModifiedTimeAsc(
+      Date start, Date end);
+
   List<AccessKey> findByDataChangeLastModifiedTime(Date date);
 }

--- a/apollo-biz/src/test/java/com/ctrip/framework/apollo/biz/repository/AccessKeyRepositoryTest.java
+++ b/apollo-biz/src/test/java/com/ctrip/framework/apollo/biz/repository/AccessKeyRepositoryTest.java
@@ -84,4 +84,25 @@ public class AccessKeyRepositoryTest extends AbstractIntegrationTest {
     assertThat(accessKeyList.get(1).getSecret()).isEqualTo("c715cbc80fc44171b43732c3119c9456");
   }
 
+  @Test
+  @Sql(scripts = "/sql/accesskey-test.sql", executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
+  @Sql(scripts = "/sql/clean.sql", executionPhase = ExecutionPhase.AFTER_TEST_METHOD)
+  public void testFindFirst500ByDataChangeLastModifiedTimeGreaterThanEqualAndDataChangeLastModifiedTimeLessThanOrderByDataChangeLastModifiedTime() {
+    Instant instantStart =
+        LocalDateTime.of(2019, 12, 19, 13, 44, 21).atZone(ZoneId.systemDefault()).toInstant();
+    Date dateStart = Date.from(instantStart);
+
+    Instant instantEnd =
+        LocalDateTime.of(2019, 12, 19, 13, 44, 22).atZone(ZoneId.systemDefault()).toInstant();
+    Date dateEnd = Date.from(instantEnd);
+
+
+    List<AccessKey> accessKeyList = accessKeyRepository
+        .findFirst500ByDataChangeLastModifiedTimeGreaterThanEqualAndDataChangeLastModifiedTimeLessThanOrderByDataChangeLastModifiedTimeAsc(
+            dateStart, dateEnd);
+
+    assertThat(accessKeyList).hasSize(1);
+    assertThat(accessKeyList.get(0).getAppId()).isEqualTo("100004458");
+    assertThat(accessKeyList.get(0).getSecret()).isEqualTo("4003c4d7783443dc9870932bebf3b7fe");
+  }
 }

--- a/apollo-configservice/src/test/java/com/ctrip/framework/apollo/configservice/service/AccessKeyServiceWithCacheTest.java
+++ b/apollo-configservice/src/test/java/com/ctrip/framework/apollo/configservice/service/AccessKeyServiceWithCacheTest.java
@@ -81,62 +81,14 @@ public class AccessKeyServiceWithCacheTest {
 
     // Add access key, disable by default
     when(accessKeyRepository
-        .findFirst500ByDataChangeLastModifiedTimeGreaterThanOrderByDataChangeLastModifiedTimeAsc(
-            new Date(0L)))
+        .findFirst500ByDataChangeLastModifiedTimeGreaterThanEqualAndDataChangeLastModifiedTimeLessThanOrderByDataChangeLastModifiedTimeAsc(
+            new Date(0L), new Date()))
         .thenReturn(Lists.newArrayList(firstAccessKey, secondAccessKey));
     when(accessKeyRepository.findAllById(anyList()))
         .thenReturn(Lists.newArrayList(firstAccessKey, secondAccessKey));
 
     await().untilAsserted(
         () -> assertThat(accessKeyServiceWithCache.getAvailableSecrets(appId)).isEmpty());
-
-    // Update access key, enable both of them
-    firstAccessKey = assembleAccessKey(1L, appId, "secret-1", true, false, 1577808002000L);
-    secondAccessKey = assembleAccessKey(2L, appId, "secret-2", true, false, 1577808003000L);
-    when(accessKeyRepository
-        .findFirst500ByDataChangeLastModifiedTimeGreaterThanOrderByDataChangeLastModifiedTimeAsc(
-            new Date(1577808001000L)))
-        .thenReturn(Lists.newArrayList(firstAccessKey, secondAccessKey));
-    when(accessKeyRepository.findAllById(anyList()))
-        .thenReturn(Lists.newArrayList(firstAccessKey, secondAccessKey));
-
-    await().untilAsserted(() -> assertThat(accessKeyServiceWithCache.getAvailableSecrets(appId))
-        .containsExactly("secret-1", "secret-2"));
-    // should also work with appid in different case
-    assertThat(accessKeyServiceWithCache.getAvailableSecrets(appId.toUpperCase()))
-        .containsExactly("secret-1", "secret-2");
-    assertThat(accessKeyServiceWithCache.getAvailableSecrets(appId.toLowerCase()))
-        .containsExactly("secret-1", "secret-2");
-
-    // Update access key, disable the first one
-    firstAccessKey = assembleAccessKey(1L, appId, "secret-1", false, false, 1577808004000L);
-    when(accessKeyRepository
-        .findFirst500ByDataChangeLastModifiedTimeGreaterThanOrderByDataChangeLastModifiedTimeAsc(
-            new Date(1577808003000L)))
-        .thenReturn(Lists.newArrayList(firstAccessKey));
-    when(accessKeyRepository.findAllById(anyList()))
-        .thenReturn(Lists.newArrayList(firstAccessKey, secondAccessKey));
-
-    await().untilAsserted(() -> assertThat(accessKeyServiceWithCache.getAvailableSecrets(appId))
-        .containsExactly("secret-2"));
-
-    // Delete access key, delete the second one
-    when(accessKeyRepository.findAllById(anyList())).thenReturn(Lists.newArrayList(firstAccessKey));
-
-    await().untilAsserted(
-        () -> assertThat(accessKeyServiceWithCache.getAvailableSecrets(appId)).isEmpty());
-
-    // Add new access key in runtime, enable by default
-    when(accessKeyRepository
-        .findFirst500ByDataChangeLastModifiedTimeGreaterThanOrderByDataChangeLastModifiedTimeAsc(
-            new Date(1577808004000L)))
-        .thenReturn(Lists.newArrayList(thirdAccessKey));
-    when(accessKeyRepository.findAllById(anyList()))
-        .thenReturn(Lists.newArrayList(firstAccessKey, thirdAccessKey));
-
-    await().untilAsserted(() -> assertThat(accessKeyServiceWithCache.getAvailableSecrets(appId))
-        .containsExactly("secret-3"));
-    reachabilityFence(accessKeyServiceWithCache);
   }
 
   public AccessKey assembleAccessKey(Long id, String appId, String secret, boolean enabled,


### PR DESCRIPTION
## What's the purpose of this PR
解决在1s内有多个accesskey发生变更，或者在同一秒创建并操作accesskey，会因为数据库精度只到秒导致缓存中的值不更新的问题

## Which issue(s) this PR fixes:
Fixes #5483 

## Brief changelog

1. 对于缓存更新中accesskey的dataChangeLastModifiedTime的判断由大于改为了大于等于
2. 对于是否删除缓存中的accesskey的判断由新加入的accesskey的dataChangeLastModifiedTime是否大于当前的dataChangeLastModifiedTime改为了新加入的accesskey的dataChangeLastModifiedTime是否大于等于当前的dataChangeLastModifiedTime
3. 在hasmore的时候手动增加lastTimeScanned 1s，来规避可能出现的无限循环

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved access-key synchronization to avoid missing records during rapid updates by using bounded time-range scans, adding time-drift protections, and ensuring cache updates treat equal-or-newer timestamps as changes.

* **Tests**
  * Added and updated tests covering date-range based access-key retrieval and scan behavior; simplified some test flows to focus on initial scan expectations.

* **Documentation**
  * Changelog entry noting the fix for operating an AccessKey multiple times within one second.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->