### PR TITLE
Feature: Support ordinary users to modify personal information

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,5 +23,6 @@ Apollo 2.5.0
 * [CI: Add code and header formatter by spotless plugin](https://github.com/apolloconfig/apollo/pull/5485)
 * [Fix: Operate the AccessKey multiple times within one second](https://github.com/apolloconfig/apollo/pull/5490)
 * [Bugfix: Prevent accidental cache deletion when recreating AppNamespace with the same name and appid](https://github.com/apolloconfig/apollo/issues/5502)
+* [Feature: Support ordinary users to modify personal information](https://github.com/apolloconfig/apollo/pull/5511)
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo/milestone/16?closed=1)

--- a/apollo-portal/src/main/resources/static/scripts/controller/UserController.js
+++ b/apollo-portal/src/main/resources/static/scripts/controller/UserController.js
@@ -32,28 +32,38 @@ function UserController($scope, $window, $translate, toastr, AppUtil, UserServic
 
     initPermission();
 
-    getCreatedUsers();
-
     function initPermission() {
         PermissionService.has_root_permission()
         .then(function (result) {
             $scope.isRootUser = result.hasPermission;
+            getCreatedUsers();
         })
     }
 
     function getCreatedUsers() {
-        UserService.find_users("",true)
-        .then(function (result) {
-            if (!result || result.length === 0) {
-                return;
-            }
-            $scope.createdUsers = [];
-            $scope.filterUser = [];
-            result.forEach(function (user) {
-                $scope.createdUsers.push(user);
-                $scope.filterUser.push(user);
+        if ($scope.isRootUser) {
+            UserService.find_users("",true)
+            .then(function (result) {
+                if (!result || result.length === 0) {
+                    return;
+                }
+                $scope.createdUsers = [];
+                $scope.filterUser = [];
+                result.forEach(function (user) {
+                    $scope.createdUsers.push(user);
+                    $scope.filterUser.push(user);
+                });
             });
-        })
+        } else {
+            UserService.load_user()
+            .then(function (result) {
+                if (!result) {
+                    return;
+                }
+                $scope.createdUsers = [result];
+                $scope.filterUser = [result];
+            });
+        }
     }
 
     function changeStatus(status, user){

--- a/apollo-portal/src/main/resources/static/user-manage.html
+++ b/apollo-portal/src/main/resources/static/user-manage.html
@@ -35,7 +35,7 @@
     <apollonav></apollonav>
     <div id ="user-list" class="container-fluid apollo-container" ng-controller="UserController">
         <div class="col-md-10 col-md-offset-1 panel">
-            <section class="panel-body" ng-show="isRootUser">
+            <section class="panel-body">
                 <div class="main-table"></div>
                 <div class="row">
                     <header class="panel-heading">
@@ -46,7 +46,7 @@
                     </header>
 
                     <div class="table-responsive" ng-show="status==='1'  && createdUsers.length > 0">
-                        <div>
+                        <div ng-show="isRootUser">
                             <div style="height: 15px"></div>
                             <div>
                                 <button type="button" ng-click="changeStatus('2')"
@@ -96,7 +96,7 @@
                                     <span class="btn btn-primary" ng-click="changeStatus('3', user)">
                                         {{'UserMange.Edit' | translate }}
                                     </span>
-                                    <span class="btn btn-primary" ng-click="changeUserEnabled(user)">
+                                    <span class="btn btn-primary" ng-click="changeUserEnabled(user)" ng-show="isRootUser">
                                         {{user.enabled === 1 ? ('UserMange.Disable' | translate) : ('UserMange.Enable' | translate) }}
                                     </span>
                                 </td>
@@ -155,7 +155,7 @@
                                 <input type="text" class="form-control" name="email" ng-model="user.email">
                             </div>
                         </div>
-                            <div class="form-group" valdr-form-group>
+                            <div class="form-group" valdr-form-group ng-show="isRootUser">
                                 <label class="col-sm-2 control-label">
                                     <apollorequiredfield></apollorequiredfield>
                                     {{'UserMange.Enabled' | translate }}
@@ -178,9 +178,6 @@
                     </div>
                     <div style="height: 15px"></div>
                 </div>
-            </section>
-            <section class="panel-body text-center" ng-if="!isRootUser">
-                <h4>{{'Common.IsRootUser' | translate }}</h4>
             </section>
         </div>
     </div>

--- a/apollo-portal/src/main/resources/static/views/common/nav.html
+++ b/apollo-portal/src/main/resources/static/views/common/nav.html
@@ -70,6 +70,16 @@
                     </ul>
                 </li>
 
+                <!-- normal user tool (not admin)-->
+                <li class="dropdown" ng-if="hasRootPermission == false">
+                    <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
+                        <span class="glyphicon glyphicon-cog"></span>&nbsp;{{'Common.Nav.NonAdminTools' | translate }}
+                        <span class="caret"></span></a>
+                    <ul class="dropdown-menu" >
+                        <li><a ng-href="{{ '/user-manage.html' | prefixPath }}" target="_blank">{{'Common.Nav.UserManage' | translate }}</a></li>
+                    </ul>
+                </li>
+
                 <li class="dropdown">
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
                         <span class="glyphicon glyphicon-user"></span>&nbsp;{{userDisplayName}}({{userName}})


### PR DESCRIPTION
## What's the purpose of this PR

Support ordinary users to modify personal information

## Brief changelog

Support ordinary users to modify personal information

Follow this checklist to help us incorporate your contribution quickly and easily:

- [√] Read the [Contributing Guide](https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [√] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [√] Write necessary unit tests to verify the code.
- [√] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [√] Run `mvn spotless:apply` to format your code.
- [√] Update the [`CHANGES` log](https://github.com/apolloconfig/apollo/blob/master/CHANGES.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Non-admin users can modify their own personal information.
  * Added a dedicated navigation menu for non-admin users.
  * Admin-only controls (user list, enable/disable, search/add) now show only to admins.

* **Bug Fixes**
  * tightened runtime permission checks to prevent unauthorized modifications.

* **Tests**
  * Added tests covering admin and non-admin modification and disable/update workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->