### PR TITLE
refactor(biz): 修改提交查询逻辑以使用ID替代时间戳

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ target
 *.orig
 .flattened-pom.xml
 
+.gradle/*
+.vscode/*

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Release Notes.
 Apollo 3.0.0
 
 ------------------
+* [Fix: use release ID instead of timestamp for commit history query to avoid slow SQL](https://github.com/apolloconfig/apollo/pull/5584) 
 * [Fix: include super admin in hasAnyPermission semantics](https://github.com/apolloconfig/apollo/pull/5568)
 
 ------------------

--- a/apollo-adminservice/src/main/java/com/ctrip/framework/apollo/adminservice/controller/ItemController.java
+++ b/apollo-adminservice/src/main/java/com/ctrip/framework/apollo/adminservice/controller/ItemController.java
@@ -202,8 +202,8 @@ public class ItemController {
         releaseService.findLatestActiveRelease(appId, clusterName, namespaceName);
     List<Commit> commits;
     if (Objects.nonNull(latestActiveRelease)) {
-      commits = commitService.find(appId, clusterName, namespaceName,
-          latestActiveRelease.getDataChangeCreatedTime(), null);
+      commits =
+          commitService.find(appId, clusterName, namespaceName, latestActiveRelease.getId(), null);
     } else {
       commits = commitService.find(appId, clusterName, namespaceName, null);
     }

--- a/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/repository/CommitRepository.java
+++ b/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/repository/CommitRepository.java
@@ -18,7 +18,6 @@ package com.ctrip.framework.apollo.biz.repository;
 
 import com.ctrip.framework.apollo.biz.entity.Commit;
 
-import java.util.Date;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -31,9 +30,8 @@ public interface CommitRepository extends JpaRepository<Commit, Long> {
   List<Commit> findByAppIdAndClusterNameAndNamespaceNameOrderByIdDesc(String appId,
       String clusterName, String namespaceName, Pageable pageable);
 
-  List<Commit> findByAppIdAndClusterNameAndNamespaceNameAndDataChangeLastModifiedTimeGreaterThanEqualOrderByIdDesc(
-      String appId, String clusterName, String namespaceName, Date dataChangeLastModifiedTime,
-      Pageable pageable);
+  List<Commit> findByAppIdAndClusterNameAndNamespaceNameAndIdGreaterThanEqualOrderByIdDesc(
+      String appId, String clusterName, String namespaceName, Long id, Pageable pageable);
 
   @Modifying
   @Query("update Commit set isDeleted = true, "

--- a/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/service/CommitService.java
+++ b/apollo-biz/src/main/java/com/ctrip/framework/apollo/biz/service/CommitService.java
@@ -18,7 +18,6 @@ package com.ctrip.framework.apollo.biz.service;
 
 import com.ctrip.framework.apollo.biz.entity.Commit;
 import com.ctrip.framework.apollo.biz.repository.CommitRepository;
-import java.util.Date;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -53,11 +52,11 @@ public class CommitService {
         clusterName, namespaceName, page);
   }
 
-  public List<Commit> find(String appId, String clusterName, String namespaceName,
-      Date lastModifiedTime, Pageable page) {
+  public List<Commit> find(String appId, String clusterName, String namespaceName, Long id,
+      Pageable page) {
     return commitRepository
-        .findByAppIdAndClusterNameAndNamespaceNameAndDataChangeLastModifiedTimeGreaterThanEqualOrderByIdDesc(
-            appId, clusterName, namespaceName, lastModifiedTime, page);
+        .findByAppIdAndClusterNameAndNamespaceNameAndIdGreaterThanEqualOrderByIdDesc(appId,
+            clusterName, namespaceName, id, page);
   }
 
   public List<Commit> findByKey(String appId, String clusterName, String namespaceName, String key,

--- a/apollo-biz/src/test/java/com/ctrip/framework/apollo/biz/service/NamespaceServiceIntegrationTest.java
+++ b/apollo-biz/src/test/java/com/ctrip/framework/apollo/biz/service/NamespaceServiceIntegrationTest.java
@@ -30,10 +30,7 @@ import com.ctrip.framework.apollo.biz.repository.NamespaceRepository;
 import com.ctrip.framework.apollo.common.entity.AppNamespace;
 
 import com.ctrip.framework.apollo.common.exception.ServiceException;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.HashSet;
 import org.junit.Assert;
 import org.junit.Test;
@@ -124,28 +121,24 @@ public class NamespaceServiceIntegrationTest extends AbstractIntegrationTest {
   @Test
   @Sql(scripts = "/sql/namespace-test.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
   @Sql(scripts = "/sql/clean.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
-  public void testGetCommitsByModifiedTime() throws ParseException {
-    String format = "yyyy-MM-dd HH:mm:ss";
-    SimpleDateFormat simpleDateFormat = new SimpleDateFormat(format);
+  public void testGetCommitsByModifiedTime() {
+    // namespace-test.sql has 1 commit for (commitTestApp, default, application)
+    // find(..., id, page) returns commits with id >= given id for the namespace
+    List<Commit> allCommits = commitService.find(commitTestApp, testCluster,
+        testPrivateNamespace, PageRequest.of(0, 10));
+    assertEquals(1, allCommits.size());
+    Long commitId = allCommits.get(0).getId();
 
-    Date lastModifiedTime = simpleDateFormat.parse("2020-08-22 09:00:00");
+    List<Commit> commitsById = commitService.find(commitTestApp, testCluster,
+        testPrivateNamespace, commitId, null);
+    List<Commit> commitsByIdGreater = commitService.find(commitTestApp, testCluster,
+        testPrivateNamespace, commitId + 1, null);
+    List<Commit> commitsByIdPage = commitService.find(commitTestApp, testCluster,
+        testPrivateNamespace, commitId, PageRequest.of(0, 1));
 
-    List<Commit> commitsByDate = commitService.find(commitTestApp, testCluster,
-        testPrivateNamespace, lastModifiedTime, null);
-
-    Date lastModifiedTimeGreater = simpleDateFormat.parse("2020-08-22 11:00:00");
-    List<Commit> commitsByDateGreater = commitService.find(commitTestApp, testCluster,
-        testPrivateNamespace, lastModifiedTimeGreater, null);
-
-
-    Date lastModifiedTimePage = simpleDateFormat.parse("2020-08-22 09:30:00");
-    List<Commit> commitsByDatePage = commitService.find(commitTestApp, testCluster,
-        testPrivateNamespace, lastModifiedTimePage, PageRequest.of(0, 1));
-
-    assertEquals(1, commitsByDate.size());
-    assertEquals(0, commitsByDateGreater.size());
-    assertEquals(1, commitsByDatePage.size());
-
+    assertEquals(1, commitsById.size());
+    assertEquals(0, commitsByIdGreater.size());
+    assertEquals(1, commitsByIdPage.size());
   }
 
 


### PR DESCRIPTION
## What's the purpose of this PR

将 commit 历史查询从按时间戳过滤改为按 release ID 过滤，解决因时间字段未走索引导致的慢 SQL 问题。

## Which issue(s) this PR fixes:
Fixes #

## Brief changelog

**背景：** 原先使用 `latestActiveRelease.getDataChangeCreatedTime()` 查询 commit，`DataChange_LastTime` 字段没有索引，查询无法有效走索引。生产环境中，当某个 Namespace 长时间未发布时（例如最后一次发布在 2024 年初），使用如此久远的 `lastModifiedTime` 进行查询会扫描大量数据，导致执行时间过长，被 DB 监控判定为慢 SQL 而杀死。改为使用 `latestActiveRelease.getId()` 过滤，可走主键索引，无论上次发布时间多久远，查询都能保持高效稳定。

**变更摘要：**
- CommitRepository：查询条件从 `dataChangeLastModifiedTime`（无索引）改为 `id`（主键索引）
- CommitService：方法签名从 `Date lastModifiedTime` 改为 `Long id`
- ItemController：传入 `latestActiveRelease.getId()` 替代 `getDataChangeCreatedTime()`
- 单元测试：更新 `testGetCommitsByModifiedTime` 以适配新 API

Follow this checklist to help us incorporate your contribution quickly and easily:

- [ ] Read the [Contributing Guide](https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit tests to verify the code.
- [ ] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [ ] Run `mvn spotless:apply` to format your code.
- [ ] Update the [`CHANGES` log](https://github.com/apolloconfig/apollo/blob/master/CHANGES.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added exclusions for Gradle build artifacts and Visual Studio Code workspace metadata to project configuration.

* **Tests**
  * Updated commit retrieval tests to use identifier-based filtering instead of timestamp-based queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->