### PR TITLE
refactor: only log AccessKey scan results when data loaded

### DIFF
--- a/apollo-configservice/src/main/java/com/ctrip/framework/apollo/configservice/service/AccessKeyServiceWithCache.java
+++ b/apollo-configservice/src/main/java/com/ctrip/framework/apollo/configservice/service/AccessKeyServiceWithCache.java
@@ -161,7 +161,9 @@ public class AccessKeyServiceWithCache implements InitializingBean {
 
       int scanned = accessKeys.size();
       mergeAccessKeys(accessKeys);
-      logger.info("Loaded {} new/updated Accesskey from startTime {}", scanned, lastTimeScanned);
+      if (scanned > 0) {
+        logger.info("Loaded {} new/updated Accesskey from startTime {}", scanned, lastTimeScanned);
+      }
 
       hasMore = scanned == 500;
 


### PR DESCRIPTION
## What's the purpose of this PR

only log AccessKey scan results when data loaded

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [x] Run `mvn spotless:apply` to format your code.
- [ ] Update the [`CHANGES` log](https://github.com/apolloconfig/apollo/blob/master/CHANGES.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized logging to display AccessKey load statistics only when records are processed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->