### PR TITLE
Add release-packages workflow for release asset build/upload

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -22,6 +22,10 @@ on:
       release_tag:
         description: 'release tag, e.g. v2.5.0'
         required: true
+      skip_version_check:
+        description: 'skip release_tag and pom revision consistency check'
+        required: false
+        default: 'false'
 
 permissions:
   contents: write
@@ -78,12 +82,17 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ steps.project-version.outputs.version }}
           RELEASE_TAG: ${{ inputs.release_tag }}
+          SKIP_VERSION_CHECK: ${{ inputs.skip_version_check }}
         run: |
           set -euo pipefail
-          TAG_VERSION="${RELEASE_TAG#v}"
-          if [[ "${TAG_VERSION}" != "${VERSION}" ]]; then
-            echo "Release tag (${RELEASE_TAG}) does not match pom revision (${VERSION})"
-            exit 1
+          if [[ "${SKIP_VERSION_CHECK,,}" != "true" ]]; then
+            TAG_VERSION="${RELEASE_TAG#v}"
+            if [[ "${TAG_VERSION}" != "${VERSION}" ]]; then
+              echo "Release tag (${RELEASE_TAG}) does not match pom revision (${VERSION})"
+              exit 1
+            fi
+          else
+            echo "Skip version consistency check by input: skip_version_check=${SKIP_VERSION_CHECK}"
           fi
           gh release view "${RELEASE_TAG}" --repo apolloconfig/apollo >/dev/null
           test -f "apollo-configservice/target/apollo-configservice-${VERSION}-github.zip"


### PR DESCRIPTION
## What's the purpose of this PR

Add a dedicated `release-packages.yml` workflow to build Apollo release zip artifacts in GitHub Actions (JDK 8), generate `.sha1` checksums, and upload all package assets to an existing GitHub release tag.

This removes local JDK/environment dependency for package generation in the release flow and keeps release assets reproducible in CI.

## Which issue(s) this PR fixes:
Fixes #N/A (release automation task)

## Brief changelog

- add `.github/workflows/release-packages.yml`
- support manual trigger with `release_tag` input
- resolve release version from root `pom.xml` `revision`
- verify `release_tag` matches resolved version before upload
- upload 3 zip packages and 3 sha1 files to GitHub release

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit tests to verify the code.
- [ ] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [ ] Run `mvn spotless:apply` to format your code.
- [ ] Update the [`CHANGES` log](https://github.com/apolloconfig/apollo/blob/master/CHANGES.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a manual release process to build package artifacts, generate SHA1 checksums, optionally validate release version, verify expected artifacts, and upload (replace) artifacts and checksums to the corresponding GitHub release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->