### PR TITLE
fix: make Mergify queue compatible with strict up-to-date protection

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -13,12 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+merge_queue:
+  max_parallel_checks: 1
+
 queue_rules:
   - name: single-commit
     autoqueue: true
     batch_size: 1
     merge_method: rebase
-    queue_conditions:
+    queue_conditions: &single_commit_conditions
       - "base = master"
       - "-draft"
       - "-closed"
@@ -32,16 +35,13 @@ queue_rules:
       - "check-success = code-style-check"
       - "check-success = license"
       - "check-success = CLAssistant"
-    merge_conditions:
-      - "check-success = build (8)"
-      - "check-success = build (11)"
-      - "check-success = build (17)"
+    merge_conditions: *single_commit_conditions
 
   - name: multi-commit
     autoqueue: true
     batch_size: 1
     merge_method: squash
-    queue_conditions:
+    queue_conditions: &multi_commit_conditions
       - "base = master"
       - "-draft"
       - "-closed"
@@ -55,10 +55,7 @@ queue_rules:
       - "check-success = code-style-check"
       - "check-success = license"
       - "check-success = CLAssistant"
-    merge_conditions:
-      - "check-success = build (8)"
-      - "check-success = build (11)"
-      - "check-success = build (17)"
+    merge_conditions: *multi_commit_conditions
 
 pull_request_rules:
   - name: notify author when PR has conflicts


### PR DESCRIPTION
## Background

Mergify queue checks were failing with `Rule: autoqueue (queue)` -> `ACTION_REQUIRED` after approvals (for example on #5550), reporting:

- `Configuration not compatible with a branch protection setting`
- `Require branches to be up to date before merging` is not compatible with draft/two-step checks

## Changes

- Add `merge_queue.max_parallel_checks: 1`
- Keep `batch_size: 1` as-is for both queue rules
- Make `merge_conditions` identical to `queue_conditions` for both rules (remove two-step CI mismatch)

## Why

This aligns Mergify queue behavior with current `master` branch protection (`strict` required status checks), which should unblock autoqueue merge for approved PRs.

## Verification

- YAML parses successfully
- Configuration now follows the compatibility guidance shown by Mergify


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated merge automation configuration to enhance validation checks and streamline merge queue management with improved rule organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->