### PR TITLE
build: bump apollo-java version to 2.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
 		<revision>2.5.0-SNAPSHOT</revision>
 		<java.version>1.8</java.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<apollo-java.version>2.5.0-SNAPSHOT</apollo-java.version>
+		<apollo-java.version>2.5.0</apollo-java.version>
 		<spring-boot.version>2.7.11</spring-boot.version>
 		<spring-cloud.version>2021.0.5</spring-cloud.version>
 		<!-- sort by alphabet -->


### PR DESCRIPTION
## What this PR does / why we need it

Upgrade Apollo's Apollo-Java dependency version from `2.5.0-SNAPSHOT` to the released `2.5.0`.

## Which issue(s) this PR fixes

N/A

## Brief changelog

- Update `apollo-java.version` in root `pom.xml` to `2.5.0`

## Does this PR introduce a user-facing change?

No

## Additional documentation

N/A

## Checklist

- [x] Build passes for affected modules (`./mvnw -U -pl apollo-common -am -DskipTests compile`)
- [ ] `mvn clean test`
- [ ] `mvn spotless:apply`
- [ ] `CHANGES.md` updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded apollo-java to stable release version, replacing pre-release snapshot to ensure access to production-ready code and ongoing support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->